### PR TITLE
(Fix) internal in API

### DIFF
--- a/app/Http/Controllers/API/TorrentController.php
+++ b/app/Http/Controllers/API/TorrentController.php
@@ -122,7 +122,11 @@ class TorrentController extends BaseController
         $torrent->anon = $request->input('anonymous');
         $torrent->stream = $request->input('stream');
         $torrent->sd = $request->input('sd');
-        $torrent->internal = $request->input('internal');
+        if ($user->group->is_internal) {
+            $torrent->internal = $request->input('internal');
+        } else {
+            $torrent->internal = 0;
+        }
         $torrent->moderated_at = Carbon::now();
         $torrent->moderated_by = User::where('username', 'System')->first()->id; //System ID
 
@@ -147,6 +151,7 @@ class TorrentController extends BaseController
             'anon'        => 'required',
             'stream'      => 'required',
             'sd'          => 'required',
+            'internal'    => 'required',
         ]);
 
         if ($v->fails()) {


### PR DESCRIPTION
Add internal to validation, since it's required. If it's missing, SQL error is caused. Additionally if user is not internal they probably shouldn't be able to make internal uploads just like when doing it on the site.