### PR TITLE
(Fix) Spoilers on Pages with markdown

### DIFF
--- a/app/Helpers/BBCodeConverter.php
+++ b/app/Helpers/BBCodeConverter.php
@@ -316,9 +316,22 @@ class BBCodeConverter
      */
     protected function replaceSpoilers()
     {
-        $this->text = \preg_replace_callback('#\[spoiler\]([\W\D\w\s]*?)\[/spoiler\]#iu',
+        $this->text = \preg_replace_callback('#\[spoiler\](.*?)\[\/spoiler\]#ius',
 
-            fn ($matches) => '<details><summary>Spoiler!</summary><pre><code>'.\trim($matches[1], ' ').'</code></pre></details>',
+            fn ($matches) => '<p><details class="label label-primary"><summary>Spoiler</summary><pre><code>'.\trim($matches[1]).'</code></pre></details></p>',
+
+            $this->text
+        );
+    }
+
+    /**
+     * @brief Replace BBCode named spoiler.
+     */
+    protected function replaceNamedSpoilers()
+    {
+        $this->text = \preg_replace_callback('#\[spoiler\=(.*?)\](.*?)\[\/spoiler\]#ius',
+
+            fn ($matches) => '<p><details class="label label-primary"><summary>'.\trim($matches[1]).'</summary><pre><code>'.\trim($matches[2]).'</code></pre></details></p>',
 
             $this->text
         );
@@ -408,6 +421,7 @@ class BBCodeConverter
         $this->replaceQuotes();
         $this->replaceSnippets();
         $this->replaceSpoilers();
+        $this->replaceNamedSpoilers();
         $this->replaceColor();
         $this->replaceVideo();
         $this->replaceYoutube();

--- a/resources/sass/main/_custom.scss
+++ b/resources/sass/main/_custom.scss
@@ -9411,9 +9411,14 @@ section.recommendations div.scroller div.item span.glyphicons {
     font-size: 1.2em;
 }
 
-.page-content p {
+.page-content p,
+.page-content details {
     margin-top: 0.5em;
     margin-bottom: 0.5em;
+}
+
+.page-content details {
+    text-align: left;
 }
 
 .page-content>blockquote {
@@ -9424,7 +9429,7 @@ section.recommendations div.scroller div.item span.glyphicons {
 }
 
 .page-content code,
-pre {
+.page-content pre {
     color: #555;
     background-color: #f5f5f5;
     border: 1px solid #ccc;
@@ -9435,7 +9440,7 @@ pre {
     word-break: normal;
 }
 
-.page-content>pre>code {
+.page-content pre>code {
     border: none;
 }
 


### PR DESCRIPTION
Fixes #1711.

Note: had to surround the spoiler with `<p>` tags because otherwise there were no line breaks.
Looks like there isn't an easy way to return `<br>` tags because of Markdown conversions.

Result:
![spoiler-fix](https://user-images.githubusercontent.com/82098328/114644679-a896e200-9ce0-11eb-8067-e937392e77f3.gif)