### PR TITLE
(Fix) Hide similar torrents button if category is no_meta

### DIFF
--- a/resources/views/torrent/torrent.blade.php
+++ b/resources/views/torrent/torrent.blade.php
@@ -61,7 +61,7 @@
                             </a>
                         @endif
 
-                        @if ($torrent->tmdb != 0)
+                        @if ($torrent->tmdb != 0 && $torrent->category->no_meta == 0)
                             <a href="{{ route('torrents.similar', ['category_id' => $torrent->category_id, 'tmdb' => $torrent->tmdb]) }}" role="button" class="btn btn-labeled btn-primary">
                                 <span class='btn-label'>
                                     <i class='{{ config("other.font-awesome") }} fa-file'></i> @lang('torrent.similar')


### PR DESCRIPTION
If torrent has tmdb set and category is no_meta, similar torrents button is shown but causes an error.