### PR TITLE
Update profile.blade.php

### DIFF
--- a/resources/views/user/profile.blade.php
+++ b/resources/views/user/profile.blade.php
@@ -187,22 +187,21 @@
                 <td class="col-md-2">@lang('common.download')</td>
                 <td>
                     <span class="badge-extra text-red" data-toggle="tooltip" title=""
-                          data-original-title="@lang('user.download-recorded')">{{ $user->getDownloaded() }}</span>
-                    +
-                    <span class="badge-extra text-orange" data-toggle="tooltip" title=""
-                          data-original-title="@lang('user.download-bon')">{{ App\Helpers\StringHelper::formatBytes($bondownload , 2) }}</span> =
+                          data-original-title="@lang('user.download-recorded')">{{ $user->getDownloaded() }}</span> = 
                     <span class="badge-extra text-blue" data-toggle="tooltip" title=""
-                          data-original-title="@lang('user.download-true')">{{ App\Helpers\StringHelper::formatBytes($realdownload , 2) }}</span></td>
+                          data-original-title="@lang('user.download-true')">{{ App\Helpers\StringHelper::formatBytes($realdownload , 2) }}</span> - 
+                    <span class="badge-extra text-orange" data-toggle="tooltip" title=""
+                          data-original-title="@lang('user.download-bon')">{{ App\Helpers\StringHelper::formatBytes($bondownload , 2) }}</span></td>
             </tr>
             <tr>
                 <td>@lang('common.upload')</td>
                 <td>
                     <span class="badge-extra text-green" data-toggle="tooltip" title=""
-                          data-original-title="@lang('user.upload-recorded')">{{ $user->getUploaded() }}</span> -
-                    <span class="badge-extra text-orange" data-toggle="tooltip" title=""
-                          data-original-title="@lang('user.upload-bon')">{{ App\Helpers\StringHelper::formatBytes($bonupload , 2) }}</span> =
+                          data-original-title="@lang('user.upload-recorded')">{{ $user->getUploaded() }}</span> = 
                     <span class="badge-extra text-blue" data-toggle="tooltip" title=""
-                          data-original-title="@lang('user.upload-true')">{{ App\Helpers\StringHelper::formatBytes($realupload , 2) }}</span></td>
+                          data-original-title="@lang('user.upload-true')">{{ App\Helpers\StringHelper::formatBytes($realupload , 2) }}</span> + 
+                    <span class="badge-extra text-orange" data-toggle="tooltip" title=""
+                          data-original-title="@lang('user.upload-bon')">{{ App\Helpers\StringHelper::formatBytes($bonupload , 2) }}</span></td>
             </tr>
             <tr>
                 <td>@lang('common.ratio')</td>


### PR DESCRIPTION
Rearrange profile upload and download figures to avoid confusion.
Now shows as [recorded figure] = [actual figure] +/- [BON store purchases]

This way, people can see their BON Store purchases of upload being _added_ and not subtracted. Yes, it's only cosmetic, but people **do** keep asking why their purchase gets subtracted. It doesn't, but removing the confusion reduces the need for explanation.