### PR TITLE
(Update) About Me in Profile: don't limit to 500 chars, add wysibb, remove badge style

### DIFF
--- a/database/migrations/2021_04_13_200421_update_about_column_on_users_table.php
+++ b/database/migrations/2021_04_13_200421_update_about_column_on_users_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class UpdateAboutColumnOnUsersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->mediumText('about')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+}

--- a/resources/lang/da/user.php
+++ b/resources/lang/da/user.php
@@ -13,7 +13,6 @@
 
 return [
     'about'                                 => 'Om',
-    'about-me'                              => 'Om mig (500 max tegn!)',
     'about-me'                              => 'Om mig',
     'accepted-at'                           => 'Accepteret den',
     'accepted-by'                           => 'Accepteret af',

--- a/resources/lang/de/user.php
+++ b/resources/lang/de/user.php
@@ -13,7 +13,7 @@
 
 return [
     'about'                                => 'Über',
-    'about-me'                             => 'Über mich (max 500 Zeichen)',
+    'about-me'                             => 'Über mich',
     'accepted-at'                          => 'Akzeptiert um',
     'accepted-by'                          => 'Akzeptiert von',
     'account-notification'                 => 'Konto-Benachrichtigungs-Einstellungen',

--- a/resources/lang/en/user.php
+++ b/resources/lang/en/user.php
@@ -13,7 +13,7 @@
 
 return [
     'about'                          => 'About',
-    'about-me'                       => 'About Me (500 Characters Max!)',
+    'about-me'                       => 'About Me',
     'accepted-at'                    => 'Accepted at',
     'accepted-by'                    => 'Accepted by',
     'account-notification'           => 'Account Notification Settings',

--- a/resources/lang/zh-CN/user.php
+++ b/resources/lang/zh-CN/user.php
@@ -13,7 +13,7 @@
 
 return [
     'about'                         => '关于',
-    'about-me'                      => '自我介绍（不超过500字符！）',
+    'about-me'                      => '自我介绍',
     'accepted-at'                   => '接受于',
     'accepted-by'                   => '接受者',
     'account-notification'          => '帐户通知设定',

--- a/resources/lang/zh-TW/user.php
+++ b/resources/lang/zh-TW/user.php
@@ -13,7 +13,7 @@
 
 return [
     'about'                         => '關於',
-    'about-me'                      => '自我簡介 (上限500字元!)',
+    'about-me'                      => '自我簡介',
     'accepted-at'                   => '接受於',
     'accepted-by'                   => '接受者',
     'account-notification'          => '帳戶通知設定',

--- a/resources/views/user/edit_profile.blade.php
+++ b/resources/views/user/edit_profile.blade.php
@@ -53,7 +53,7 @@
                             <label for="about">@lang('user.about-me') <span class="badge-extra">BBCode
                                     @lang('common.is-allowed')</span></label>
                             <label>
-                                <textarea name="about" cols="30" rows="10" class="form-control">{{ $user->about }}</textarea>
+                                <textarea name="about" id="about" cols="30" rows="10" class="form-control">{{ $user->about }}</textarea>
                             </label>
                         </div>
 
@@ -61,7 +61,7 @@
                             <label for="signature">@lang('user.forum-signature') <span class="badge-extra">BBCode
                                     @lang('common.is-allowed')</span></label>
                             <label for=""></label>
-                            <textarea name="signature" id="" cols="30" rows="10" class="form-control">{{ $user->signature }}</textarea>
+                            <textarea name="signature" id="signature" cols="30" rows="10" class="form-control">{{ $user->signature }}</textarea>
                         </div>
 
                         @if ( !is_null($user->signature))
@@ -79,4 +79,12 @@
         </div>
     </div>
     </div>
+@endsection
+
+@section('javascripts')
+    <script nonce="{{ Bepsvpt\SecureHeaders\SecureHeaders::nonce('script') }}">
+        $(document).ready(function() {
+            $('#about, #signature').wysibb({});
+        })
+    </script>
 @endsection

--- a/resources/views/user/edit_profile.blade.php
+++ b/resources/views/user/edit_profile.blade.php
@@ -39,28 +39,23 @@
                             <label for="image">@lang('user.avatar')</label>
                             <small>@lang('user.formats-are-supported', ['formats' => '.jpg , .jpeg , .bmp , .png , .tiff ,
                                 .gif'])</small>
-                            <input type="file" name="image">
+                            <input type="file" name="image" id="image">
                         </div>
 
                         <div class="form-group">
                             <label for="title">@lang('user.custom-title')</label>
-                            <label>
-                                <input type="text" name="title" class="form-control" value="{{ $user->title }}">
-                            </label>
+                            <input type="text" name="title" id="title" class="form-control" value="{{ $user->title }}">
                         </div>
 
                         <div class="form-group">
                             <label for="about">@lang('user.about-me') <span class="badge-extra">BBCode
                                     @lang('common.is-allowed')</span></label>
-                            <label>
-                                <textarea name="about" id="about" cols="30" rows="10" class="form-control">{{ $user->about }}</textarea>
-                            </label>
+                            <textarea name="about" id="about" cols="30" rows="10" class="form-control">{{ $user->about }}</textarea>
                         </div>
 
                         <div class="form-group">
                             <label for="signature">@lang('user.forum-signature') <span class="badge-extra">BBCode
                                     @lang('common.is-allowed')</span></label>
-                            <label for=""></label>
                             <textarea name="signature" id="signature" cols="30" rows="10" class="form-control">{{ $user->signature }}</textarea>
                         </div>
 

--- a/resources/views/user/edit_profile.blade.php
+++ b/resources/views/user/edit_profile.blade.php
@@ -34,36 +34,36 @@
                     enctype="multipart/form-data">
                     @csrf
                     <div class="well">
-    
+
                         <div class="form-group">
                             <label for="image">@lang('user.avatar')</label>
                             <small>@lang('user.formats-are-supported', ['formats' => '.jpg , .jpeg , .bmp , .png , .tiff ,
                                 .gif'])</small>
                             <input type="file" name="image">
                         </div>
-    
+
                         <div class="form-group">
                             <label for="title">@lang('user.custom-title')</label>
                             <label>
                                 <input type="text" name="title" class="form-control" value="{{ $user->title }}">
                             </label>
                         </div>
-    
+
                         <div class="form-group">
                             <label for="about">@lang('user.about-me') <span class="badge-extra">BBCode
                                     @lang('common.is-allowed')</span></label>
                             <label>
-                                <textarea name="about" cols="30" rows="10" maxlength="496" class="form-control">{{ $user->about }}</textarea>
+                                <textarea name="about" cols="30" rows="10" class="form-control">{{ $user->about }}</textarea>
                             </label>
                         </div>
-    
+
                         <div class="form-group">
                             <label for="signature">@lang('user.forum-signature') <span class="badge-extra">BBCode
                                     @lang('common.is-allowed')</span></label>
                             <label for=""></label>
                             <textarea name="signature" id="" cols="30" rows="10" class="form-control">{{ $user->signature }}</textarea>
                         </div>
-    
+
                         @if ( !is_null($user->signature))
                             <div class="text-center">
                                 <p>@lang('user.forum-signature') </p> {!! $user->getSignature() !!}
@@ -74,7 +74,7 @@
                         <button type="submit" class="btn btn-primary">@lang('common.submit')</button>
                     </div>
                 </form>
-    
+
             </div>
         </div>
     </div>

--- a/resources/views/user/profile.blade.php
+++ b/resources/views/user/profile.blade.php
@@ -183,7 +183,7 @@
                         <tr>
                             <td>@lang('user.about')</td>
                             <td>
-                                <span class="badge-extra">@joypixels($user->getAboutHtml())</span>
+                                @joypixels($user->getAboutHtml())
                             </td>
                         </tr>
                         @endif


### PR DESCRIPTION
I see no logical reason why About Me column should be limited only to 500 chars.
Uploaders want to use this field to specify their upload schedule and other useful info.
Forum signature doesn't have such limitations (though it makes more sense to limit it).

Other fixes:
- added wysibb support
- removed unnecessary labels that made whole text inside textarea bold
- removed badge style since it applies unnecessary `text-align: center` and `white-space: nowrap` styles

Tested using current master branch on Ubuntu 20.04.2 (used UNIT3D Installer).

<details>
<summary>Before</summary>

![2021-04-13_225436](https://user-images.githubusercontent.com/82098328/114626067-d9185500-9cbb-11eb-9663-4de98a520d80.png)
</details>

<details>
<summary>After</summary>

![2021-04-14_003752](https://user-images.githubusercontent.com/82098328/114626096-e2092680-9cbb-11eb-8a8f-3c66f7bb4f31.png)
![2021-04-14_004016](https://user-images.githubusercontent.com/82098328/114626100-e5041700-9cbb-11eb-8232-1c527f8e6963.png)
</details>