### PR TITLE
Fix Regular Expressions to find inline HTML encoded special characters

### DIFF
--- a/app/Helpers/Markdown.php
+++ b/app/Helpers/Markdown.php
@@ -1205,7 +1205,7 @@ class Markdown
 
     protected function inlineSpecialCharacter($Excerpt)
     {
-        if ($Excerpt['text'][0] === '&' && ! \preg_match('#^&#?\w+;#', $Excerpt['text'])) {
+        if ($Excerpt['text'][0] === '&' && ! \preg_match('~^&#?\w+;~', $Excerpt['text'])) {
             return [
                 'markup' => '&amp;',
                 'extent' => 1,


### PR DESCRIPTION
In our current expression where trying to find anything like `&#numbers;`, but wrong delimiter is used, since we can't use `#` as delimiter to find something which contains delimiter itself, so the simplest solutions as php manual explains ( https://www.php.net/manual/en/regexp.reference.delimiters.php ) is to replace delimiter from `#^&#?\w+;#` to `~^&#?\w+;~`, and everything will works as excepted. 
Checkout: https://regex101.com/r/qQuanG/1

#1429 