### PR TITLE
Update AutoHighspeedTag.php

### DIFF
--- a/app/Console/Commands/AutoHighspeedTag.php
+++ b/app/Console/Commands/AutoHighspeedTag.php
@@ -51,9 +51,11 @@ class AutoHighspeedTag extends Command
 
             foreach ($torid as $id) {
                 $torrent = Torrent::where('id', '=', $id)->first();
-                $torrent->highspeed = 1;
-                $torrent->save();
-
+                if (isset($torrent)) { 
+                    $torrent->highspeed = 1;
+                    $torrent->save();
+                }
+                
                 unset($torrent);
             }
         }

--- a/app/Console/Commands/AutoHighspeedTag.php
+++ b/app/Console/Commands/AutoHighspeedTag.php
@@ -51,11 +51,11 @@ class AutoHighspeedTag extends Command
 
             foreach ($torid as $id) {
                 $torrent = Torrent::where('id', '=', $id)->first();
-                if (isset($torrent)) { 
+                if (isset($torrent)) {
                     $torrent->highspeed = 1;
                     $torrent->save();
                 }
-                
+
                 unset($torrent);
             }
         }


### PR DESCRIPTION
Is this a suitable fix for the error:

Creating default object from empty value {"exception":"[object] (ErrorException(code: 0): Creating default object from empty value at /var/www/html/app/Console/Commands/AutoHighspeedTag.php:54)