### PR TITLE
(Add) missingTorrentFiles.CSV

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -2027,9 +2027,9 @@ class UserController extends Controller
                 }
             }
             if ($failCount > 0) {
-                $CSVtmpName = sprintf('%s.zip', $user->username) . '-missingTorrentFiles.CSV';
-                file_put_contents(getcwd() . '/files/tmp/' . $CSVtmpName, $failCSV);
-                $zip->addFile(getcwd() . '/files/tmp/' . $CSVtmpName, 'missingTorrentFiles.CSV');
+                $CSVtmpName = sprintf('%s.zip', $user->username).'-missingTorrentFiles.CSV';
+                file_put_contents(getcwd().'/files/tmp/'.$CSVtmpName, $failCSV);
+                $zip->addFile(getcwd().'/files/tmp/'.$CSVtmpName, 'missingTorrentFiles.CSV');
             }
             // Close ZipArchive
             $zip->close();

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -1994,6 +1994,7 @@ class UserController extends Controller
         if ($zip->open($path.'/'.$zipFileName, ZipArchive::CREATE) === true) {
             // Match History Results To Torrents
             $failCSV = "\"Name\",\"URL\",\"ID\",\"info_hash\"\r\n";
+            $failCount = 0;
             foreach ($historyTorrents as $historyTorrent) {
                 // Get Torrent
                 $torrent = Torrent::withAnyStatus()->where('info_hash', '=', $historyTorrent)->first();
@@ -2004,6 +2005,7 @@ class UserController extends Controller
                 // The Torrent File Exist?
                 if (!file_exists(getcwd().'/files/torrents/'.$torrent->file_name)) {
                     $failCSV .= '"'.$torrent->name.'","'.route('torrent', ['id' => $torrent->id]).'","'.$torrent->id.'","'.$historyTorrent."\"\r\n";
+                    $failCount++;
                 } else {
                     // Delete The Last Torrent Tmp File If Exist
                     if (file_exists(getcwd().'/files/tmp/'.$tmpFileName)) {
@@ -2024,9 +2026,11 @@ class UserController extends Controller
                     $zip->addFile(getcwd().'/files/tmp/'.$tmpFileName, $tmpFileName);
                 }
             }
-            $CSVtmpName = sprintf('%s.zip', $user->username).'-missingTorrentFiles.CSV';
-            file_put_contents(getcwd().'/files/tmp/'.$CSVtmpName, $failCSV);
-            $zip->addFile(getcwd().'/files/tmp/'.$CSVtmpName, 'missingTorrentFiles.CSV');
+            if ($failCount > 0) {
+                $CSVtmpName = sprintf('%s.zip', $user->username) . '-missingTorrentFiles.CSV';
+                file_put_contents(getcwd() . '/files/tmp/' . $CSVtmpName, $failCSV);
+                $zip->addFile(getcwd() . '/files/tmp/' . $CSVtmpName, 'missingTorrentFiles.CSV');
+            }
             // Close ZipArchive
             $zip->close();
         }

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -2003,25 +2003,25 @@ class UserController extends Controller
 
                 // The Torrent File Exist?
                 if (!file_exists(getcwd().'/files/torrents/'.$torrent->file_name)) {
-                    $failCSV .= "\"".$torrent->name . "\",\"". route('torrent', ['id' => $torrent->id]) . "\",\"" . $torrent->id . "\",\"" . $historyTorrent ."\"\r\n" ;
+                    $failCSV .= '"'.$torrent->name.'","'.route('torrent', ['id' => $torrent->id]).'","'.$torrent->id.'","'.$historyTorrent."\"\r\n";
                 } else {
                     // Delete The Last Torrent Tmp File If Exist
-                    if (file_exists(getcwd() . '/files/tmp/' . $tmpFileName)) {
-                        unlink(getcwd() . '/files/tmp/' . $tmpFileName);
+                    if (file_exists(getcwd().'/files/tmp/'.$tmpFileName)) {
+                        unlink(getcwd().'/files/tmp/'.$tmpFileName);
                     }
 
                     // Get The Content Of The Torrent
-                    $dict = Bencode::bdecode(file_get_contents(getcwd() . '/files/torrents/' . $torrent->file_name));
+                    $dict = Bencode::bdecode(file_get_contents(getcwd().'/files/torrents/'.$torrent->file_name));
                     // Set the announce key and add the user passkey
                     $dict['announce'] = route('announce', ['passkey' => $user->passkey]);
                     // Remove Other announce url
                     unset($dict['announce-list']);
 
                     $fileToDownload = Bencode::bencode($dict);
-                    file_put_contents(getcwd() . '/files/tmp/' . $tmpFileName, $fileToDownload);
+                    file_put_contents(getcwd().'/files/tmp/'.$tmpFileName, $fileToDownload);
 
                     // Add Files To ZipArchive
-                    $zip->addFile(getcwd() . '/files/tmp/' . $tmpFileName, $tmpFileName);
+                    $zip->addFile(getcwd().'/files/tmp/'.$tmpFileName, $tmpFileName);
                 }
             }
             $CSVtmpName = sprintf('%s.zip', $user->username).'-missingTorrentFiles.CSV';

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,8 @@
         "spatie/ssl-certificate": "^1.12",
         "symfony/dom-crawler": "^2.7|^3.0",
         "theodorejb/polycast": "^1.0",
-        "voku/anti-xss": "^4.1"
+        "voku/anti-xss": "^4.1",
+        "ext-zip": "*"
     },
     "require-dev": {
         "facade/ignition": "^1.4",


### PR DESCRIPTION
**Route:** `/users/{user}/downloadHistoryTorrents`

When _**Downloading All**_ torrents from `/users/{user}/torrents`, if a torrent file is missing, instead of issuing an error and preventing the download, it will output into a CSV called `missingTorrentFiles.csv` into the Zip File along with the successfully located torrent files. 

This also fixes the issue where users wouldn't be able to download All Torrents if One or More files are missing. 