### PR TITLE
(Enhancement) New options on torrent upload api

### DIFF
--- a/app/Http/Controllers/API/TorrentController.php
+++ b/app/Http/Controllers/API/TorrentController.php
@@ -75,7 +75,7 @@ class TorrentController extends BaseController
     {
         $user = $request->user();
         $requestFile = $request->file('torrent');
-        if ($request->hasFile('torrent') === false) {
+        if (!$request->hasFile('torrent')) {
             return $this->sendError('Validation Error.', 'You Must Provide A Torrent File For Upload!');
         }
 
@@ -123,31 +123,11 @@ class TorrentController extends BaseController
         $torrent->anon = $request->input('anonymous');
         $torrent->stream = $request->input('stream');
         $torrent->sd = $request->input('sd');
-        if ($user->group->is_modo || $user->group->is_internal) {
-            $torrent->internal = $request->input('internal');
-        } else {
-            $torrent->internal = 0;
-        }
-        if ($user->group->is_modo || $user->group->is_internal) {
-            $torrent->featured = $request->input('featured');
-        } else {
-            $torrent->featured = 0;
-        }
-        if ($user->group->is_modo || $user->group->is_internal) {
-            $torrent->doubleup = $request->input('doubleup');
-        } else {
-            $torrent->doubleup = 0;
-        }
-        if ($user->group->is_modo || $user->group->is_internal) {
-            $torrent->free = $request->input('free');
-        } else {
-            $torrent->free = 0;
-        }
-        if ($user->group->is_modo || $user->group->is_internal) {
-            $torrent->sticky = $request->input('sticky');
-        } else {
-            $torrent->sticky = 0;
-        }
+        $torrent->internal = $user->group->is_modo || $user->group->is_internal ? $request->input('internal') : 0;
+        $torrent->featured = $user->group->is_modo || $user->group->is_internal ? $request->input('featured') : 0;
+        $torrent->doubleup = $user->group->is_modo || $user->group->is_internal ? $request->input('doubleup') : 0;
+        $torrent->free = $user->group->is_modo || $user->group->is_internal ? $request->input('free') : 0;
+        $torrent->sticky = $user->group->is_modo || $user->group->is_internal ? $request->input('sticky') : 0;
         $torrent->moderated_at = Carbon::now();
         $torrent->moderated_by = User::where('username', 'System')->first()->id; //System ID
 

--- a/app/Http/Controllers/API/TorrentController.php
+++ b/app/Http/Controllers/API/TorrentController.php
@@ -189,7 +189,7 @@ class TorrentController extends BaseController
         // Save The Torrent
         $torrent->save();
         // Set torrent to featured
-		if ($torrent->featured == 1) {
+        if ($torrent->featured == 1) {
             $feature = new FeaturedTorrent();
             $feature->user_id = $user->id;
             $feature->torrent_id = $torrent->id;

--- a/app/Http/Controllers/API/TorrentController.php
+++ b/app/Http/Controllers/API/TorrentController.php
@@ -173,10 +173,10 @@ class TorrentController extends BaseController
             'stream'      => 'required',
             'sd'          => 'required',
             'internal'    => 'required',
-			'featured'    => 'required',
-			'free'        => 'required',
-			'doubleup'    => 'required',
-			'sticky'      => 'required',
+            'featured'    => 'required',
+            'free'        => 'required',
+            'doubleup'    => 'required',
+            'sticky'      => 'required',
         ]);
 
         if ($v->fails()) {

--- a/app/Http/Controllers/API/TorrentController.php
+++ b/app/Http/Controllers/API/TorrentController.php
@@ -251,7 +251,7 @@ class TorrentController extends BaseController
                 );
             }
 
-            if ($anon == 0 || $featured == 1) {
+            if ($anon == 0 && $featured == 1) {
                 $this->chat->systemMessage(
                     sprintf('Ladies and Gents, [url=%s/torrents/', $appurl).$torrent->id.']'.$torrent->name.sprintf('[/url] has been added to the Featured Torrents Slider by [url=%s/users/', $appurl).$username.']'.$username.'[/url]! Grab It While You Can! :fire:'
                 );

--- a/tests/Feature/Http/Controllers/API/TorrentControllerTest.php
+++ b/tests/Feature/Http/Controllers/API/TorrentControllerTest.php
@@ -132,6 +132,10 @@ class TorrentControllerTest extends TestCase
             'stream'      => $torrent->stream,
             'sd'          => $torrent->sd,
             'internal'    => $torrent->internal,
+            'featured'    => false,
+            'doubleup'    => $torrent->doubleup,
+            'free'        => $torrent->free,
+            'sticky'      => $torrent->sticky,
         ]);
 
         $response->assertOk()


### PR DESCRIPTION
Adds options to set torrent as Featured, DoubleUp, Freeleech, and Sticky on upload api endpoint.

I've done limited testing on this and I'm worndering if this could be done better.