### PR TITLE
(Enhancement) Only softdelete unused accounts when pruning

### DIFF
--- a/app/Console/Commands/AutoSoftDeleteDisabledUsers.php
+++ b/app/Console/Commands/AutoSoftDeleteDisabledUsers.php
@@ -70,7 +70,12 @@ class AutoSoftDeleteDisabledUsers extends Command
                 $user->group_id = $pruned_group[0];
                 $user->deleted_by = 1;
                 $user->save();
-                $user->delete();
+                if ($user->posts()->count() === 0 && $user->topics()->count() === 0 &&
+                $user->history()->count() === 0 && $user->requests()->count() === 0 &&
+                $user->sentInvite()->count() === 0 && $user->comments()->count() === 0 &&
+                $user->notes()->count() === 0) {
+                    $user->delete();
+                }
             }
         }
         $this->comment('Automated Soft Delete Disabled Users Command Complete');

--- a/app/Http/Controllers/AnnounceController.php
+++ b/app/Http/Controllers/AnnounceController.php
@@ -145,6 +145,9 @@ class AnnounceController extends Controller
         $disabled_group = cache()->rememberForever('disabled_group', function () {
             return Group::where('slug', '=', 'disabled')->pluck('id');
         });
+        $pruned_group = cache()->rememberForever('pruned_group', function () {
+            return Group::where('slug', '=', 'pruned')->pluck('id');
+        });
 
         // If User Is Banned Return Error to Client
         if ($user->group_id == $banned_group[0]) {
@@ -156,6 +159,10 @@ class AnnounceController extends Controller
         if ($user->group_id == $disabled_group[0]) {
             //info('A Disabled User (' . $user->username . ') Attempted To Announce');
             return response(Bencode::bencode(['failure reason' => 'Your account is disabled. Please login.']))->withHeaders(['Content-Type' => 'text/plain']);
+        }
+        // If User Is Pruned Return Error to Client
+        if ($user->group_id == $pruned_group[0]) {
+            return response(Bencode::bencode(['failure reason' => 'Your account has been pruned.']))->withHeaders(['Content-Type' => 'text/plain']);
         }
 
         // If User Account Is Unactivated Return Error to Client

--- a/app/Http/Controllers/Auth/ActivationController.php
+++ b/app/Http/Controllers/Auth/ActivationController.php
@@ -24,12 +24,16 @@ class ActivationController extends Controller
         $banned_group = cache()->rememberForever('banned_group', function () {
             return Group::where('slug', '=', 'banned')->pluck('id');
         });
+        $pruned_group = cache()->rememberForever('pruned_group', function () {
+            return Group::where('slug', '=', 'pruned')->pluck('id');
+        });
         $member_group = cache()->rememberForever('member_group', function () {
             return Group::where('slug', '=', 'user')->pluck('id');
         });
 
         $activation = UserActivation::with('user')->where('token', '=', $token)->firstOrFail();
-        if ($activation->user->id && $activation->user->group->id != $banned_group[0]) {
+        if ($activation->user->id && $activation->user->group->id != $banned_group[0] &&
+        $activation->user->group->id != $pruned_group[0]) {
             $activation->user->active = 1;
             $activation->user->can_upload = 1;
             $activation->user->can_download = 1;

--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -78,6 +78,9 @@ class LoginController extends Controller
         $disabled_group = cache()->rememberForever('disabled_group', function () {
             return Group::where('slug', '=', 'disabled')->pluck('id');
         });
+        $pruned_group = cache()->rememberForever('pruned_group', function () {
+            return Group::where('slug', '=', 'pruned')->pluck('id');
+        });
         $member_group = cache()->rememberForever('member_group', function () {
             return Group::where('slug', '=', 'user')->pluck('id');
         });
@@ -96,6 +99,14 @@ class LoginController extends Controller
 
             return redirect()->route('login')
                 ->withErrors(trans('auth.banned'));
+        }
+
+        if ($user->group_id == $pruned_group[0]) {
+            $this->guard()->logout();
+            $request->session()->invalidate();
+
+            return redirect()->route('login')
+                ->withErrors(trans('auth.pruned'));
         }
 
         if ($user->group_id == $disabled_group[0]) {

--- a/app/Http/Controllers/RssController.php
+++ b/app/Http/Controllers/RssController.php
@@ -155,11 +155,17 @@ class RssController extends Controller
         $disabled_group = cache()->rememberForever('disabled_group', function () {
             return Group::where('slug', '=', 'disabled')->pluck('id');
         });
+        $pruned_group = cache()->rememberForever('pruned_group', function () {
+            return Group::where('slug', '=', 'pruned')->pluck('id');
+        });
 
         if ($user->group->id == $banned_group[0]) {
             abort(404);
         }
         if ($user->group->id == $disabled_group[0]) {
+            abort(404);
+        }
+        if ($user->group->id == $pruned_group[0]) {
             abort(404);
         }
         if ($user->active == 0) {

--- a/app/Http/Controllers/StatsController.php
+++ b/app/Http/Controllers/StatsController.php
@@ -81,7 +81,7 @@ class StatsController extends Controller
                 return Group::where('slug', '=', 'pruned')->pluck('id');
             });
 
-            return User::onlyTrashed()->where('group_id', '=', $pruned_group[0])->count();
+            return User::withTrashed()->where('group_id', '=', $pruned_group[0])->count();
         });
 
         // Total Banned Members Count

--- a/app/Http/Middleware/CheckIfBanned.php
+++ b/app/Http/Middleware/CheckIfBanned.php
@@ -35,6 +35,9 @@ class CheckIfBanned
         $banned_group = cache()->rememberForever('banned_group', function () {
             return Group::where('slug', '=', 'banned')->pluck('id');
         });
+        $pruned_group = cache()->rememberForever('pruned_group', function () {
+            return Group::where('slug', '=', 'pruned')->pluck('id');
+        });
 
         if ($user && $user->group_id == $banned_group[0]) {
             auth()->logout();
@@ -42,6 +45,14 @@ class CheckIfBanned
 
             return redirect()->route('login')
                 ->withErrors('This account is Banned!');
+        }
+
+        if ($user && $user->group_id == $pruned_group[0]) {
+            auth()->logout();
+            $request->session()->flush();
+
+            return redirect()->route('login')
+                ->withErrors('This account is Pruned!');
         }
 
         return $next($request);

--- a/resources/lang/en/auth.php
+++ b/resources/lang/en/auth.php
@@ -51,6 +51,7 @@ return [
     'proof-profile'       => 'Profile Link URL',
     'proof-profile-title' => 'Links to your profiles',
     'proof-min'           => '(Minimum 2, Recommended 3)',
+    'pruned'              => 'This account has been pruned due to inactivity.',
     'recover-my-password' => 'Recover My Password',
     'register-thanks'     => 'Thanks for signing up! Please check your email to Validate your account',
     'remember-me'         => 'Remember Me',


### PR DESCRIPTION
Check if user has contributed in any way, and only delete if not. Makes pruned group essentially same than banned.