### PR TITLE
chore: Add ignore rules for additional assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,8 +13,12 @@
 /public/js
 /public/mix-manifest.json
 /public/tmp
+/public/fonts/bootstrap
+/public/fonts/font-awesome
+/public/fonts/wysibb
 /public/fonts/fa-*
 /public/img/emojione
+/public/img/joypixels
 /public/images
 /storage/backups
 /storage/gitupdate
@@ -34,6 +38,7 @@ laravel-echo-server.json
 /.idea
 /.vscode
 /nbproject
+.phpunit.result.cache
 
 # Vim
 .*.swp


### PR DESCRIPTION
There are a handful of generated assets that are not Git-ignored, currently. This PR adds them to the top-level `.gitignore` file.