### PR TITLE
(Refactor) Count and Sum Queries

### DIFF
--- a/app/Http/Controllers/RequestController.php
+++ b/app/Http/Controllers/RequestController.php
@@ -35,6 +35,7 @@ use App\Repositories\ChatRepository;
 use App\Repositories\RequestFacetedRepository;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use MarcReichel\IGDBLaravel\Models\Game;
 
@@ -63,7 +64,7 @@ class RequestController extends Controller
     }
 
     /**
-     * Displays Torrent List View.
+     * Displays Requests List View.
      *
      * @param \Illuminate\Http\Request $request
      *
@@ -72,9 +73,11 @@ class RequestController extends Controller
     public function requests(Request $request)
     {
         $user = $request->user();
-        $num_req = TorrentRequest::count();
-        $num_fil = TorrentRequest::whereNotNull('filled_by')->count();
-        $num_unfil = TorrentRequest::whereNull('filled_by')->count();
+        $requests = DB::table('requests')
+            ->selectRaw('count(*) as total')
+            ->selectRaw("count(case when filled_by != null then 1 end) as filled")
+            ->selectRaw("count(case when filled_by = null then 1 end) as unfilled")
+            ->first();
         $total_bounty = TorrentRequest::all()->sum('bounty');
         $claimed_bounty = TorrentRequest::whereNotNull('filled_by')->sum('bounty');
         $unclaimed_bounty = TorrentRequest::whereNull('filled_by')->sum('bounty');
@@ -86,9 +89,7 @@ class RequestController extends Controller
             'torrentRequests'  => $torrentRequests,
             'repository'       => $repository,
             'user'             => $user,
-            'num_req'          => $num_req,
-            'num_fil'          => $num_fil,
-            'num_unfil'        => $num_unfil,
+            'requests'         => $requests,
             'total_bounty'     => $total_bounty,
             'claimed_bounty'   => $claimed_bounty,
             'unclaimed_bounty' => $unclaimed_bounty,

--- a/app/Http/Controllers/Staff/HomeController.php
+++ b/app/Http/Controllers/Staff/HomeController.php
@@ -45,26 +45,26 @@ class HomeController extends Controller
         // Torrent Info
         $torrents = DB::table('torrents')
             ->selectRaw('count(*) as total')
-            ->selectRaw("count(case when status = 0 then 1 end) as pending")
-            ->selectRaw("count(case when status = 2 then 1 end) as rejected")
-            ->selectRaw("count(case when status = 3 then 1 end) as postponed")
+            ->selectRaw('count(case when status = 0 then 1 end) as pending')
+            ->selectRaw('count(case when status = 2 then 1 end) as rejected')
+            ->selectRaw('count(case when status = 3 then 1 end) as postponed')
             ->first();
 
         // Peers Info
         $peers = DB::table('peers')
             ->selectRaw('count(*) as total')
-            ->selectRaw("count(case when seeder = 0 then 1 end) as leechers")
-            ->selectRaw("count(case when seeder = 1 then 1 end) as seeders")
+            ->selectRaw('count(case when seeder = 0 then 1 end) as leechers')
+            ->selectRaw('count(case when seeder = 1 then 1 end) as seeders')
             ->first();
 
         // Reports Info
         $reports = DB::table('reports')
-            ->selectRaw("count(case when solved = 0 then 1 end) as unsolved")
+            ->selectRaw('count(case when solved = 0 then 1 end) as unsolved')
             ->first();
 
         // Pending Applications Count
         $apps = DB::table('applications')
-            ->selectRaw("count(case when status = 0 then 1 end) as pending")
+            ->selectRaw('count(case when status = 0 then 1 end) as pending')
             ->first();
 
         // SSL Info

--- a/resources/views/Staff/dashboard/index.blade.php
+++ b/resources/views/Staff/dashboard/index.blade.php
@@ -88,10 +88,10 @@
                             <div class="col-xs-6 col-sm-4 col-md-4">
                                 <div class="text-center black-item">
                                     <h1 style=" color: #ffffff;">Torrents</h1>
-                                    <span class="badge-user">Total: {{ $num_torrent }}</span>
+                                    <span class="badge-user">Total: {{ $torrents->total }}</span>
                                     <br>
-                                    <span class="badge-user">Pending: {{ $pending }}</span>
-                                    <span class="badge-user">Rejected: {{ $rejected }}</span>
+                                    <span class="badge-user">Pending: {{ $torrents->pending }}</span>
+                                    <span class="badge-user">Rejected: {{ $torrents->rejected }}</span>
                                     <i class="fal fa-magnet black-icon text-green"></i>
                                 </div>
                             </div>
@@ -99,10 +99,10 @@
                             <div class="col-xs-6 col-sm-4 col-md-4">
                                 <div class="text-center black-item">
                                     <h1 style=" color: #ffffff;">Peers</h1>
-                                    <span class="badge-user">Total: {{ $peers }}</span>
+                                    <span class="badge-user">Total: {{ $peers->total }}</span>
                                     <br>
-                                    <span class="badge-user">Seeders: {{ $seeders }}</span>
-                                    <span class="badge-user">Leechers: {{ $leechers }}</span>
+                                    <span class="badge-user">Seeders: {{ $peers->seeders }}</span>
+                                    <span class="badge-user">Leechers: {{ $peers->leechers }}</span>
                                     <i class="fal fa-wifi black-icon text-green"></i>
                                 </div>
                             </div>
@@ -110,10 +110,10 @@
                             <div class="col-xs-6 col-sm-4 col-md-4">
                                 <div class="text-center black-item">
                                     <h1 style=" color: #ffffff;">Users</h1>
-                                    <span class="badge-user">Total: {{ $num_user }}</span>
+                                    <span class="badge-user">Total: {{ $users->total }}</span>
                                     <br>
-                                    <span class="badge-user">Validating: {{ $validating }}</span>
-                                    <span class="badge-user">Banned: {{ $banned }}</span>
+                                    <span class="badge-user">Validating: {{ $users->validating }}</span>
+                                    <span class="badge-user">Banned: {{ $users->banned }}</span>
                                     <i class="fal fa-users black-icon text-green"></i>
                                 </div>
                             </div>

--- a/resources/views/partials/dashboardmenu.blade.php
+++ b/resources/views/partials/dashboardmenu.blade.php
@@ -64,7 +64,7 @@
             <li>
                 <a href="{{ route('staff.applications.index') }}">
                     <i class="{{ config('other.font-awesome') }} fa-list"></i> @lang('staff.applications')
-                    <span class="badge badge-danger"> {{ $app_count }} </span>
+                    <span class="badge badge-danger"> {{ $apps->pending }} </span>
                 </a>
             </li>
             @if (auth()->user()->group->is_admin)
@@ -201,7 +201,7 @@
             <li>
                 <a href="{{ route('staff.reports.index') }}">
                     <i class="{{ config('other.font-awesome') }} fa-file"></i> @lang('staff.reports-log')
-                    <span class="badge badge-danger"> {{ $reports_count }} </span>
+                    <span class="badge badge-danger"> {{ $reports->unsolved }} </span>
                 </a>
             </li>
             <li>

--- a/resources/views/requests/requests.blade.php
+++ b/resources/views/requests/requests.blade.php
@@ -190,9 +190,9 @@
                     <strong>@lang('request.requests'):</strong> {{ $requests->total }} |
                     <strong>@lang('request.filled'):</strong> {{ $requests->filled }} |
                     <strong>@lang('request.unfilled'):</strong> {{ $requests->unfilled }} |
-                    <strong>@lang('request.total-bounty'):</strong> {{ $total_bounty }} @lang('bon.bon') |
-                    <strong>@lang('request.bounty-claimed'):</strong> {{ $claimed_bounty }} @lang('bon.bon') |
-                    <strong>@lang('request.bounty-unclaimed'):</strong> {{ $unclaimed_bounty }} @lang('bon.bon')
+                    <strong>@lang('request.total-bounty'):</strong> {{ $bounties->total }} @lang('bon.bon') |
+                    <strong>@lang('request.bounty-claimed'):</strong> {{ $bounties->claimed }} @lang('bon.bon') |
+                    <strong>@lang('request.bounty-unclaimed'):</strong> {{ $bounties->unclaimed }} @lang('bon.bon')
                 </span>
                 <a href="{{ route('add_request') }}" role="button" data-toggle="tooltip"
                     data-original-title="@lang('request.add-request')!" class="btn btn btn-success">

--- a/resources/views/requests/requests.blade.php
+++ b/resources/views/requests/requests.blade.php
@@ -187,9 +187,9 @@
         <div class="container-fluid">
             <div class="block">
                 <span class="badge-user" style="float: right;">
-                    <strong>@lang('request.requests'):</strong> {{ $num_req }} |
-                    <strong>@lang('request.filled'):</strong> {{ $num_fil }} |
-                    <strong>@lang('request.unfilled'):</strong> {{ $num_unfil }} |
+                    <strong>@lang('request.requests'):</strong> {{ $requests->total }} |
+                    <strong>@lang('request.filled'):</strong> {{ $requests->filled }} |
+                    <strong>@lang('request.unfilled'):</strong> {{ $requests->unfilled }} |
                     <strong>@lang('request.total-bounty'):</strong> {{ $total_bounty }} @lang('bon.bon') |
                     <strong>@lang('request.bounty-claimed'):</strong> {{ $claimed_bounty }} @lang('bon.bon') |
                     <strong>@lang('request.bounty-unclaimed'):</strong> {{ $unclaimed_bounty }} @lang('bon.bon')


### PR DESCRIPTION
Ideally we'd like to calculate these values using a single database query. What we were doing was not the case. The trick is to put conditions within aggregate functions. Here's an example in Query Builder that we are performing in this PR to combine multiple count or sum queries into one for better performance!

### `Calculating Totals Using Conditional Aggregates`

Combine multiple count queries into one

```diff
- $total = Subscriber::count();
- $confirmed = Subscriber::where('status', 'confirmed')->count();
- $unconfirmed = Subscriber::where('status', 'unconfirmed')->count();
- $cancelled = Subscriber::where('status', 'cancelled')->count();
- $bounced = Subscriber::where('status', 'bounced')->count();

+ $totals = DB::table('subscribers')
+   ->selectRaw('count(*) as total')
+    ->selectRaw("count(case when status = 'confirmed' then 1 end) as confirmed")
+   ->selectRaw("count(case when status = 'unconfirmed' then 1 end) as unconfirmed")
+    ->selectRaw("count(case when status = 'cancelled' then 1 end) as cancelled")
+    ->selectRaw("count(case when status = 'bounced' then 1 end) as bounced")
+    ->first();
```

Which is then called in the view like so:
```
<div>Total: {{ $totals->total }}</div>
<div>Confirmed: {{ $totals->confirmed }}</div>
<div>Unconfirmed: {{ $totals->unconfirmed }}</div>
<div>Cancelled: {{ $totals->cancelled }}</div>
<div>Bounced: {{ $totals->bounced }}</div>
```