### PR TITLE
Update downloads.blade.php

### DIFF
--- a/resources/views/user/filters/downloads.blade.php
+++ b/resources/views/user/filters/downloads.blade.php
@@ -51,9 +51,9 @@
                         @endif
                         <td>
                             @if ($download->seeder == 1)
-                                <span class='label label-success'>{{ strtoupper(trans('torrent.seeder')) }}</span>
+                                <span class='label label-success'>{{ strtoupper(trans('torrent.downloaded')) }}</span>
                             @else
-                                <span class='label label-danger'>{{ strtoupper(trans('torrent.not-seeding')) }}</span>
+                                <span class='label label-danger'>{{ strtoupper(trans('torrent.not-downloaded')) }}</span>
                             @endif
                         </td>
                 </tr>

--- a/resources/views/user/filters/unsatisfieds.blade.php
+++ b/resources/views/user/filters/unsatisfieds.blade.php
@@ -62,9 +62,9 @@
                             @endif
                             <td>
                                 @if ($download->seeder == 1)
-                                    <span class='label label-success'>{{ strtoupper(trans('torrent.seeder')) }}</span>
+                                    <span class='label label-success'>{{ strtoupper(trans('torrent.downloaded')) }}</span>
                                 @else
-                                    <span class='label label-danger'>{{ strtoupper(trans('torrent.not-seeding')) }}</span>
+                                    <span class='label label-danger'>{{ strtoupper(trans('torrent.not-downloaded')) }}</span>
                                 @endif
                             </td>
                 </tr>

--- a/resources/views/user/private/downloads.blade.php
+++ b/resources/views/user/private/downloads.blade.php
@@ -171,10 +171,10 @@
                                         @endif
                                         <td>
                                             @if ($download->seeder == 1)
-                                                <span class='label label-success'>{{ strtoupper(trans('torrent.seeder')) }}</span>
+                                                <span class='label label-success'>{{ strtoupper(trans('torrent.downloaded')) }}</span>
                                             @else
                                                 <span
-                                                    class='label label-danger'>{{ strtoupper(trans('torrent.not-seeding')) }}</span>
+                                                    class='label label-danger'>{{ strtoupper(trans('torrent.not-downloaded')) }}</span>
                                             @endif
                                         </td>
                                 </tr>

--- a/resources/views/user/private/unsatisfieds.blade.php
+++ b/resources/views/user/private/unsatisfieds.blade.php
@@ -182,10 +182,10 @@
                                             <td>
                                                 @if ($download->seeder == 1)
                                                     <span
-                                                        class='label label-success'>{{ strtoupper(trans('torrent.seeder')) }}</span>
+                                                        class='label label-success'>{{ strtoupper(trans('torrent.downloaded')) }}</span>
                                                 @else
                                                     <span
-                                                        class='label label-danger'>{{ strtoupper(trans('torrent.not-seeding')) }}</span>
+                                                        class='label label-danger'>{{ strtoupper(trans('torrent.not-downloaded')) }}</span>
                                                 @endif
                                             </td>
                                 </tr>


### PR DESCRIPTION
Open to review:
The 'seeder' field is populated by $history->seeder = ($left == 0) ? true : false;
so "(Not) Downloaded" would be a more suitable and meaningful label than "Seeder/Not Seeding"