### PR TITLE
(Fix) Metadata: placeholders for actor photos, make them clickable

### DIFF
--- a/resources/views/mediahub/movie/show.blade.php
+++ b/resources/views/mediahub/movie/show.blade.php
@@ -102,9 +102,9 @@
                         @if (isset($movie->cast))
                             @foreach ($movie->cast as $actor)
                                 <div class="col-xs-4 col-md-2 text-center">
-                                    <img class="img-people" src="https://images.weserv.nl/?url={{ $actor->still ?? 'https://via.placeholder.com/95x140' }}&w=95&h=140"
-                                         alt="{{ $actor->name }}">
                                     <a href="{{ route('mediahub.persons.show', ['id' => $actor->id]) }}">
+                                        <img class="img-people" src="https://images.weserv.nl/?url={{ $actor->still ?? 'https://via.placeholder.com/95x140' }}&w=95&h=140"
+                                             alt="{{ $actor->name }}">
                                         <span class="badge-user" style="white-space:normal;">
                                             <strong>{{ $actor->name }}</strong>
                                         </span>

--- a/resources/views/mediahub/movie/show.blade.php
+++ b/resources/views/mediahub/movie/show.blade.php
@@ -102,7 +102,7 @@
                         @if (isset($movie->cast))
                             @foreach ($movie->cast as $actor)
                                 <div class="col-xs-4 col-md-2 text-center">
-                                    <img class="img-people" src="https://images.weserv.nl/?url={{ $actor->still }}&w=95&h=140"
+                                    <img class="img-people" src="https://images.weserv.nl/?url={{ $actor->still ?? 'https://via.placeholder.com/95x140' }}&w=95&h=140"
                                          alt="{{ $actor->name }}">
                                     <a href="{{ route('mediahub.persons.show', ['id' => $actor->id]) }}">
                                         <span class="badge-user" style="white-space:normal;">

--- a/resources/views/requests/partials/movie_meta.blade.php
+++ b/resources/views/requests/partials/movie_meta.blade.php
@@ -94,7 +94,7 @@
                         @if (isset($meta->cast))
                             @foreach ($meta->cast as $actor)
                                 <div class="col-xs-4 col-md-2 text-center">
-                                    <img class="img-people" src="https://images.weserv.nl/?url={{ $actor->still }}&w=95&h=140"
+                                    <img class="img-people" src="https://images.weserv.nl/?url={{ $actor->still ?? 'https://via.placeholder.com/95x140' }}&w=95&h=140"
                                          alt="{{ $actor->name }}">
                                     <a href="{{ route('mediahub.persons.show', ['id' => $actor->id]) }}">
                                         <span class="badge-user" style="white-space:normal;">

--- a/resources/views/requests/partials/movie_meta.blade.php
+++ b/resources/views/requests/partials/movie_meta.blade.php
@@ -94,9 +94,9 @@
                         @if (isset($meta->cast))
                             @foreach ($meta->cast as $actor)
                                 <div class="col-xs-4 col-md-2 text-center">
-                                    <img class="img-people" src="https://images.weserv.nl/?url={{ $actor->still ?? 'https://via.placeholder.com/95x140' }}&w=95&h=140"
-                                         alt="{{ $actor->name }}">
                                     <a href="{{ route('mediahub.persons.show', ['id' => $actor->id]) }}">
+                                        <img class="img-people" src="https://images.weserv.nl/?url={{ $actor->still ?? 'https://via.placeholder.com/95x140' }}&w=95&h=140"
+                                             alt="{{ $actor->name }}">
                                         <span class="badge-user" style="white-space:normal;">
                                             <strong>{{ $actor->name }}</strong>
                                         </span>

--- a/resources/views/requests/partials/tv_meta.blade.php
+++ b/resources/views/requests/partials/tv_meta.blade.php
@@ -103,9 +103,9 @@
                         @if (isset($meta->cast))
                             @foreach ($meta->cast as $actor)
                                 <div class="col-xs-4 col-md-2 text-center">
-                                    <img class="img-people" src="https://images.weserv.nl/?url={{ $actor->still ?? 'https://via.placeholder.com/95x140' }}&w=95&h=140"
-                                         alt="{{ $actor->name }}">
                                     <a href="{{ route('mediahub.persons.show', ['id' => $actor->id]) }}">
+                                        <img class="img-people" src="https://images.weserv.nl/?url={{ $actor->still ?? 'https://via.placeholder.com/95x140' }}&w=95&h=140"
+                                             alt="{{ $actor->name }}">
                                         <span class="badge-user" style="white-space:normal;">
                                             <strong>{{ $actor->name }}</strong>
                                         </span>

--- a/resources/views/requests/partials/tv_meta.blade.php
+++ b/resources/views/requests/partials/tv_meta.blade.php
@@ -103,7 +103,7 @@
                         @if (isset($meta->cast))
                             @foreach ($meta->cast as $actor)
                                 <div class="col-xs-4 col-md-2 text-center">
-                                    <img class="img-people" src="https://images.weserv.nl/?url={{ $actor->still }}&w=95&h=140"
+                                    <img class="img-people" src="https://images.weserv.nl/?url={{ $actor->still ?? 'https://via.placeholder.com/95x140' }}&w=95&h=140"
                                          alt="{{ $actor->name }}">
                                     <a href="{{ route('mediahub.persons.show', ['id' => $actor->id]) }}">
                                         <span class="badge-user" style="white-space:normal;">

--- a/resources/views/torrent/partials/movie_meta.blade.php
+++ b/resources/views/torrent/partials/movie_meta.blade.php
@@ -94,7 +94,7 @@
                         @if (isset($meta->cast))
                             @foreach ($meta->cast as $actor)
                                 <div class="col-xs-4 col-md-2 text-center">
-                                    <img class="img-people" src="https://images.weserv.nl/?url={{ $actor->still }}&w=95&h=140"
+                                    <img class="img-people" src="https://images.weserv.nl/?url={{ $actor->still ?? 'https://via.placeholder.com/95x140' }}&w=95&h=140"
                                          alt="{{ $actor->name }}">
                                     <a href="{{ route('mediahub.persons.show', ['id' => $actor->id]) }}">
                                         <span class="badge-user" style="white-space:normal;">

--- a/resources/views/torrent/partials/movie_meta.blade.php
+++ b/resources/views/torrent/partials/movie_meta.blade.php
@@ -94,9 +94,9 @@
                         @if (isset($meta->cast))
                             @foreach ($meta->cast as $actor)
                                 <div class="col-xs-4 col-md-2 text-center">
-                                    <img class="img-people" src="https://images.weserv.nl/?url={{ $actor->still ?? 'https://via.placeholder.com/95x140' }}&w=95&h=140"
-                                         alt="{{ $actor->name }}">
                                     <a href="{{ route('mediahub.persons.show', ['id' => $actor->id]) }}">
+                                        <img class="img-people" src="https://images.weserv.nl/?url={{ $actor->still ?? 'https://via.placeholder.com/95x140' }}&w=95&h=140"
+                                             alt="{{ $actor->name }}">
                                         <span class="badge-user" style="white-space:normal;">
                                             <strong>{{ $actor->name }}</strong>
                                         </span>

--- a/resources/views/torrent/partials/tv_meta.blade.php
+++ b/resources/views/torrent/partials/tv_meta.blade.php
@@ -103,9 +103,9 @@
                         @if (isset($meta->cast))
                             @foreach ($meta->cast as $actor)
                                 <div class="col-xs-4 col-md-2 text-center">
-                                    <img class="img-people" src="https://images.weserv.nl/?url={{ $actor->still ?? 'https://via.placeholder.com/95x140' }}&w=95&h=140"
-                                         alt="{{ $actor->name }}">
                                     <a href="{{ route('mediahub.persons.show', ['id' => $actor->id]) }}">
+                                        <img class="img-people" src="https://images.weserv.nl/?url={{ $actor->still ?? 'https://via.placeholder.com/95x140' }}&w=95&h=140"
+                                             alt="{{ $actor->name }}">
                                         <span class="badge-user" style="white-space:normal;">
                                             <strong>{{ $actor->name }}</strong>
                                         </span>

--- a/resources/views/torrent/partials/tv_meta.blade.php
+++ b/resources/views/torrent/partials/tv_meta.blade.php
@@ -103,7 +103,7 @@
                         @if (isset($meta->cast))
                             @foreach ($meta->cast as $actor)
                                 <div class="col-xs-4 col-md-2 text-center">
-                                    <img class="img-people" src="https://images.weserv.nl/?url={{ $actor->still }}&w=95&h=140"
+                                    <img class="img-people" src="https://images.weserv.nl/?url={{ $actor->still ?? 'https://via.placeholder.com/95x140' }}&w=95&h=140"
                                          alt="{{ $actor->name }}">
                                     <a href="{{ route('mediahub.persons.show', ['id' => $actor->id]) }}">
                                         <span class="badge-user" style="white-space:normal;">


### PR DESCRIPTION
Fixes two minor issues:
1. Broken actor images if TMDB doesn't have any photos (e.g. https://www.themoviedb.org/tv/111027-i-love)
2. Make actor photos clickable, same as names (easier to click, no need to hover names only)

Before:
![2021-04-11_134247](https://user-images.githubusercontent.com/82098328/114301217-8f1d4c80-9acc-11eb-9652-e6829facda8d.png)

After:
![2021-04-11_134748](https://user-images.githubusercontent.com/82098328/114301223-97758780-9acc-11eb-80ae-195f60005d1e.png)