### PR TITLE
Fix error in check/delete of torrent after failing validation

### DIFF
--- a/app/Http/Controllers/API/TorrentController.php
+++ b/app/Http/Controllers/API/TorrentController.php
@@ -145,8 +145,8 @@ class TorrentController extends BaseController
         ]);
 
         if ($v->fails()) {
-            if (Storage::disk('torrent')->exists($fileName)) {
-                Storage::disk('torrent')->delete($fileName);
+            if (Storage::disk('torrents')->exists($fileName)) {
+                Storage::disk('torrents')->delete($fileName);
             }
 
             return $this->sendError('Validation Error.', $v->errors());


### PR DESCRIPTION
Check / delete of torrent file was referencing the incorrect disk.  It was referring to `torrent` instead of `torrents`.