### PR TITLE
(Fix) Mass PM Attributes

### DIFF
--- a/app/Jobs/ProcessMassPM.php
+++ b/app/Jobs/ProcessMassPM.php
@@ -47,8 +47,8 @@ class ProcessMassPM implements ShouldQueue
     public function handle()
     {
         $privateMessage = new PrivateMessage();
-        $privateMessage->sender_id = $this->sender_id;
-        $privateMessage->receiver_id = $this->receiver_id;
+        $privateMessage->sender_id = $this->senderId;
+        $privateMessage->receiver_id = $this->receiverId;
         $privateMessage->subject = $this->subject;
         $privateMessage->message = $this->message;
         $privateMessage->save();


### PR DESCRIPTION
Due to the refactor a couple of days ago there is now a mismatch between constructor params and the attributes used in the handle function