### PR TITLE
tests: Add default mail credentials

### DIFF
--- a/.env.testing
+++ b/.env.testing
@@ -12,7 +12,7 @@ DB_DATABASE=unit3d_test
 DB_USERNAME=homestead
 DB_PASSWORD=secret
 
-PRISTINE_DB_FILE=
+#PRISTINE_DB_FILE=/home/vagrant/code/database/unit3d_test.sql
 
 BROADCAST_DRIVER=log
 CACHE_DRIVER=file
@@ -30,6 +30,8 @@ MAIL_PORT=2525
 MAIL_USERNAME=null
 MAIL_PASSWORD=null
 MAIL_ENCRYPTION=null
+MAIL_FROM_ADDRESS='support@unit3d.site'
+MAIL_FROM_NAME='UNIT3D Support'
 
 PUSHER_APP_ID=
 PUSHER_APP_KEY=


### PR DESCRIPTION
Fixes exception, "Address in mailbox given [] does not comply with
RFC 2822, 3.6.2." in tests that send mail.