### PR TITLE
fix: formatting of multiple nested quotes

### DIFF
--- a/resources/views/forum/topic.blade.php
+++ b/resources/views/forum/topic.blade.php
@@ -124,7 +124,7 @@
                                 </span>
                             </aside>
 
-                            <article class="col-md-9 post-content">
+                            <article class="col-md-9 post-content" data-bbcode="{{ $p->content }}">
                                 @joypixels($p->getContentHtml())
                             </article>
 
@@ -325,7 +325,7 @@
         $(document).ready(function() {
             $('.profil').on('click', 'button#quote', function () {
                 let author = $(this).closest('.profil').find('.post-info-username').first().text();
-                let text = $(this).closest('.profil').find('.post-content').text().replace('@here', '');
+                let text = $(this).closest('.profil').find('.post-content').data('bbcode');
                 $("#topic-response").wysibb().insertAtCursor('[quote=@'+author.trim()+']'+text.trim()+'[/quote]\r\n', true);
             });
         });


### PR DESCRIPTION
This aims to solve the issues in #1448 

Rather than making it more complicated than it needs to be for now.. simply add the raw bbcode that's pulled from the database as a data attribute and then when quoting simply push that to the comment box rather than the text content of the html node. 

I'm happy for people to test this out though if they wish. I'm also not 100% sure what the replacement of '@ here' was about but i'm assuming it was some sort of side effect of getting the data from html?