### PR TITLE
(Refactor) Closure To Arrow Function

### DIFF
--- a/app/Console/Commands/AutoBan.php
+++ b/app/Console/Commands/AutoBan.php
@@ -44,7 +44,7 @@ class AutoBan extends Command
      */
     public function handle()
     {
-        $banned_group = cache()->rememberForever('banned_group', fn() => Group::where('slug', '=', 'banned')->pluck('id'));
+        $banned_group = cache()->rememberForever('banned_group', fn () => Group::where('slug', '=', 'banned')->pluck('id'));
 
         $bans = Warning::with('warneduser')->select(DB::raw('user_id, count(*) as value'))->where('active', '=', 1)->groupBy('user_id')->having('value', '>=', config('hitrun.max_warnings'))->get();
 

--- a/app/Console/Commands/AutoBan.php
+++ b/app/Console/Commands/AutoBan.php
@@ -44,9 +44,7 @@ class AutoBan extends Command
      */
     public function handle()
     {
-        $banned_group = cache()->rememberForever('banned_group', function () {
-            return Group::where('slug', '=', 'banned')->pluck('id');
-        });
+        $banned_group = cache()->rememberForever('banned_group', fn() => Group::where('slug', '=', 'banned')->pluck('id'));
 
         $bans = Warning::with('warneduser')->select(DB::raw('user_id, count(*) as value'))->where('active', '=', 1)->groupBy('user_id')->having('value', '>=', config('hitrun.max_warnings'))->get();
 

--- a/app/Console/Commands/AutoDisableInactiveUsers.php
+++ b/app/Console/Commands/AutoDisableInactiveUsers.php
@@ -43,7 +43,7 @@ class AutoDisableInactiveUsers extends Command
     public function handle()
     {
         if (config('pruning.user_pruning') == true) {
-            $disabled_group = cache()->rememberForever('disabled_group', fn() => Group::where('slug', '=', 'disabled')->pluck('id'));
+            $disabled_group = cache()->rememberForever('disabled_group', fn () => Group::where('slug', '=', 'disabled')->pluck('id'));
 
             $current = Carbon::now();
 

--- a/app/Console/Commands/AutoDisableInactiveUsers.php
+++ b/app/Console/Commands/AutoDisableInactiveUsers.php
@@ -43,9 +43,7 @@ class AutoDisableInactiveUsers extends Command
     public function handle()
     {
         if (config('pruning.user_pruning') == true) {
-            $disabled_group = cache()->rememberForever('disabled_group', function () {
-                return Group::where('slug', '=', 'disabled')->pluck('id');
-            });
+            $disabled_group = cache()->rememberForever('disabled_group', fn() => Group::where('slug', '=', 'disabled')->pluck('id'));
 
             $current = Carbon::now();
 

--- a/app/Console/Commands/AutoRevokePermissions.php
+++ b/app/Console/Commands/AutoRevokePermissions.php
@@ -42,11 +42,11 @@ class AutoRevokePermissions extends Command
      */
     public function handle()
     {
-        $banned_group = cache()->rememberForever('banned_group', fn() => Group::where('slug', '=', 'banned')->pluck('id'));
-        $validating_group = cache()->rememberForever('validating_group', fn() => Group::where('slug', '=', 'validating')->pluck('id'));
-        $leech_group = cache()->rememberForever('leech_group', fn() => Group::where('slug', '=', 'leech')->pluck('id'));
-        $disabled_group = cache()->rememberForever('disabled_group', fn() => Group::where('slug', '=', 'disabled')->pluck('id'));
-        $pruned_group = cache()->rememberForever('pruned_group', fn() => Group::where('slug', '=', 'pruned')->pluck('id'));
+        $banned_group = cache()->rememberForever('banned_group', fn () => Group::where('slug', '=', 'banned')->pluck('id'));
+        $validating_group = cache()->rememberForever('validating_group', fn () => Group::where('slug', '=', 'validating')->pluck('id'));
+        $leech_group = cache()->rememberForever('leech_group', fn () => Group::where('slug', '=', 'leech')->pluck('id'));
+        $disabled_group = cache()->rememberForever('disabled_group', fn () => Group::where('slug', '=', 'disabled')->pluck('id'));
+        $pruned_group = cache()->rememberForever('pruned_group', fn () => Group::where('slug', '=', 'pruned')->pluck('id'));
 
         User::whereNotIn('group_id', [$banned_group[0], $validating_group[0], $leech_group[0], $disabled_group[0], $pruned_group[0]])->update(['can_download' => '1', 'can_request' => '1']);
         User::whereIn('group_id', [$banned_group[0], $validating_group[0], $leech_group[0], $disabled_group[0], $pruned_group[0]])->update(['can_download' => '0', 'can_request' => '0']);

--- a/app/Console/Commands/AutoRevokePermissions.php
+++ b/app/Console/Commands/AutoRevokePermissions.php
@@ -42,21 +42,11 @@ class AutoRevokePermissions extends Command
      */
     public function handle()
     {
-        $banned_group = cache()->rememberForever('banned_group', function () {
-            return Group::where('slug', '=', 'banned')->pluck('id');
-        });
-        $validating_group = cache()->rememberForever('validating_group', function () {
-            return Group::where('slug', '=', 'validating')->pluck('id');
-        });
-        $leech_group = cache()->rememberForever('leech_group', function () {
-            return Group::where('slug', '=', 'leech')->pluck('id');
-        });
-        $disabled_group = cache()->rememberForever('disabled_group', function () {
-            return Group::where('slug', '=', 'disabled')->pluck('id');
-        });
-        $pruned_group = cache()->rememberForever('pruned_group', function () {
-            return Group::where('slug', '=', 'pruned')->pluck('id');
-        });
+        $banned_group = cache()->rememberForever('banned_group', fn() => Group::where('slug', '=', 'banned')->pluck('id'));
+        $validating_group = cache()->rememberForever('validating_group', fn() => Group::where('slug', '=', 'validating')->pluck('id'));
+        $leech_group = cache()->rememberForever('leech_group', fn() => Group::where('slug', '=', 'leech')->pluck('id'));
+        $disabled_group = cache()->rememberForever('disabled_group', fn() => Group::where('slug', '=', 'disabled')->pluck('id'));
+        $pruned_group = cache()->rememberForever('pruned_group', fn() => Group::where('slug', '=', 'pruned')->pluck('id'));
 
         User::whereNotIn('group_id', [$banned_group[0], $validating_group[0], $leech_group[0], $disabled_group[0], $pruned_group[0]])->update(['can_download' => '1', 'can_request' => '1']);
         User::whereIn('group_id', [$banned_group[0], $validating_group[0], $leech_group[0], $disabled_group[0], $pruned_group[0]])->update(['can_download' => '0', 'can_request' => '0']);

--- a/app/Console/Commands/AutoSoftDeleteDisabledUsers.php
+++ b/app/Console/Commands/AutoSoftDeleteDisabledUsers.php
@@ -43,8 +43,8 @@ class AutoSoftDeleteDisabledUsers extends Command
     public function handle()
     {
         if (config('pruning.user_pruning') == true) {
-            $disabled_group = cache()->rememberForever('disabled_group', fn() => Group::where('slug', '=', 'disabled')->pluck('id'));
-            $pruned_group = cache()->rememberForever('pruned_group', fn() => Group::where('slug', '=', 'pruned')->pluck('id'));
+            $disabled_group = cache()->rememberForever('disabled_group', fn () => Group::where('slug', '=', 'disabled')->pluck('id'));
+            $pruned_group = cache()->rememberForever('pruned_group', fn () => Group::where('slug', '=', 'pruned')->pluck('id'));
 
             $current = Carbon::now();
             $users = User::where('group_id', '=', $disabled_group[0])

--- a/app/Console/Commands/AutoSoftDeleteDisabledUsers.php
+++ b/app/Console/Commands/AutoSoftDeleteDisabledUsers.php
@@ -43,12 +43,8 @@ class AutoSoftDeleteDisabledUsers extends Command
     public function handle()
     {
         if (config('pruning.user_pruning') == true) {
-            $disabled_group = cache()->rememberForever('disabled_group', function () {
-                return Group::where('slug', '=', 'disabled')->pluck('id');
-            });
-            $pruned_group = cache()->rememberForever('pruned_group', function () {
-                return Group::where('slug', '=', 'pruned')->pluck('id');
-            });
+            $disabled_group = cache()->rememberForever('disabled_group', fn() => Group::where('slug', '=', 'disabled')->pluck('id'));
+            $pruned_group = cache()->rememberForever('pruned_group', fn() => Group::where('slug', '=', 'pruned')->pluck('id'));
 
             $current = Carbon::now();
             $users = User::where('group_id', '=', $disabled_group[0])

--- a/app/Http/Controllers/AnnounceController.php
+++ b/app/Http/Controllers/AnnounceController.php
@@ -132,9 +132,9 @@ class AnnounceController extends Controller
         }
 
         // Caached System Required Groups
-        $banned_group = cache()->rememberForever('banned_group', fn() => Group::where('slug', '=', 'banned')->pluck('id'));
-        $validating_group = cache()->rememberForever('validating_group', fn() => Group::where('slug', '=', 'validating')->pluck('id'));
-        $disabled_group = cache()->rememberForever('disabled_group', fn() => Group::where('slug', '=', 'disabled')->pluck('id'));
+        $banned_group = cache()->rememberForever('banned_group', fn () => Group::where('slug', '=', 'banned')->pluck('id'));
+        $validating_group = cache()->rememberForever('validating_group', fn () => Group::where('slug', '=', 'validating')->pluck('id'));
+        $disabled_group = cache()->rememberForever('disabled_group', fn () => Group::where('slug', '=', 'disabled')->pluck('id'));
 
         // If User Is Banned Return Error to Client
         if ($user->group_id == $banned_group[0]) {
@@ -230,7 +230,7 @@ class AnnounceController extends Controller
         $peers = Peer::where('torrent_id', '=', $torrent->id)->take(50)->get()->toArray();
 
         // Pull Count On Users Peers Per Torrent For Rate Limiting
-        $connections = Cache::remember(sprintf('user_connections.%s', $torrent->id), 1800, fn() => Peer::where('torrent_id', '=', $torrent->id)->where('user_id', '=', $user->id)->count());
+        $connections = Cache::remember(sprintf('user_connections.%s', $torrent->id), 1800, fn () => Peer::where('torrent_id', '=', $torrent->id)->where('user_id', '=', $user->id)->count());
 
         // If Users Peer Count On A Single Torrent Is Greater Than X Return Error to Client
         if ($connections > config('announce.rate_limit')) {

--- a/app/Http/Controllers/AnnounceController.php
+++ b/app/Http/Controllers/AnnounceController.php
@@ -132,15 +132,9 @@ class AnnounceController extends Controller
         }
 
         // Caached System Required Groups
-        $banned_group = cache()->rememberForever('banned_group', function () {
-            return Group::where('slug', '=', 'banned')->pluck('id');
-        });
-        $validating_group = cache()->rememberForever('validating_group', function () {
-            return Group::where('slug', '=', 'validating')->pluck('id');
-        });
-        $disabled_group = cache()->rememberForever('disabled_group', function () {
-            return Group::where('slug', '=', 'disabled')->pluck('id');
-        });
+        $banned_group = cache()->rememberForever('banned_group', fn() => Group::where('slug', '=', 'banned')->pluck('id'));
+        $validating_group = cache()->rememberForever('validating_group', fn() => Group::where('slug', '=', 'validating')->pluck('id'));
+        $disabled_group = cache()->rememberForever('disabled_group', fn() => Group::where('slug', '=', 'disabled')->pluck('id'));
 
         // If User Is Banned Return Error to Client
         if ($user->group_id == $banned_group[0]) {
@@ -236,9 +230,7 @@ class AnnounceController extends Controller
         $peers = Peer::where('torrent_id', '=', $torrent->id)->take(50)->get()->toArray();
 
         // Pull Count On Users Peers Per Torrent For Rate Limiting
-        $connections = Cache::remember(sprintf('user_connections.%s', $torrent->id), 1800, function () use ($torrent, $user) {
-            return Peer::where('torrent_id', '=', $torrent->id)->where('user_id', '=', $user->id)->count();
-        });
+        $connections = Cache::remember(sprintf('user_connections.%s', $torrent->id), 1800, fn() => Peer::where('torrent_id', '=', $torrent->id)->where('user_id', '=', $user->id)->count());
 
         // If Users Peer Count On A Single Torrent Is Greater Than X Return Error to Client
         if ($connections > config('announce.rate_limit')) {

--- a/app/Http/Controllers/Auth/ActivationController.php
+++ b/app/Http/Controllers/Auth/ActivationController.php
@@ -21,12 +21,8 @@ class ActivationController extends Controller
 {
     public function activate($token)
     {
-        $banned_group = cache()->rememberForever('banned_group', function () {
-            return Group::where('slug', '=', 'banned')->pluck('id');
-        });
-        $member_group = cache()->rememberForever('member_group', function () {
-            return Group::where('slug', '=', 'user')->pluck('id');
-        });
+        $banned_group = cache()->rememberForever('banned_group', fn() => Group::where('slug', '=', 'banned')->pluck('id'));
+        $member_group = cache()->rememberForever('member_group', fn() => Group::where('slug', '=', 'user')->pluck('id'));
 
         $activation = UserActivation::with('user')->where('token', '=', $token)->firstOrFail();
         if ($activation->user->id && $activation->user->group->id != $banned_group[0]) {

--- a/app/Http/Controllers/Auth/ActivationController.php
+++ b/app/Http/Controllers/Auth/ActivationController.php
@@ -21,8 +21,8 @@ class ActivationController extends Controller
 {
     public function activate($token)
     {
-        $banned_group = cache()->rememberForever('banned_group', fn() => Group::where('slug', '=', 'banned')->pluck('id'));
-        $member_group = cache()->rememberForever('member_group', fn() => Group::where('slug', '=', 'user')->pluck('id'));
+        $banned_group = cache()->rememberForever('banned_group', fn () => Group::where('slug', '=', 'banned')->pluck('id'));
+        $member_group = cache()->rememberForever('member_group', fn () => Group::where('slug', '=', 'user')->pluck('id'));
 
         $activation = UserActivation::with('user')->where('token', '=', $token)->firstOrFail();
         if ($activation->user->id && $activation->user->group->id != $banned_group[0]) {

--- a/app/Http/Controllers/Auth/ApplicationController.php
+++ b/app/Http/Controllers/Auth/ApplicationController.php
@@ -122,10 +122,10 @@ class ApplicationController extends Controller
         }
         $application->save();
         // Map And Save IMG Proofs
-        $imgs = collect($request->input('images'))->map(fn($value) => new ApplicationImageProof(['image' => $value]));
+        $imgs = collect($request->input('images'))->map(fn ($value) => new ApplicationImageProof(['image' => $value]));
         $application->imageProofs()->saveMany($imgs);
         // Map And Save URL Proofs
-        $urls = collect($request->input('links'))->map(fn($value) => new ApplicationUrlProof(['url' => $value]));
+        $urls = collect($request->input('links'))->map(fn ($value) => new ApplicationUrlProof(['url' => $value]));
         $application->urlProofs()->saveMany($urls);
 
         return redirect()->route('login')

--- a/app/Http/Controllers/Auth/ApplicationController.php
+++ b/app/Http/Controllers/Auth/ApplicationController.php
@@ -122,14 +122,10 @@ class ApplicationController extends Controller
         }
         $application->save();
         // Map And Save IMG Proofs
-        $imgs = collect($request->input('images'))->map(function ($value) {
-            return new ApplicationImageProof(['image' => $value]);
-        });
+        $imgs = collect($request->input('images'))->map(fn($value) => new ApplicationImageProof(['image' => $value]));
         $application->imageProofs()->saveMany($imgs);
         // Map And Save URL Proofs
-        $urls = collect($request->input('links'))->map(function ($value) {
-            return new ApplicationUrlProof(['url' => $value]);
-        });
+        $urls = collect($request->input('links'))->map(fn($value) => new ApplicationUrlProof(['url' => $value]));
         $application->urlProofs()->saveMany($urls);
 
         return redirect()->route('login')

--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -67,10 +67,10 @@ class LoginController extends Controller
 
     protected function authenticated(Request $request, $user)
     {
-        $banned_group = cache()->rememberForever('banned_group', fn() => Group::where('slug', '=', 'banned')->pluck('id'));
-        $validating_group = cache()->rememberForever('validating_group', fn() => Group::where('slug', '=', 'validating')->pluck('id'));
-        $disabled_group = cache()->rememberForever('disabled_group', fn() => Group::where('slug', '=', 'disabled')->pluck('id'));
-        $member_group = cache()->rememberForever('member_group', fn() => Group::where('slug', '=', 'user')->pluck('id'));
+        $banned_group = cache()->rememberForever('banned_group', fn () => Group::where('slug', '=', 'banned')->pluck('id'));
+        $validating_group = cache()->rememberForever('validating_group', fn () => Group::where('slug', '=', 'validating')->pluck('id'));
+        $disabled_group = cache()->rememberForever('disabled_group', fn () => Group::where('slug', '=', 'disabled')->pluck('id'));
+        $member_group = cache()->rememberForever('member_group', fn () => Group::where('slug', '=', 'user')->pluck('id'));
 
         if ($user->active == 0 || $user->group_id == $validating_group[0]) {
             $this->guard()->logout();

--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -67,18 +67,10 @@ class LoginController extends Controller
 
     protected function authenticated(Request $request, $user)
     {
-        $banned_group = cache()->rememberForever('banned_group', function () {
-            return Group::where('slug', '=', 'banned')->pluck('id');
-        });
-        $validating_group = cache()->rememberForever('validating_group', function () {
-            return Group::where('slug', '=', 'validating')->pluck('id');
-        });
-        $disabled_group = cache()->rememberForever('disabled_group', function () {
-            return Group::where('slug', '=', 'disabled')->pluck('id');
-        });
-        $member_group = cache()->rememberForever('member_group', function () {
-            return Group::where('slug', '=', 'user')->pluck('id');
-        });
+        $banned_group = cache()->rememberForever('banned_group', fn() => Group::where('slug', '=', 'banned')->pluck('id'));
+        $validating_group = cache()->rememberForever('validating_group', fn() => Group::where('slug', '=', 'validating')->pluck('id'));
+        $disabled_group = cache()->rememberForever('disabled_group', fn() => Group::where('slug', '=', 'disabled')->pluck('id'));
+        $member_group = cache()->rememberForever('member_group', fn() => Group::where('slug', '=', 'user')->pluck('id'));
 
         if ($user->active == 0 || $user->group_id == $validating_group[0]) {
             $this->guard()->logout();

--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -78,7 +78,7 @@ class RegisterController extends Controller
                 ->withErrors(trans('auth.invalid-key'));
         }
 
-        $validating_group = cache()->rememberForever('validating_group', fn() => Group::where('slug', '=', 'validating')->pluck('id'));
+        $validating_group = cache()->rememberForever('validating_group', fn () => Group::where('slug', '=', 'validating')->pluck('id'));
 
         $user = new User();
         $user->username = $request->input('username');

--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -78,9 +78,7 @@ class RegisterController extends Controller
                 ->withErrors(trans('auth.invalid-key'));
         }
 
-        $validating_group = cache()->rememberForever('validating_group', function () {
-            return Group::where('slug', '=', 'validating')->pluck('id');
-        });
+        $validating_group = cache()->rememberForever('validating_group', fn() => Group::where('slug', '=', 'validating')->pluck('id'));
 
         $user = new User();
         $user->username = $request->input('username');

--- a/app/Http/Controllers/Auth/ResetPasswordController.php
+++ b/app/Http/Controllers/Auth/ResetPasswordController.php
@@ -32,8 +32,8 @@ class ResetPasswordController extends Controller
 
     protected function resetPassword($user, $password)
     {
-        $validating_group = cache()->rememberForever('validating_group', fn() => Group::where('slug', '=', 'validating')->pluck('id'));
-        $member_group = cache()->rememberForever('member_group', fn() => Group::where('slug', '=', 'user')->pluck('id'));
+        $validating_group = cache()->rememberForever('validating_group', fn () => Group::where('slug', '=', 'validating')->pluck('id'));
+        $member_group = cache()->rememberForever('member_group', fn () => Group::where('slug', '=', 'user')->pluck('id'));
         $user->password = bcrypt($password);
         $user->remember_token = Str::random(60);
 

--- a/app/Http/Controllers/Auth/ResetPasswordController.php
+++ b/app/Http/Controllers/Auth/ResetPasswordController.php
@@ -32,12 +32,8 @@ class ResetPasswordController extends Controller
 
     protected function resetPassword($user, $password)
     {
-        $validating_group = cache()->rememberForever('validating_group', function () {
-            return Group::where('slug', '=', 'validating')->pluck('id');
-        });
-        $member_group = cache()->rememberForever('member_group', function () {
-            return Group::where('slug', '=', 'user')->pluck('id');
-        });
+        $validating_group = cache()->rememberForever('validating_group', fn() => Group::where('slug', '=', 'validating')->pluck('id'));
+        $member_group = cache()->rememberForever('member_group', fn() => Group::where('slug', '=', 'user')->pluck('id'));
         $user->password = bcrypt($password);
         $user->remember_token = Str::random(60);
 

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -48,65 +48,49 @@ class HomeController extends Controller
         $user = $request->user();
 
         // Latest Articles/News Block
-        $articles = cache()->remember('latest_article', $expiresAt, function () {
-            return Article::latest()->take(1)->get();
-        });
+        $articles = cache()->remember('latest_article', $expiresAt, fn() => Article::latest()->take(1)->get());
 
         // Latest Torrents Block
         $personal_freeleech = PersonalFreeleech::where('user_id', '=', $user->id)->first();
 
-        $newest = cache()->remember('newest_torrents', $expiresAt, function () {
-            return Torrent::with(['user', 'category'])
-                ->withCount(['thanks', 'comments'])
-                ->latest()
-                ->take(5)
-                ->get();
-        });
+        $newest = cache()->remember('newest_torrents', $expiresAt, fn() => Torrent::with(['user', 'category'])
+            ->withCount(['thanks', 'comments'])
+            ->latest()
+            ->take(5)
+            ->get());
 
-        $seeded = cache()->remember('seeded_torrents', $expiresAt, function () {
-            return Torrent::with(['user', 'category'])
-                ->withCount(['thanks', 'comments'])
-                ->latest('seeders')
-                ->take(5)
-                ->get();
-        });
+        $seeded = cache()->remember('seeded_torrents', $expiresAt, fn() => Torrent::with(['user', 'category'])
+            ->withCount(['thanks', 'comments'])
+            ->latest('seeders')
+            ->take(5)
+            ->get());
 
-        $leeched = cache()->remember('leeched_torrents', $expiresAt, function () {
-            return Torrent::with(['user', 'category'])
-                ->withCount(['thanks', 'comments'])
-                ->latest('leechers')
-                ->take(5)
-                ->get();
-        });
+        $leeched = cache()->remember('leeched_torrents', $expiresAt, fn() => Torrent::with(['user', 'category'])
+            ->withCount(['thanks', 'comments'])
+            ->latest('leechers')
+            ->take(5)
+            ->get());
 
-        $dying = cache()->remember('dying_torrents', $expiresAt, function () {
-            return Torrent::with(['user', 'category'])
-                ->withCount(['thanks', 'comments'])
-                ->where('seeders', '=', 1)
-                ->where('times_completed', '>=', 1)
-                ->latest('leechers')
-                ->take(5)
-                ->get();
-        });
+        $dying = cache()->remember('dying_torrents', $expiresAt, fn() => Torrent::with(['user', 'category'])
+            ->withCount(['thanks', 'comments'])
+            ->where('seeders', '=', 1)
+            ->where('times_completed', '>=', 1)
+            ->latest('leechers')
+            ->take(5)
+            ->get());
 
-        $dead = cache()->remember('dead_torrents', $expiresAt, function () {
-            return Torrent::with(['user', 'category'])
-                ->withCount(['thanks', 'comments'])
-                ->where('seeders', '=', 0)
-                ->latest('leechers')
-                ->take(5)
-                ->get();
-        });
+        $dead = cache()->remember('dead_torrents', $expiresAt, fn() => Torrent::with(['user', 'category'])
+            ->withCount(['thanks', 'comments'])
+            ->where('seeders', '=', 0)
+            ->latest('leechers')
+            ->take(5)
+            ->get());
 
         // Latest Topics Block
-        $topics = cache()->remember('latest_topics', $expiresAt, function () {
-            return Topic::with('forum')->latest()->take(5)->get();
-        });
+        $topics = cache()->remember('latest_topics', $expiresAt, fn() => Topic::with('forum')->latest()->take(5)->get());
 
         // Latest Posts Block
-        $posts = cache()->remember('latest_posts', $expiresAt, function () {
-            return Post::with('topic', 'user')->latest()->take(5)->get();
-        });
+        $posts = cache()->remember('latest_posts', $expiresAt, fn() => Post::with('topic', 'user')->latest()->take(5)->get());
 
         // Online Block
         $users = User::with('group', 'privacy')
@@ -118,39 +102,29 @@ class HomeController extends Controller
             ->where('last_action', '>', now()->subMinutes(5))
             ->get();
 
-        $groups = cache()->remember('user-groups', $expiresAt, function () {
-            return Group::select(['name', 'color', 'effect', 'icon'])->oldest('position')->get();
-        });
+        $groups = cache()->remember('user-groups', $expiresAt, fn() => Group::select(['name', 'color', 'effect', 'icon'])->oldest('position')->get());
 
         // Featured Torrents Block
-        $featured = cache()->remember('latest_featured', $expiresAt, function () {
-            return FeaturedTorrent::with('torrent')->get();
-        });
+        $featured = cache()->remember('latest_featured', $expiresAt, fn() => FeaturedTorrent::with('torrent')->get());
 
         // Latest Poll Block
-        $poll = cache()->remember('latest_poll', $expiresAt, function () {
-            return Poll::latest()->first();
-        });
+        $poll = cache()->remember('latest_poll', $expiresAt, fn() => Poll::latest()->first());
 
         // Top Uploaders Block
-        $uploaders = cache()->remember('top_uploaders', $expiresAt, function () {
-            return Torrent::with('user')
-                ->select(DB::raw('user_id, count(*) as value'))
-                ->groupBy('user_id')
-                ->latest('value')
-                ->take(10)
-                ->get();
-        });
+        $uploaders = cache()->remember('top_uploaders', $expiresAt, fn() => Torrent::with('user')
+            ->select(DB::raw('user_id, count(*) as value'))
+            ->groupBy('user_id')
+            ->latest('value')
+            ->take(10)
+            ->get());
 
-        $past_uploaders = cache()->remember('month_uploaders', $expiresAt, function () use ($current) {
-            return Torrent::with('user')
-                ->where('created_at', '>', $current->copy()->subDays(30)->toDateTimeString())
-                ->select(DB::raw('user_id, count(*) as value'))
-                ->groupBy('user_id')
-                ->latest('value')
-                ->take(10)
-                ->get();
-        });
+        $past_uploaders = cache()->remember('month_uploaders', $expiresAt, fn() => Torrent::with('user')
+            ->where('created_at', '>', $current->copy()->subDays(30)->toDateTimeString())
+            ->select(DB::raw('user_id, count(*) as value'))
+            ->groupBy('user_id')
+            ->latest('value')
+            ->take(10)
+            ->get());
 
         $freeleech_tokens = FreeleechToken::where('user_id', $user->id)->get();
         $bookmarks = Bookmark::where('user_id', $user->id)->get();

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -48,30 +48,30 @@ class HomeController extends Controller
         $user = $request->user();
 
         // Latest Articles/News Block
-        $articles = cache()->remember('latest_article', $expiresAt, fn() => Article::latest()->take(1)->get());
+        $articles = cache()->remember('latest_article', $expiresAt, fn () => Article::latest()->take(1)->get());
 
         // Latest Torrents Block
         $personal_freeleech = PersonalFreeleech::where('user_id', '=', $user->id)->first();
 
-        $newest = cache()->remember('newest_torrents', $expiresAt, fn() => Torrent::with(['user', 'category'])
+        $newest = cache()->remember('newest_torrents', $expiresAt, fn () => Torrent::with(['user', 'category'])
             ->withCount(['thanks', 'comments'])
             ->latest()
             ->take(5)
             ->get());
 
-        $seeded = cache()->remember('seeded_torrents', $expiresAt, fn() => Torrent::with(['user', 'category'])
+        $seeded = cache()->remember('seeded_torrents', $expiresAt, fn () => Torrent::with(['user', 'category'])
             ->withCount(['thanks', 'comments'])
             ->latest('seeders')
             ->take(5)
             ->get());
 
-        $leeched = cache()->remember('leeched_torrents', $expiresAt, fn() => Torrent::with(['user', 'category'])
+        $leeched = cache()->remember('leeched_torrents', $expiresAt, fn () => Torrent::with(['user', 'category'])
             ->withCount(['thanks', 'comments'])
             ->latest('leechers')
             ->take(5)
             ->get());
 
-        $dying = cache()->remember('dying_torrents', $expiresAt, fn() => Torrent::with(['user', 'category'])
+        $dying = cache()->remember('dying_torrents', $expiresAt, fn () => Torrent::with(['user', 'category'])
             ->withCount(['thanks', 'comments'])
             ->where('seeders', '=', 1)
             ->where('times_completed', '>=', 1)
@@ -79,7 +79,7 @@ class HomeController extends Controller
             ->take(5)
             ->get());
 
-        $dead = cache()->remember('dead_torrents', $expiresAt, fn() => Torrent::with(['user', 'category'])
+        $dead = cache()->remember('dead_torrents', $expiresAt, fn () => Torrent::with(['user', 'category'])
             ->withCount(['thanks', 'comments'])
             ->where('seeders', '=', 0)
             ->latest('leechers')
@@ -87,10 +87,10 @@ class HomeController extends Controller
             ->get());
 
         // Latest Topics Block
-        $topics = cache()->remember('latest_topics', $expiresAt, fn() => Topic::with('forum')->latest()->take(5)->get());
+        $topics = cache()->remember('latest_topics', $expiresAt, fn () => Topic::with('forum')->latest()->take(5)->get());
 
         // Latest Posts Block
-        $posts = cache()->remember('latest_posts', $expiresAt, fn() => Post::with('topic', 'user')->latest()->take(5)->get());
+        $posts = cache()->remember('latest_posts', $expiresAt, fn () => Post::with('topic', 'user')->latest()->take(5)->get());
 
         // Online Block
         $users = User::with('group', 'privacy')
@@ -102,23 +102,23 @@ class HomeController extends Controller
             ->where('last_action', '>', now()->subMinutes(5))
             ->get();
 
-        $groups = cache()->remember('user-groups', $expiresAt, fn() => Group::select(['name', 'color', 'effect', 'icon'])->oldest('position')->get());
+        $groups = cache()->remember('user-groups', $expiresAt, fn () => Group::select(['name', 'color', 'effect', 'icon'])->oldest('position')->get());
 
         // Featured Torrents Block
-        $featured = cache()->remember('latest_featured', $expiresAt, fn() => FeaturedTorrent::with('torrent')->get());
+        $featured = cache()->remember('latest_featured', $expiresAt, fn () => FeaturedTorrent::with('torrent')->get());
 
         // Latest Poll Block
-        $poll = cache()->remember('latest_poll', $expiresAt, fn() => Poll::latest()->first());
+        $poll = cache()->remember('latest_poll', $expiresAt, fn () => Poll::latest()->first());
 
         // Top Uploaders Block
-        $uploaders = cache()->remember('top_uploaders', $expiresAt, fn() => Torrent::with('user')
+        $uploaders = cache()->remember('top_uploaders', $expiresAt, fn () => Torrent::with('user')
             ->select(DB::raw('user_id, count(*) as value'))
             ->groupBy('user_id')
             ->latest('value')
             ->take(10)
             ->get());
 
-        $past_uploaders = cache()->remember('month_uploaders', $expiresAt, fn() => Torrent::with('user')
+        $past_uploaders = cache()->remember('month_uploaders', $expiresAt, fn () => Torrent::with('user')
             ->where('created_at', '>', $current->copy()->subDays(30)->toDateTimeString())
             ->select(DB::raw('user_id, count(*) as value'))
             ->groupBy('user_id')

--- a/app/Http/Controllers/RssController.php
+++ b/app/Http/Controllers/RssController.php
@@ -148,12 +148,8 @@ class RssController extends Controller
         $user = User::where('rsskey', '=', (string) $rsskey)->firstOrFail();
         $rss = Rss::where('id', '=', (int) $id)->whereRaw('(user_id = ? OR is_private != ?)', [$user->id, 1])->firstOrFail();
 
-        $banned_group = cache()->rememberForever('banned_group', function () {
-            return Group::where('slug', '=', 'banned')->pluck('id');
-        });
-        $disabled_group = cache()->rememberForever('disabled_group', function () {
-            return Group::where('slug', '=', 'disabled')->pluck('id');
-        });
+        $banned_group = cache()->rememberForever('banned_group', fn() => Group::where('slug', '=', 'banned')->pluck('id'));
+        $disabled_group = cache()->rememberForever('disabled_group', fn() => Group::where('slug', '=', 'disabled')->pluck('id'));
 
         if ($user->group->id == $banned_group[0]) {
             abort(404);

--- a/app/Http/Controllers/RssController.php
+++ b/app/Http/Controllers/RssController.php
@@ -148,8 +148,8 @@ class RssController extends Controller
         $user = User::where('rsskey', '=', (string) $rsskey)->firstOrFail();
         $rss = Rss::where('id', '=', (int) $id)->whereRaw('(user_id = ? OR is_private != ?)', [$user->id, 1])->firstOrFail();
 
-        $banned_group = cache()->rememberForever('banned_group', fn() => Group::where('slug', '=', 'banned')->pluck('id'));
-        $disabled_group = cache()->rememberForever('disabled_group', fn() => Group::where('slug', '=', 'disabled')->pluck('id'));
+        $banned_group = cache()->rememberForever('banned_group', fn () => Group::where('slug', '=', 'banned')->pluck('id'));
+        $disabled_group = cache()->rememberForever('disabled_group', fn () => Group::where('slug', '=', 'disabled')->pluck('id'));
 
         if ($user->group->id == $banned_group[0]) {
             abort(404);

--- a/app/Http/Controllers/Staff/BanController.php
+++ b/app/Http/Controllers/Staff/BanController.php
@@ -49,9 +49,7 @@ class BanController extends Controller
     {
         $user = User::where('username', '=', $username)->firstOrFail();
         $staff = $request->user();
-        $banned_group = cache()->rememberForever('banned_group', function () {
-            return Group::where('slug', '=', 'banned')->pluck('id');
-        });
+        $banned_group = cache()->rememberForever('banned_group', fn() => Group::where('slug', '=', 'banned')->pluck('id'));
 
         abort_if($user->group->is_modo || $request->user()->id == $user->id, 403);
 

--- a/app/Http/Controllers/Staff/BanController.php
+++ b/app/Http/Controllers/Staff/BanController.php
@@ -49,7 +49,7 @@ class BanController extends Controller
     {
         $user = User::where('username', '=', $username)->firstOrFail();
         $staff = $request->user();
-        $banned_group = cache()->rememberForever('banned_group', fn() => Group::where('slug', '=', 'banned')->pluck('id'));
+        $banned_group = cache()->rememberForever('banned_group', fn () => Group::where('slug', '=', 'banned')->pluck('id'));
 
         abort_if($user->group->is_modo || $request->user()->id == $user->id, 403);
 

--- a/app/Http/Controllers/Staff/HomeController.php
+++ b/app/Http/Controllers/Staff/HomeController.php
@@ -36,8 +36,8 @@ class HomeController extends Controller
     public function index(Request $request)
     {
         // User Info
-        $banned_group = cache()->rememberForever('banned_group', fn() => Group::where('slug', '=', 'banned')->pluck('id'));
-        $validating_group = cache()->rememberForever('validating_group', fn() => Group::where('slug', '=', 'validating')->pluck('id'));
+        $banned_group = cache()->rememberForever('banned_group', fn () => Group::where('slug', '=', 'banned')->pluck('id'));
+        $validating_group = cache()->rememberForever('validating_group', fn () => Group::where('slug', '=', 'validating')->pluck('id'));
         $num_user = User::count();
         $banned = User::where('group_id', '=', $banned_group[0])->count();
         $validating = User::where('group_id', '=', $validating_group[0])->count();

--- a/app/Http/Controllers/Staff/HomeController.php
+++ b/app/Http/Controllers/Staff/HomeController.php
@@ -36,12 +36,8 @@ class HomeController extends Controller
     public function index(Request $request)
     {
         // User Info
-        $banned_group = cache()->rememberForever('banned_group', function () {
-            return Group::where('slug', '=', 'banned')->pluck('id');
-        });
-        $validating_group = cache()->rememberForever('validating_group', function () {
-            return Group::where('slug', '=', 'validating')->pluck('id');
-        });
+        $banned_group = cache()->rememberForever('banned_group', fn() => Group::where('slug', '=', 'banned')->pluck('id'));
+        $validating_group = cache()->rememberForever('validating_group', fn() => Group::where('slug', '=', 'validating')->pluck('id'));
         $num_user = User::count();
         $banned = User::where('group_id', '=', $banned_group[0])->count();
         $validating = User::where('group_id', '=', $validating_group[0])->count();

--- a/app/Http/Controllers/Staff/MassActionController.php
+++ b/app/Http/Controllers/Staff/MassActionController.php
@@ -70,12 +70,8 @@ class MassActionController extends Controller
      */
     public function update()
     {
-        $validating_group = cache()->rememberForever('validating_group', function () {
-            return Group::where('slug', '=', 'validating')->pluck('id');
-        });
-        $member_group = cache()->rememberForever('member_group', function () {
-            return Group::where('slug', '=', 'user')->pluck('id');
-        });
+        $validating_group = cache()->rememberForever('validating_group', fn() => Group::where('slug', '=', 'validating')->pluck('id'));
+        $member_group = cache()->rememberForever('member_group', fn() => Group::where('slug', '=', 'user')->pluck('id'));
         $users = User::where('active', '=', 0)->where('group_id', '=', $validating_group[0])->get();
 
         foreach ($users as $user) {

--- a/app/Http/Controllers/Staff/MassActionController.php
+++ b/app/Http/Controllers/Staff/MassActionController.php
@@ -70,8 +70,8 @@ class MassActionController extends Controller
      */
     public function update()
     {
-        $validating_group = cache()->rememberForever('validating_group', fn() => Group::where('slug', '=', 'validating')->pluck('id'));
-        $member_group = cache()->rememberForever('member_group', fn() => Group::where('slug', '=', 'user')->pluck('id'));
+        $validating_group = cache()->rememberForever('validating_group', fn () => Group::where('slug', '=', 'validating')->pluck('id'));
+        $member_group = cache()->rememberForever('member_group', fn () => Group::where('slug', '=', 'user')->pluck('id'));
         $users = User::where('active', '=', 0)->where('group_id', '=', $validating_group[0])->get();
 
         foreach ($users as $user) {

--- a/app/Http/Controllers/Staff/PollController.php
+++ b/app/Http/Controllers/Staff/PollController.php
@@ -85,9 +85,7 @@ class PollController extends Controller
 
         $poll = $request->user() ? $user->polls()->create($request->all()) : Poll::create($request->all());
 
-        $options = collect($request->input('options'))->map(function ($value) {
-            return new Option(['name' => $value]);
-        });
+        $options = collect($request->input('options'))->map(fn($value) => new Option(['name' => $value]));
         $poll->options()->saveMany($options);
 
         $poll_url = hrefPoll($poll);
@@ -134,13 +132,9 @@ class PollController extends Controller
         }
 
         // Remove the deleted options in poll
-        $oldOptionIds = collect($poll->options)->map(function ($option) {
-            return $option->id;
-        })->all();
+        $oldOptionIds = collect($poll->options)->map(fn($option) => $option->id)->all();
 
-        $existingOldOptionIds = collect($request->input('option-id'))->map(function ($id) {
-            return intval($id);
-        })->all();
+        $existingOldOptionIds = collect($request->input('option-id'))->map(fn($id) => intval($id))->all();
 
         $idsOfOptionToBeRemove = array_diff($oldOptionIds, $existingOldOptionIds);
 
@@ -150,9 +144,7 @@ class PollController extends Controller
         }
 
         // Update existing options
-        $existingOldOptionContents = collect($request->input('option-content'))->map(function ($content) {
-            return strval($content);
-        })->all();
+        $existingOldOptionContents = collect($request->input('option-content'))->map(fn($content) => strval($content))->all();
 
         if (count($existingOldOptionContents) === count($existingOldOptionIds)) {
             $len = count($existingOldOptionContents);
@@ -164,9 +156,7 @@ class PollController extends Controller
         }
 
         // Insert new options
-        $newOptions = collect($request->input('new-option-content'))->map(function ($content) {
-            return new Option(['name' => $content]);
-        });
+        $newOptions = collect($request->input('new-option-content'))->map(fn($content) => new Option(['name' => $content]));
 
         $poll->options()->saveMany($newOptions);
 

--- a/app/Http/Controllers/Staff/PollController.php
+++ b/app/Http/Controllers/Staff/PollController.php
@@ -85,7 +85,7 @@ class PollController extends Controller
 
         $poll = $request->user() ? $user->polls()->create($request->all()) : Poll::create($request->all());
 
-        $options = collect($request->input('options'))->map(fn($value) => new Option(['name' => $value]));
+        $options = collect($request->input('options'))->map(fn ($value) => new Option(['name' => $value]));
         $poll->options()->saveMany($options);
 
         $poll_url = hrefPoll($poll);
@@ -132,9 +132,9 @@ class PollController extends Controller
         }
 
         // Remove the deleted options in poll
-        $oldOptionIds = collect($poll->options)->map(fn($option) => $option->id)->all();
+        $oldOptionIds = collect($poll->options)->map(fn ($option) => $option->id)->all();
 
-        $existingOldOptionIds = collect($request->input('option-id'))->map(fn($id) => intval($id))->all();
+        $existingOldOptionIds = collect($request->input('option-id'))->map(fn ($id) => intval($id))->all();
 
         $idsOfOptionToBeRemove = array_diff($oldOptionIds, $existingOldOptionIds);
 
@@ -144,7 +144,7 @@ class PollController extends Controller
         }
 
         // Update existing options
-        $existingOldOptionContents = collect($request->input('option-content'))->map(fn($content) => strval($content))->all();
+        $existingOldOptionContents = collect($request->input('option-content'))->map(fn ($content) => strval($content))->all();
 
         if (count($existingOldOptionContents) === count($existingOldOptionIds)) {
             $len = count($existingOldOptionContents);
@@ -156,7 +156,7 @@ class PollController extends Controller
         }
 
         // Insert new options
-        $newOptions = collect($request->input('new-option-content'))->map(fn($content) => new Option(['name' => $content]));
+        $newOptions = collect($request->input('new-option-content'))->map(fn ($content) => new Option(['name' => $content]));
 
         $poll->options()->saveMany($newOptions);
 

--- a/app/Http/Controllers/StatsController.php
+++ b/app/Http/Controllers/StatsController.php
@@ -44,74 +44,74 @@ class StatsController extends Controller
     public function index()
     {
         // Total Members Count (All Groups)
-        $all_user = cache()->remember('all_user', $this->expiresAt, fn() => User::withTrashed()->count());
+        $all_user = cache()->remember('all_user', $this->expiresAt, fn () => User::withTrashed()->count());
 
         // Total Active Members Count (Not Validating, Banned, Disabled, Pruned)
         $active_user = cache()->remember('active_user', $this->expiresAt, function () {
-            $banned_group = cache()->rememberForever('banned_group', fn() => Group::where('slug', '=', 'banned')->pluck('id'));
-            $validating_group = cache()->rememberForever('validating_group', fn() => Group::where('slug', '=', 'validating')->pluck('id'));
-            $disabled_group = cache()->rememberForever('disabled_group', fn() => Group::where('slug', '=', 'disabled')->pluck('id'));
-            $pruned_group = cache()->rememberForever('pruned_group', fn() => Group::where('slug', '=', 'pruned')->pluck('id'));
+            $banned_group = cache()->rememberForever('banned_group', fn () => Group::where('slug', '=', 'banned')->pluck('id'));
+            $validating_group = cache()->rememberForever('validating_group', fn () => Group::where('slug', '=', 'validating')->pluck('id'));
+            $disabled_group = cache()->rememberForever('disabled_group', fn () => Group::where('slug', '=', 'disabled')->pluck('id'));
+            $pruned_group = cache()->rememberForever('pruned_group', fn () => Group::where('slug', '=', 'pruned')->pluck('id'));
 
             return User::whereNotIn('group_id', [$validating_group[0], $banned_group[0], $disabled_group[0], $pruned_group[0]])->count();
         });
 
         // Total Disabled Members Count
         $disabled_user = cache()->remember('disabled_user', $this->expiresAt, function () {
-            $disabled_group = cache()->rememberForever('disabled_group', fn() => Group::where('slug', '=', 'disabled')->pluck('id'));
+            $disabled_group = cache()->rememberForever('disabled_group', fn () => Group::where('slug', '=', 'disabled')->pluck('id'));
 
             return User::where('group_id', '=', $disabled_group[0])->count();
         });
 
         // Total Pruned Members Count
         $pruned_user = cache()->remember('pruned_user', $this->expiresAt, function () {
-            $pruned_group = cache()->rememberForever('pruned_group', fn() => Group::where('slug', '=', 'pruned')->pluck('id'));
+            $pruned_group = cache()->rememberForever('pruned_group', fn () => Group::where('slug', '=', 'pruned')->pluck('id'));
 
             return User::onlyTrashed()->where('group_id', '=', $pruned_group[0])->count();
         });
 
         // Total Banned Members Count
         $banned_user = cache()->remember('banned_user', $this->expiresAt, function () {
-            $banned_group = cache()->rememberForever('banned_group', fn() => Group::where('slug', '=', 'banned')->pluck('id'));
+            $banned_group = cache()->rememberForever('banned_group', fn () => Group::where('slug', '=', 'banned')->pluck('id'));
 
             return User::where('group_id', '=', $banned_group[0])->count();
         });
 
         // Total Torrents Count
-        $num_torrent = cache()->remember('num_torrent', $this->expiresAt, fn() => Torrent::count());
+        $num_torrent = cache()->remember('num_torrent', $this->expiresAt, fn () => Torrent::count());
 
         // Total Categories With Torrent Count
         $categories = Category::withCount('torrents')->get()->sortBy('position');
 
         // Total HD Count
-        $num_hd = cache()->remember('num_hd', $this->expiresAt, fn() => Torrent::where('sd', '=', 0)->count());
+        $num_hd = cache()->remember('num_hd', $this->expiresAt, fn () => Torrent::where('sd', '=', 0)->count());
 
         // Total SD Count
-        $num_sd = cache()->remember('num_sd', $this->expiresAt, fn() => Torrent::where('sd', '=', 1)->count());
+        $num_sd = cache()->remember('num_sd', $this->expiresAt, fn () => Torrent::where('sd', '=', 1)->count());
 
         // Total Torrent Size
-        $torrent_size = cache()->remember('torrent_size', $this->expiresAt, fn() => Torrent::sum('size'));
+        $torrent_size = cache()->remember('torrent_size', $this->expiresAt, fn () => Torrent::sum('size'));
 
         // Total Seeders
-        $num_seeders = cache()->remember('num_seeders', $this->expiresAt, fn() => Peer::where('seeder', '=', 1)->count());
+        $num_seeders = cache()->remember('num_seeders', $this->expiresAt, fn () => Peer::where('seeder', '=', 1)->count());
 
         // Total Leechers
-        $num_leechers = cache()->remember('num_leechers', $this->expiresAt, fn() => Peer::where('seeder', '=', 0)->count());
+        $num_leechers = cache()->remember('num_leechers', $this->expiresAt, fn () => Peer::where('seeder', '=', 0)->count());
 
         // Total Peers
-        $num_peers = cache()->remember('num_peers', $this->expiresAt, fn() => Peer::count());
+        $num_peers = cache()->remember('num_peers', $this->expiresAt, fn () => Peer::count());
 
         //Total Upload Traffic Without Double Upload
-        $actual_upload = cache()->remember('actual_upload', $this->expiresAt, fn() => History::sum('actual_uploaded'));
+        $actual_upload = cache()->remember('actual_upload', $this->expiresAt, fn () => History::sum('actual_uploaded'));
 
         //Total Upload Traffic With Double Upload
-        $credited_upload = cache()->remember('credited_upload', $this->expiresAt, fn() => History::sum('uploaded'));
+        $credited_upload = cache()->remember('credited_upload', $this->expiresAt, fn () => History::sum('uploaded'));
 
         //Total Download Traffic Without Freeleech
-        $actual_download = cache()->remember('actual_download', $this->expiresAt, fn() => History::sum('actual_downloaded'));
+        $actual_download = cache()->remember('actual_download', $this->expiresAt, fn () => History::sum('actual_downloaded'));
 
         //Total Download Traffic With Freeleech
-        $credited_download = cache()->remember('credited_download', $this->expiresAt, fn() => History::sum('downloaded'));
+        $credited_download = cache()->remember('credited_download', $this->expiresAt, fn () => History::sum('downloaded'));
 
         //Total Up/Down Traffic without perks
         $actual_up_down = $actual_upload + $actual_download;
@@ -149,10 +149,10 @@ class StatsController extends Controller
      */
     public function uploaded()
     {
-        $banned_group = cache()->rememberForever('banned_group', fn() => Group::where('slug', '=', 'banned')->pluck('id'));
-        $validating_group = cache()->rememberForever('validating_group', fn() => Group::where('slug', '=', 'validating')->pluck('id'));
-        $disabled_group = cache()->rememberForever('disabled_group', fn() => Group::where('slug', '=', 'disabled')->pluck('id'));
-        $pruned_group = cache()->rememberForever('pruned_group', fn() => Group::where('slug', '=', 'pruned')->pluck('id'));
+        $banned_group = cache()->rememberForever('banned_group', fn () => Group::where('slug', '=', 'banned')->pluck('id'));
+        $validating_group = cache()->rememberForever('validating_group', fn () => Group::where('slug', '=', 'validating')->pluck('id'));
+        $disabled_group = cache()->rememberForever('disabled_group', fn () => Group::where('slug', '=', 'disabled')->pluck('id'));
+        $pruned_group = cache()->rememberForever('pruned_group', fn () => Group::where('slug', '=', 'pruned')->pluck('id'));
 
         // Fetch Top Uploaders
         $uploaded = User::latest('uploaded')->whereNotIn('group_id', [$validating_group[0], $banned_group[0], $disabled_group[0], $pruned_group[0]])->take(100)->get();
@@ -167,10 +167,10 @@ class StatsController extends Controller
      */
     public function downloaded()
     {
-        $banned_group = cache()->rememberForever('banned_group', fn() => Group::where('slug', '=', 'banned')->pluck('id'));
-        $validating_group = cache()->rememberForever('validating_group', fn() => Group::where('slug', '=', 'validating')->pluck('id'));
-        $disabled_group = cache()->rememberForever('disabled_group', fn() => Group::where('slug', '=', 'disabled')->pluck('id'));
-        $pruned_group = cache()->rememberForever('pruned_group', fn() => Group::where('slug', '=', 'pruned')->pluck('id'));
+        $banned_group = cache()->rememberForever('banned_group', fn () => Group::where('slug', '=', 'banned')->pluck('id'));
+        $validating_group = cache()->rememberForever('validating_group', fn () => Group::where('slug', '=', 'validating')->pluck('id'));
+        $disabled_group = cache()->rememberForever('disabled_group', fn () => Group::where('slug', '=', 'disabled')->pluck('id'));
+        $pruned_group = cache()->rememberForever('pruned_group', fn () => Group::where('slug', '=', 'pruned')->pluck('id'));
 
         // Fetch Top Downloaders
         $downloaded = User::latest('downloaded')->whereNotIn('group_id', [$validating_group[0], $banned_group[0], $disabled_group[0], $pruned_group[0]])->take(100)->get();
@@ -224,10 +224,10 @@ class StatsController extends Controller
      */
     public function bankers()
     {
-        $banned_group = cache()->rememberForever('banned_group', fn() => Group::where('slug', '=', 'banned')->pluck('id'));
-        $validating_group = cache()->rememberForever('validating_group', fn() => Group::where('slug', '=', 'validating')->pluck('id'));
-        $disabled_group = cache()->rememberForever('disabled_group', fn() => Group::where('slug', '=', 'disabled')->pluck('id'));
-        $pruned_group = cache()->rememberForever('pruned_group', fn() => Group::where('slug', '=', 'pruned')->pluck('id'));
+        $banned_group = cache()->rememberForever('banned_group', fn () => Group::where('slug', '=', 'banned')->pluck('id'));
+        $validating_group = cache()->rememberForever('validating_group', fn () => Group::where('slug', '=', 'validating')->pluck('id'));
+        $disabled_group = cache()->rememberForever('disabled_group', fn () => Group::where('slug', '=', 'disabled')->pluck('id'));
+        $pruned_group = cache()->rememberForever('pruned_group', fn () => Group::where('slug', '=', 'pruned')->pluck('id'));
 
         // Fetch Top Bankers
         $bankers = User::latest('seedbonus')->whereNotIn('group_id', [$validating_group[0], $banned_group[0], $disabled_group[0], $pruned_group[0]])->take(100)->get();

--- a/app/Http/Controllers/StatsController.php
+++ b/app/Http/Controllers/StatsController.php
@@ -44,112 +44,74 @@ class StatsController extends Controller
     public function index()
     {
         // Total Members Count (All Groups)
-        $all_user = cache()->remember('all_user', $this->expiresAt, function () {
-            return User::withTrashed()->count();
-        });
+        $all_user = cache()->remember('all_user', $this->expiresAt, fn() => User::withTrashed()->count());
 
         // Total Active Members Count (Not Validating, Banned, Disabled, Pruned)
         $active_user = cache()->remember('active_user', $this->expiresAt, function () {
-            $banned_group = cache()->rememberForever('banned_group', function () {
-                return Group::where('slug', '=', 'banned')->pluck('id');
-            });
-            $validating_group = cache()->rememberForever('validating_group', function () {
-                return Group::where('slug', '=', 'validating')->pluck('id');
-            });
-            $disabled_group = cache()->rememberForever('disabled_group', function () {
-                return Group::where('slug', '=', 'disabled')->pluck('id');
-            });
-            $pruned_group = cache()->rememberForever('pruned_group', function () {
-                return Group::where('slug', '=', 'pruned')->pluck('id');
-            });
+            $banned_group = cache()->rememberForever('banned_group', fn() => Group::where('slug', '=', 'banned')->pluck('id'));
+            $validating_group = cache()->rememberForever('validating_group', fn() => Group::where('slug', '=', 'validating')->pluck('id'));
+            $disabled_group = cache()->rememberForever('disabled_group', fn() => Group::where('slug', '=', 'disabled')->pluck('id'));
+            $pruned_group = cache()->rememberForever('pruned_group', fn() => Group::where('slug', '=', 'pruned')->pluck('id'));
 
             return User::whereNotIn('group_id', [$validating_group[0], $banned_group[0], $disabled_group[0], $pruned_group[0]])->count();
         });
 
         // Total Disabled Members Count
         $disabled_user = cache()->remember('disabled_user', $this->expiresAt, function () {
-            $disabled_group = cache()->rememberForever('disabled_group', function () {
-                return Group::where('slug', '=', 'disabled')->pluck('id');
-            });
+            $disabled_group = cache()->rememberForever('disabled_group', fn() => Group::where('slug', '=', 'disabled')->pluck('id'));
 
             return User::where('group_id', '=', $disabled_group[0])->count();
         });
 
         // Total Pruned Members Count
         $pruned_user = cache()->remember('pruned_user', $this->expiresAt, function () {
-            $pruned_group = cache()->rememberForever('pruned_group', function () {
-                return Group::where('slug', '=', 'pruned')->pluck('id');
-            });
+            $pruned_group = cache()->rememberForever('pruned_group', fn() => Group::where('slug', '=', 'pruned')->pluck('id'));
 
             return User::onlyTrashed()->where('group_id', '=', $pruned_group[0])->count();
         });
 
         // Total Banned Members Count
         $banned_user = cache()->remember('banned_user', $this->expiresAt, function () {
-            $banned_group = cache()->rememberForever('banned_group', function () {
-                return Group::where('slug', '=', 'banned')->pluck('id');
-            });
+            $banned_group = cache()->rememberForever('banned_group', fn() => Group::where('slug', '=', 'banned')->pluck('id'));
 
             return User::where('group_id', '=', $banned_group[0])->count();
         });
 
         // Total Torrents Count
-        $num_torrent = cache()->remember('num_torrent', $this->expiresAt, function () {
-            return Torrent::count();
-        });
+        $num_torrent = cache()->remember('num_torrent', $this->expiresAt, fn() => Torrent::count());
 
         // Total Categories With Torrent Count
         $categories = Category::withCount('torrents')->get()->sortBy('position');
 
         // Total HD Count
-        $num_hd = cache()->remember('num_hd', $this->expiresAt, function () {
-            return Torrent::where('sd', '=', 0)->count();
-        });
+        $num_hd = cache()->remember('num_hd', $this->expiresAt, fn() => Torrent::where('sd', '=', 0)->count());
 
         // Total SD Count
-        $num_sd = cache()->remember('num_sd', $this->expiresAt, function () {
-            return Torrent::where('sd', '=', 1)->count();
-        });
+        $num_sd = cache()->remember('num_sd', $this->expiresAt, fn() => Torrent::where('sd', '=', 1)->count());
 
         // Total Torrent Size
-        $torrent_size = cache()->remember('torrent_size', $this->expiresAt, function () {
-            return Torrent::sum('size');
-        });
+        $torrent_size = cache()->remember('torrent_size', $this->expiresAt, fn() => Torrent::sum('size'));
 
         // Total Seeders
-        $num_seeders = cache()->remember('num_seeders', $this->expiresAt, function () {
-            return Peer::where('seeder', '=', 1)->count();
-        });
+        $num_seeders = cache()->remember('num_seeders', $this->expiresAt, fn() => Peer::where('seeder', '=', 1)->count());
 
         // Total Leechers
-        $num_leechers = cache()->remember('num_leechers', $this->expiresAt, function () {
-            return Peer::where('seeder', '=', 0)->count();
-        });
+        $num_leechers = cache()->remember('num_leechers', $this->expiresAt, fn() => Peer::where('seeder', '=', 0)->count());
 
         // Total Peers
-        $num_peers = cache()->remember('num_peers', $this->expiresAt, function () {
-            return Peer::count();
-        });
+        $num_peers = cache()->remember('num_peers', $this->expiresAt, fn() => Peer::count());
 
         //Total Upload Traffic Without Double Upload
-        $actual_upload = cache()->remember('actual_upload', $this->expiresAt, function () {
-            return History::sum('actual_uploaded');
-        });
+        $actual_upload = cache()->remember('actual_upload', $this->expiresAt, fn() => History::sum('actual_uploaded'));
 
         //Total Upload Traffic With Double Upload
-        $credited_upload = cache()->remember('credited_upload', $this->expiresAt, function () {
-            return History::sum('uploaded');
-        });
+        $credited_upload = cache()->remember('credited_upload', $this->expiresAt, fn() => History::sum('uploaded'));
 
         //Total Download Traffic Without Freeleech
-        $actual_download = cache()->remember('actual_download', $this->expiresAt, function () {
-            return History::sum('actual_downloaded');
-        });
+        $actual_download = cache()->remember('actual_download', $this->expiresAt, fn() => History::sum('actual_downloaded'));
 
         //Total Download Traffic With Freeleech
-        $credited_download = cache()->remember('credited_download', $this->expiresAt, function () {
-            return History::sum('downloaded');
-        });
+        $credited_download = cache()->remember('credited_download', $this->expiresAt, fn() => History::sum('downloaded'));
 
         //Total Up/Down Traffic without perks
         $actual_up_down = $actual_upload + $actual_download;
@@ -187,18 +149,10 @@ class StatsController extends Controller
      */
     public function uploaded()
     {
-        $banned_group = cache()->rememberForever('banned_group', function () {
-            return Group::where('slug', '=', 'banned')->pluck('id');
-        });
-        $validating_group = cache()->rememberForever('validating_group', function () {
-            return Group::where('slug', '=', 'validating')->pluck('id');
-        });
-        $disabled_group = cache()->rememberForever('disabled_group', function () {
-            return Group::where('slug', '=', 'disabled')->pluck('id');
-        });
-        $pruned_group = cache()->rememberForever('pruned_group', function () {
-            return Group::where('slug', '=', 'pruned')->pluck('id');
-        });
+        $banned_group = cache()->rememberForever('banned_group', fn() => Group::where('slug', '=', 'banned')->pluck('id'));
+        $validating_group = cache()->rememberForever('validating_group', fn() => Group::where('slug', '=', 'validating')->pluck('id'));
+        $disabled_group = cache()->rememberForever('disabled_group', fn() => Group::where('slug', '=', 'disabled')->pluck('id'));
+        $pruned_group = cache()->rememberForever('pruned_group', fn() => Group::where('slug', '=', 'pruned')->pluck('id'));
 
         // Fetch Top Uploaders
         $uploaded = User::latest('uploaded')->whereNotIn('group_id', [$validating_group[0], $banned_group[0], $disabled_group[0], $pruned_group[0]])->take(100)->get();
@@ -213,18 +167,10 @@ class StatsController extends Controller
      */
     public function downloaded()
     {
-        $banned_group = cache()->rememberForever('banned_group', function () {
-            return Group::where('slug', '=', 'banned')->pluck('id');
-        });
-        $validating_group = cache()->rememberForever('validating_group', function () {
-            return Group::where('slug', '=', 'validating')->pluck('id');
-        });
-        $disabled_group = cache()->rememberForever('disabled_group', function () {
-            return Group::where('slug', '=', 'disabled')->pluck('id');
-        });
-        $pruned_group = cache()->rememberForever('pruned_group', function () {
-            return Group::where('slug', '=', 'pruned')->pluck('id');
-        });
+        $banned_group = cache()->rememberForever('banned_group', fn() => Group::where('slug', '=', 'banned')->pluck('id'));
+        $validating_group = cache()->rememberForever('validating_group', fn() => Group::where('slug', '=', 'validating')->pluck('id'));
+        $disabled_group = cache()->rememberForever('disabled_group', fn() => Group::where('slug', '=', 'disabled')->pluck('id'));
+        $pruned_group = cache()->rememberForever('pruned_group', fn() => Group::where('slug', '=', 'pruned')->pluck('id'));
 
         // Fetch Top Downloaders
         $downloaded = User::latest('downloaded')->whereNotIn('group_id', [$validating_group[0], $banned_group[0], $disabled_group[0], $pruned_group[0]])->take(100)->get();
@@ -278,18 +224,10 @@ class StatsController extends Controller
      */
     public function bankers()
     {
-        $banned_group = cache()->rememberForever('banned_group', function () {
-            return Group::where('slug', '=', 'banned')->pluck('id');
-        });
-        $validating_group = cache()->rememberForever('validating_group', function () {
-            return Group::where('slug', '=', 'validating')->pluck('id');
-        });
-        $disabled_group = cache()->rememberForever('disabled_group', function () {
-            return Group::where('slug', '=', 'disabled')->pluck('id');
-        });
-        $pruned_group = cache()->rememberForever('pruned_group', function () {
-            return Group::where('slug', '=', 'pruned')->pluck('id');
-        });
+        $banned_group = cache()->rememberForever('banned_group', fn() => Group::where('slug', '=', 'banned')->pluck('id'));
+        $validating_group = cache()->rememberForever('validating_group', fn() => Group::where('slug', '=', 'validating')->pluck('id'));
+        $disabled_group = cache()->rememberForever('disabled_group', fn() => Group::where('slug', '=', 'disabled')->pluck('id'));
+        $pruned_group = cache()->rememberForever('pruned_group', fn() => Group::where('slug', '=', 'pruned')->pluck('id'));
 
         // Fetch Top Bankers
         $bankers = User::latest('seedbonus')->whereNotIn('group_id', [$validating_group[0], $banned_group[0], $disabled_group[0], $pruned_group[0]])->take(100)->get();

--- a/app/Http/Middleware/CheckIfBanned.php
+++ b/app/Http/Middleware/CheckIfBanned.php
@@ -30,9 +30,7 @@ class CheckIfBanned
     public function handle($request, Closure $next, $guard = null)
     {
         $user = $request->user();
-        $banned_group = cache()->rememberForever('banned_group', function () {
-            return Group::where('slug', '=', 'banned')->pluck('id');
-        });
+        $banned_group = cache()->rememberForever('banned_group', fn() => Group::where('slug', '=', 'banned')->pluck('id'));
 
         if ($user && $user->group_id == $banned_group[0]) {
             auth()->logout();

--- a/app/Http/Middleware/CheckIfBanned.php
+++ b/app/Http/Middleware/CheckIfBanned.php
@@ -30,7 +30,7 @@ class CheckIfBanned
     public function handle($request, Closure $next, $guard = null)
     {
         $user = $request->user();
-        $banned_group = cache()->rememberForever('banned_group', fn() => Group::where('slug', '=', 'banned')->pluck('id'));
+        $banned_group = cache()->rememberForever('banned_group', fn () => Group::where('slug', '=', 'banned')->pluck('id'));
 
         if ($user && $user->group_id == $banned_group[0]) {
             auth()->logout();

--- a/app/Http/Middleware/Http2ServerPush.php
+++ b/app/Http/Middleware/Http2ServerPush.php
@@ -74,17 +74,13 @@ class Http2ServerPush
         $excludeKeywords ?? $this->getConfig('exclude_keywords', []);
         $headers = $this->fetchLinkableNodes($response)
             ->flatten(1)
-            ->map(function ($url) {
-                return $this->buildLinkHeaderString($url);
-            })
+            ->map(fn($url) => $this->buildLinkHeaderString($url))
             ->unique()
             ->filter(function ($value, $key) use ($excludeKeywords) {
                 if (!$value) {
                     return false;
                 }
-                $exclude_keywords = collect($excludeKeywords)->map(function ($keyword) {
-                    return preg_quote($keyword);
-                });
+                $exclude_keywords = collect($excludeKeywords)->map(fn($keyword) => preg_quote($keyword));
                 if ($exclude_keywords->count() <= 0) {
                     return true;
                 }
@@ -151,9 +147,7 @@ class Http2ServerPush
             '.JS'   => 'script',
         ];
 
-        $type = collect($linkTypeMap)->first(function ($type, $extension) use ($url) {
-            return Str::contains(strtoupper($url), $extension);
-        });
+        $type = collect($linkTypeMap)->first(fn($type, $extension) => Str::contains(strtoupper($url), $extension));
 
         if (!preg_match('%^https?://%i', $url)) {
             $basePath = $this->getConfig('base_path', '/');

--- a/app/Http/Middleware/Http2ServerPush.php
+++ b/app/Http/Middleware/Http2ServerPush.php
@@ -74,13 +74,13 @@ class Http2ServerPush
         $excludeKeywords ?? $this->getConfig('exclude_keywords', []);
         $headers = $this->fetchLinkableNodes($response)
             ->flatten(1)
-            ->map(fn($url) => $this->buildLinkHeaderString($url))
+            ->map(fn ($url) => $this->buildLinkHeaderString($url))
             ->unique()
             ->filter(function ($value, $key) use ($excludeKeywords) {
                 if (!$value) {
                     return false;
                 }
-                $exclude_keywords = collect($excludeKeywords)->map(fn($keyword) => preg_quote($keyword));
+                $exclude_keywords = collect($excludeKeywords)->map(fn ($keyword) => preg_quote($keyword));
                 if ($exclude_keywords->count() <= 0) {
                     return true;
                 }
@@ -147,7 +147,7 @@ class Http2ServerPush
             '.JS'   => 'script',
         ];
 
-        $type = collect($linkTypeMap)->first(fn($type, $extension) => Str::contains(strtoupper($url), $extension));
+        $type = collect($linkTypeMap)->first(fn ($type, $extension) => Str::contains(strtoupper($url), $extension));
 
         if (!preg_match('%^https?://%i', $url)) {
             $basePath = $this->getConfig('base_path', '/');

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -71,7 +71,7 @@ class AppServiceProvider extends ServiceProvider
 
         // Share $footer_pages across all views
         view()->composer('*', function (View $view) {
-            $footer_pages = cache()->remember('cached-pages', 3600, fn() => Page::select(['id', 'name', 'slug', 'created_at'])->take(6)->get());
+            $footer_pages = cache()->remember('cached-pages', 3600, fn () => Page::select(['id', 'name', 'slug', 'created_at'])->take(6)->get());
 
             $view->with(compact('footer_pages'));
         });

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -77,7 +77,7 @@ class AppServiceProvider extends ServiceProvider
         });
 
         // Hidden Captcha
-        Blade::directive('hiddencaptcha', fn($mustBeEmptyField = '_username') => sprintf('<?= App\Helpers\HiddenCaptcha::render(%s); ?>', $mustBeEmptyField));
+        Blade::directive('hiddencaptcha', fn ($mustBeEmptyField = '_username') => sprintf('<?= App\Helpers\HiddenCaptcha::render(%s); ?>', $mustBeEmptyField));
 
         $this->app['validator']->extendImplicit(
             'hiddencaptcha',

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -71,17 +71,13 @@ class AppServiceProvider extends ServiceProvider
 
         // Share $footer_pages across all views
         view()->composer('*', function (View $view) {
-            $footer_pages = cache()->remember('cached-pages', 3600, function () {
-                return Page::select(['id', 'name', 'slug', 'created_at'])->take(6)->get();
-            });
+            $footer_pages = cache()->remember('cached-pages', 3600, fn() => Page::select(['id', 'name', 'slug', 'created_at'])->take(6)->get());
 
             $view->with(compact('footer_pages'));
         });
 
         // Hidden Captcha
-        Blade::directive('hiddencaptcha', function ($mustBeEmptyField = '_username') {
-            return sprintf('<?= App\Helpers\HiddenCaptcha::render(%s); ?>', $mustBeEmptyField);
-        });
+        Blade::directive('hiddencaptcha', fn($mustBeEmptyField = '_username') => sprintf('<?= App\Helpers\HiddenCaptcha::render(%s); ?>', $mustBeEmptyField));
 
         $this->app['validator']->extendImplicit(
             'hiddencaptcha',

--- a/app/Services/Clients/Client.php
+++ b/app/Services/Clients/Client.php
@@ -67,9 +67,7 @@ abstract class Client
         $key = 'movietvdb:'.$key;
 
         if ($data) {
-            cache()->remember($key, 7 * 24 * 60, function () use ($data) {
-                return serialize($data);
-            });
+            cache()->remember($key, 7 * 24 * 60, fn() => serialize($data));
         }
 
         if (cache()->has($key)) {

--- a/app/Services/Clients/Client.php
+++ b/app/Services/Clients/Client.php
@@ -67,7 +67,7 @@ abstract class Client
         $key = 'movietvdb:'.$key;
 
         if ($data) {
-            cache()->remember($key, 7 * 24 * 60, fn() => serialize($data));
+            cache()->remember($key, 7 * 24 * 60, fn () => serialize($data));
         }
 
         if (cache()->has($key)) {

--- a/app/Services/Clients/TmdbClient.php
+++ b/app/Services/Clients/TmdbClient.php
@@ -335,13 +335,9 @@ class TmdbClient extends Client implements MovieTvInterface
 
     private function formatImages($images, $path, $image)
     {
-        $images = array_map(function ($item) use ($path) {
-            return $path.$item['file_path'];
-        }, $images);
+        $images = array_map(fn($item) => $path.$item['file_path'], $images);
 
-        return array_filter($images, function ($item) use ($path, $image) {
-            return !($item == $path.$image);
-        });
+        return array_filter($images, fn($item) => !($item == $path.$image));
     }
 
     private function formatCasts($credits, $role)

--- a/app/Services/Clients/TmdbClient.php
+++ b/app/Services/Clients/TmdbClient.php
@@ -335,9 +335,9 @@ class TmdbClient extends Client implements MovieTvInterface
 
     private function formatImages($images, $path, $image)
     {
-        $images = array_map(fn($item) => $path.$item['file_path'], $images);
+        $images = array_map(fn ($item) => $path.$item['file_path'], $images);
 
-        return array_filter($images, fn($item) => !($item == $path.$image));
+        return array_filter($images, fn ($item) => !($item == $path.$image));
     }
 
     private function formatCasts($credits, $role)


### PR DESCRIPTION
`Note: Merging Into Development Until All PHP7.4 Refactors Are Complete And New UNIT3D Release Is Ready.`

### `Closure To Arrow Function`

Change closure to arrow function

```diff
 class SomeClass
 {
     public function run($meetups)
     {
-        return array_filter($meetups, function (Meetup $meetup) {
-            return is_object($meetup);
-        });
+        return array_filter($meetups, fn(Meetup $meetup) => is_object($meetup));
     }
 }
```