### PR TITLE
(Update) Announce Controller

### DIFF
--- a/app/Http/Controllers/AnnounceController.php
+++ b/app/Http/Controllers/AnnounceController.php
@@ -231,7 +231,7 @@ class AnnounceController extends Controller
         }
 
         // Get Torrents Peers
-        $peers = Peer::where('torrent_id', '=', $torrent->id)->take(50)->get()->toArray();
+        $peers = Peer::where('torrent_id', '=', $torrent->id)->where('user_id', '!=', $user->id)->take(50)->get()->toArray();
 
         // Pull Count On Users Peers Per Torrent For Rate Limiting
         $connections = Peer::where('torrent_id', '=', $torrent->id)->where('user_id', '=', $user->id)->count();


### PR DESCRIPTION
This stops announce from sending peers to the user's client that is from the same user.

This does not stop a user from manually adding their other peer to the client to seed to themselves.

With that being said if a user is found to be seeding to themselves that means they are actively trying to break the rules and should be banned.