### PR TITLE
fix: Mass PM Attributes

### DIFF
--- a/app/Jobs/ProcessMassPM.php
+++ b/app/Jobs/ProcessMassPM.php
@@ -47,8 +47,8 @@ class ProcessMassPM implements ShouldQueue
     public function handle()
     {
         $privateMessage = new PrivateMessage();
-        $privateMessage->sender_id = $this->sender_id;
-        $privateMessage->receiver_id = $this->receiver_id;
+        $privateMessage->sender_id = $this->senderId;
+        $privateMessage->receiver_id = $this->receiverId;
         $privateMessage->subject = $this->subject;
         $privateMessage->message = $this->message;
         $privateMessage->save();


### PR DESCRIPTION
The refactor done a couple of days ago broke mass pm's due to the contructor being changed from sender_id and receiver_id to senderId and receiverId