### PR TITLE
Fix buffer figure

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -959,7 +959,7 @@ class User extends Authenticatable
             return '∞';
         }
 
-        $bytes = round(($this->uploaded - $this->downloaded) / $ratio);
+        $bytes = round(($this->uploaded / $ratio) - $this->downloaded);
 
         return StringHelper::formatBytes($bytes);
     }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -959,7 +959,7 @@ class User extends Authenticatable
             return '∞';
         }
 
-        $bytes = round($this->uploaded / $ratio);
+        $bytes = round(($this->uploaded - $this->downloaded) / $ratio);
 
         return StringHelper::formatBytes($bytes);
     }


### PR DESCRIPTION
Buffer was being calculated solely from the upload figure divided by the config ratio. It should also take into account the amount already downloaded. Hence (uploaded - downloaded) / ratio.