### PR TITLE
(Refactor) Change Read Only Property With Default Value To Constant

### DIFF
--- a/app/Helpers/MediaInfo.php
+++ b/app/Helpers/MediaInfo.php
@@ -15,7 +15,7 @@ namespace App\Helpers;
 
 class MediaInfo
 {
-    private $regex_section = "/^(?:(?:general|video|audio|text|menu)(?:\s\#\d+?)*)$/i";
+    private const REGEX_SECTION = "/^(?:(?:general|video|audio|text|menu)(?:\s\#\d+?)*)$/i";
 
     public function parse($string)
     {
@@ -25,7 +25,7 @@ class MediaInfo
         $output = [];
         foreach ($lines as $line) {
             $line = trim($line); // removed strtolower, unnecessary with the i-switch in the regexp (caseless) and adds problems with values; added it in the required places instead.
-            if (preg_match($this->regex_section, $line)) {
+            if (preg_match(self::REGEX_SECTION, $line)) {
                 $section = $line;
                 $output[$section] = [];
             }

--- a/app/Services/Clients/TmdbClient.php
+++ b/app/Services/Clients/TmdbClient.php
@@ -24,11 +24,11 @@ class TmdbClient extends Client implements MovieTvInterface
 
     protected $apiSecure = true;
 
-    private $imagePath = 'https://image.tmdb.org/t/p/w780';
+    private const IMAGE_PATH = 'https://image.tmdb.org/t/p/w780';
 
-    private $imageBackdropPath = 'https://image.tmdb.org/t/p/w1280';
+    private const IMAGE_BACKDROP_PATH = 'https://image.tmdb.org/t/p/w1280';
 
-    private $imageProfilePath = 'https://image.tmdb.org/t/p/h632';
+    private const IMAGE_PROFILE_PATH = 'https://image.tmdb.org/t/p/h632';
 
     public function __construct($apiKey)
     {
@@ -137,16 +137,16 @@ class TmdbClient extends Client implements MovieTvInterface
                 'directors'    => $this->formatCasts($movie['credits'], 'directors'),
                 'writers'      => $this->formatCasts($movie['credits'], 'writers'),
                 'producers'    => $this->formatCasts($movie['credits'], 'producers'),
-                'poster'       => !empty($movie['poster_path']) ? $this->imagePath.$movie['poster_path'] : 'https://via.placeholder.com/600x900',
+                'poster'       => !empty($movie['poster_path']) ? self::IMAGE_PATH.$movie['poster_path'] : 'https://via.placeholder.com/600x900',
                 'posters'      => !empty($movie['images']['posters']) ? $this->formatImages(
                     $movie['images']['posters'],
-                    $this->imagePath,
+                    self::IMAGE_PATH,
                     $movie['poster_path']
                 ) : 'https://via.placeholder.com/600x900',
-                'backdrop'  => !empty($movie['backdrop_path']) ? $this->imageBackdropPath.$movie['backdrop_path'] : 'https://via.placeholder.com/1400x800',
+                'backdrop'  => !empty($movie['backdrop_path']) ? self::IMAGE_BACKDROP_PATH.$movie['backdrop_path'] : 'https://via.placeholder.com/1400x800',
                 'backdrops' => !empty($movie['images']['backdrops']) ? $this->formatImages(
                     $movie['images']['backdrops'],
-                    $this->imageBackdropPath,
+                    self::IMAGE_BACKDROP_PATH,
                     $movie['backdrop_path']
                 ) : 'https://via.placeholder.com/1400x800',
                 'tmdbRating'      => $movie['vote_average'],
@@ -178,16 +178,16 @@ class TmdbClient extends Client implements MovieTvInterface
                 'languages'    => $this->formatLanguages($movie['languages'], 'tv'),
                 'genres'       => $this->formatGenres($movie['genres']),
                 'videoTrailer' => $this->formatVideoTrailers($movie),
-                'poster'       => !empty($movie['poster_path']) ? $this->imagePath.$movie['poster_path'] : 'https://via.placeholder.com/600x900',
+                'poster'       => !empty($movie['poster_path']) ? self::IMAGE_PATH.$movie['poster_path'] : 'https://via.placeholder.com/600x900',
                 'posters'      => !empty($movie['images']['posters']) ? $this->formatImages(
                     $movie['images']['posters'],
-                    $this->imagePath,
+                    self::IMAGE_PATH,
                     $movie['poster_path']
                 ) : 'https://via.placeholder.com/600x900',
-                'backdrop'  => !empty($movie['backdrop_path']) ? $this->imageBackdropPath.$movie['backdrop_path'] : 'https://via.placeholder.com/1400x800',
+                'backdrop'  => !empty($movie['backdrop_path']) ? self::IMAGE_BACKDROP_PATH.$movie['backdrop_path'] : 'https://via.placeholder.com/1400x800',
                 'backdrops' => !empty($movie['images']['backdrops']) ? $this->formatImages(
                     $movie['images']['backdrops'],
-                    $this->imageBackdropPath,
+                    self::IMAGE_BACKDROP_PATH,
                     $movie['backdrop_path']
                 ) : 'https://via.placeholder.com/1400x800',
                 'tmdbRating'      => $movie['vote_average'],
@@ -214,10 +214,10 @@ class TmdbClient extends Client implements MovieTvInterface
             'deathday'     => $person['deathday'] ?? null,
             'placeOfBirth' => $person['place_of_birth'] ?? null,
             'biography'    => $person['biography'] ?? null,
-            'photo'        => !empty($person['profile_path']) ? $this->imageProfilePath.$person['profile_path'] : 'https://via.placeholder.com/100x100',
+            'photo'        => !empty($person['profile_path']) ? self::IMAGE_PROFILE_PATH.$person['profile_path'] : 'https://via.placeholder.com/100x100',
             'photos'       => !empty($person['images']['profiles']) ? $this->formatImages(
                 $person['images']['profiles'],
-                $this->imageProfilePath,
+                self::IMAGE_PROFILE_PATH,
                 $person['profile_path']
             ) : null,
             'moviecredits' => $person['movie_credits'],


### PR DESCRIPTION
### `Change Read Only Property With Default Value To Constant`

- Changes properties with read only status and a default value to a constant

```diff
 class SomeClass
 {
     /**
      * @var string[]
      */
-    private $magicMethods = [
+    private const MAGIC_METHODS = [
         '__toString',
         '__wakeup',
     ];

     public function run()
     {
-        foreach ($this->magicMethods as $magicMethod) {
+        foreach (self::MAGIC_METHODS as $magicMethod) {
             echo $magicMethod;
         }
     }
 }
```