### PR TITLE
(Update) Test Email command

### DIFF
--- a/app/Console/Commands/TestMailSettings.php
+++ b/app/Console/Commands/TestMailSettings.php
@@ -14,7 +14,6 @@
 namespace App\Console\Commands;
 
 use App\Mail\TestEmail;
-use App\Models\User;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Mail;
 

--- a/app/Console/Commands/TestMailSettings.php
+++ b/app/Console/Commands/TestMailSettings.php
@@ -41,7 +41,7 @@ class TestMailSettings extends Command
      */
     public function handle()
     {
-        $owner = User::where('id', '=', 3)->pluck('email');
+        $owner = env('DEFAULT_OWNER_EMAIL');
 
         $this->info('Sending Test Email To '.$owner);
         sleep(5);

--- a/app/Console/Commands/TestMailSettings.php
+++ b/app/Console/Commands/TestMailSettings.php
@@ -40,7 +40,7 @@ class TestMailSettings extends Command
      */
     public function handle()
     {
-        $owner = env('DEFAULT_OWNER_EMAIL');
+        $owner = config('other.email');
 
         $this->info('Sending Test Email To '.$owner);
         sleep(5);


### PR DESCRIPTION
Changed Test Email command to use owner email set in env instead of using mysql query to pluck email using hardcoded default owner user ID.

This is needed incase a tracker decides to change owners. They can easily change the owner info in env file and test emails will just work.