### PR TITLE
Fix: unique tables

### DIFF
--- a/database/migrations/2021_01_02_230512_update_users_table
+++ b/database/migrations/2021_01_02_230512_update_users_table
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class UpdateUsersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->unique('username');
+            $table->unique('passkey');
+            $table->unique('rsskey');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropUnique('users_username_unique');
+            $table->dropUnique('users_passkey_unique');
+            $table->dropUnique('users_rsskey_unique');
+        });
+    }
+}


### PR DESCRIPTION
This is fix so that username can't be the same. 
+ some other tables that need to be uniqu.

You can change the username if you staff to anything whitout checks and the system don't handle that well. 

It will be smart that mails is unique to but with now when you create a new site the system use the same mails 3 times so i did not add the unique mail. 