### PR TITLE
(Fix) Filter torrents by health: support multiple choices

### DIFF
--- a/app/Http/Controllers/API/TorrentController.php
+++ b/app/Http/Controllers/API/TorrentController.php
@@ -458,20 +458,25 @@ class TorrentController extends BaseController
             $torrent->where('torrents.internal', '=', $internal);
         }
 
+        $func = 'where';
+
         if ($request->has('alive') && $request->input('alive') != null) {
-            $torrent->where('torrents.seeders', '>=', $alive);
+            $torrent->$func('torrents.seeders', '>=', $alive);
+            $func = 'orWhere';
         }
 
         if ($request->has('dying') && $request->input('dying') != null) {
-            $torrent->where('torrents.seeders', '=', $dying)->where('times_completed', '>=', 3);
+            $torrent->$func([['torrents.seeders', '=', $dying], ['times_completed', '>=', 3]]);
+            $func = 'orWhere';
         }
 
         if ($request->has('dead') && $request->input('dead') != null) {
-            $torrent->where('torrents.seeders', '=', $dead);
+            $torrent->$func('torrents.seeders', '=', $dead);
+            $func = 'orWhere';
         }
 
         if ($request->has('reseed') && $request->input('reseed') != null) {
-            $torrent->where('torrents.seeders', '=', 0)->where('torrents.leechers', '>=', 1);
+            $torrent->$func([['torrents.seeders', '=', 0], ['torrents.leechers', '>=', 1]]);
         }
 
         if ($torrent !== null) {

--- a/app/Http/Controllers/TorrentController.php
+++ b/app/Http/Controllers/TorrentController.php
@@ -548,16 +548,20 @@ class TorrentController extends Controller
                 $torrent->where('torrentsl.internal', '=', $internal);
             }
 
+            $func = 'where';
+
             if ($request->has('alive') && $request->input('alive') != null) {
-                $torrent->where('torrentsl.seeders', '>=', $alive);
+                $torrent->$func('torrentsl.seeders', '>=', $alive);
+                $func = 'orWhere';
             }
 
             if ($request->has('dying') && $request->input('dying') != null) {
-                $torrent->where('torrentsl.seeders', '=', $dying)->where('torrentsl.times_completed', '>=', 3);
+                $torrent->$func([['torrentsl.seeders', '=', $dying], ['torrentsl.times_completed', '>=', 3]]);
+                $func = 'orWhere';
             }
 
             if ($request->has('dead') && $request->input('dead') != null) {
-                $torrent->where('torrentsl.seeders', '=', $dead);
+                $torrent->$func('torrentsl.seeders', '=', $dead);
             }
         } elseif ($nohistory == 1) {
             $history = History::select(['torrents.id'])->leftJoin('torrents', 'torrents.info_hash', '=', 'history.info_hash')->where('history.user_id', '=', $user->id)->get()->toArray();
@@ -690,16 +694,20 @@ class TorrentController extends Controller
                 $torrent->where('torrents.internal', '=', $internal);
             }
 
+            $func = 'where';
+
             if ($request->has('alive') && $request->input('alive') != null) {
-                $torrent->where('torrents.seeders', '>=', $alive);
+                $torrent->$func('torrents.seeders', '>=', $alive);
+                $func = 'orWhere';
             }
 
             if ($request->has('dying') && $request->input('dying') != null) {
-                $torrent->where('torrents.seeders', '=', $dying)->where('times_completed', '>=', 3);
+                $torrent->$func([['torrents.seeders', '=', $dying], ['times_completed', '>=', 3]]);
+                $func = 'orWhere';
             }
 
             if ($request->has('dead') && $request->input('dead') != null) {
-                $torrent->where('torrents.seeders', '=', $dead);
+                $torrent->$func('torrents.seeders', '=', $dead);
             }
         }
 


### PR DESCRIPTION
Fixes #1625.

The solution is a bit ugly, but since it's gonna be refactored, I think it's okay.
Can still be useful as a patch for current versions.

<details>
<summary>Result</summary>

![unit3d-filter](https://user-images.githubusercontent.com/82098328/114761329-feaf6800-9d68-11eb-8093-ff07fd38369a.gif)
</details>