### PR TITLE
(Add) Send notifications instead of chat announce for posts at staff area

### DIFF
--- a/app/Http/Controllers/TopicController.php
+++ b/app/Http/Controllers/TopicController.php
@@ -203,15 +203,17 @@ class TopicController extends Controller
             $forum->last_post_user_username = $user->username;
             $forum->save();
 
-            $forum->notifySubscribers($user, $topic);
-
             // Post To ShoutBox
             $appurl = config('app.url');
             $topicUrl = sprintf('%s/forums/topics/%s', $appurl, $topic->id);
             $profileUrl = sprintf('%s/users/%s', $appurl, $user->username);
 
-            $this->chat->systemMessage(sprintf('[url=%s]%s[/url] has created a new topic [url=%s]%s[/url]', $profileUrl, $user->username, $topicUrl, $topic->name));
-
+            if (config('other.staff-forum-notify') && ($forum->id == config('other.staff-forum-id') || $forum->parent_id == config('other.staff-forum-id'))) {
+                $forum->notifyStaffers($user, $topic);
+            } else {
+                $this->chat->systemMessage(sprintf('[url=%s]%s[/url] has created a new topic [url=%s]%s[/url]', $profileUrl, $user->username, $topicUrl, $topic->name));
+                $forum->notifySubscribers($user, $topic);
+            }
             //Achievements
             $user->unlock(new UserMadeFirstPost(), 1);
             $user->addProgress(new UserMade25Posts(), 1);

--- a/app/Models/Forum.php
+++ b/app/Models/Forum.php
@@ -172,6 +172,27 @@ class Forum extends Model
     }
 
     /**
+     * Notify Staffers When New Staff Topic Is Made.
+     *
+     * @param $poster
+     * @param $topic
+     *
+     * @return string
+     */
+    public function notifyStaffers($poster, $topic)
+    {
+        $staffers = User::leftJoin('groups', 'users.group_id', '=', 'groups.id')
+            ->select('users.id')
+            ->where('users.id', '<>', $poster->id)
+            ->where('groups.is_modo', 1)
+            ->get();
+
+        foreach ($staffers as $staffer) {
+            $staffer->notify(new NewTopic('staff', $poster, $topic));
+        }
+    }
+
+    /**
      * Returns A Table With The Forums In The Category.
      *
      * @return string

--- a/app/Models/Topic.php
+++ b/app/Models/Topic.php
@@ -147,6 +147,28 @@ class Topic extends Model
     }
 
     /**
+     * Notify Staffers When New Staff Post Is Made.
+     *
+     * @param $poster
+     * @param $topic
+     * @param $post
+     *
+     * @return string
+     */
+    public function notifyStaffers($poster, $topic, $post)
+    {
+        $staffers = User::leftJoin('groups', 'users.group_id', '=', 'groups.id')
+            ->select('users.id')
+            ->where('users.id', '<>', $poster->id)
+            ->where('groups.is_modo', 1)
+            ->get();
+
+        foreach ($staffers as $staffer) {
+            $staffer->notify(new NewPost('staff', $poster, $post));
+        }
+    }
+
+    /**
      * Does User Have Permission To View Topic.
      *
      * @return string

--- a/app/Notifications/NewPost.php
+++ b/app/Notifications/NewPost.php
@@ -74,6 +74,14 @@ class NewPost extends Notification implements ShouldQueue
             ];
         }
 
+        if ($this->type == 'staff') {
+            return [
+                'title' => $this->poster->username.' Has Posted In A Staff Forum Topic',
+                'body'  => $this->poster->username.' has left a new post in Staff Topic '.$this->post->topic->name,
+                'url'   => sprintf('%s?page=%s#post-%s', route('forum_topic', ['id' => $this->post->topic->id]), $this->post->getPageNumber(), $this->post->id),
+            ];
+        }
+
         return [
             'title' => $this->poster->username.' Has Posted In A Topic You Started',
             'body'  => $this->poster->username.' has left a new post in Your Topic '.$this->post->topic->name,

--- a/app/Notifications/NewTopic.php
+++ b/app/Notifications/NewTopic.php
@@ -66,6 +66,14 @@ class NewTopic extends Notification implements ShouldQueue
     {
         $appurl = config('app.url');
 
+        if ($this->type == 'staff') {
+            return [
+                'title' => $this->poster->username.' Has Posted In A Staff Forum',
+                'body'  => $this->poster->username.' has started a new staff topic in '.$this->topic->forum->name,
+                'url'   => sprintf('%s', route('forum_topic', ['id' => $this->topic->id])),
+            ];
+        }
+
         return [
             'title' => $this->poster->username.' Has Posted In A Subscribed Forum',
             'body'  => $this->poster->username.' has started a new topic in '.$this->topic->forum->name,

--- a/config/other.php
+++ b/config/other.php
@@ -200,4 +200,24 @@ return [
     | Example: 4
     */
     'upload-guide_url' => 'https://'.parse_url(env('APP_URL'), PHP_URL_HOST).'/pages/4',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Hide Staff Area Forum Posts From Chat
+    |--------------------------------------------------------------------------
+    | 1 = Enabled
+    | 0 = Disabled
+    | If enabled, Staff members get notifications instead of posting being announced in chat.
+    */
+    'staff-forum-notify' => '0',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Staff Forum Id
+    |--------------------------------------------------------------------------
+    | Example: 2
+    | The ID value of staff forum area. Should be the main / parent ID.
+    */
+    'staff-forum-id' => '',
+
 ];


### PR DESCRIPTION
Select whether to send notifications to staff members instead of announcing posts in chatbox for a given forum area, determined by ID. In future could/should be improved by having a no_announce flag for forum areas for example.