### PR TITLE
(Add) Validate if files inside torrents have valid filenames

### DIFF
--- a/app/Helpers/TorrentTools.php
+++ b/app/Helpers/TorrentTools.php
@@ -183,4 +183,24 @@ class TorrentTools
 
         return $fileContent;
     }
+
+    /**
+     * Check if the filename is valid or not.
+     *
+     * @param $filename
+     *
+     * @return bool
+     */
+    public static function isValidFilename($filename)
+    {
+        $result = true;
+        if (\strlen($filename) > 255 ||
+            \preg_match('#[/?<>\\:*|"\x00-\x1f]#', $filename) ||
+            \preg_match('#(^\.+|[\. ]+)$#', $filename) ||
+            \preg_match('#^(con|prn|aux|nul|com[0-9]|lpt[0-9])(\..*)?$#i', $filename)) {
+            $result = false;
+        }
+
+        return $result;
+    }
 }

--- a/app/Http/Controllers/API/TorrentController.php
+++ b/app/Http/Controllers/API/TorrentController.php
@@ -88,6 +88,13 @@ class TorrentController extends BaseController
             return $this->sendError('Validation Error.', 'You Must Provide A Valid Torrent File For Upload!');
         }
 
+        $torrentFiles = TorrentTools::getTorrentFiles($decodedTorrent);
+        foreach ($torrentFiles as $file) {
+            if (! TorrentTools::isValidFilename($file['name'])) {
+                return $this->sendError('Validation Error.', 'Invalid Filenames In Torrent Files!');
+            }
+        }
+
         $fileName = \sprintf('%s.torrent', \uniqid('', true)); // Generate a unique name
         Storage::disk('torrents')->put($fileName, Bencode::bencode($decodedTorrent));
 
@@ -181,7 +188,7 @@ class TorrentController extends BaseController
         $category->num_torrent = $category->torrents_count;
         $category->save();
         // Backup the files contained in the torrent
-        foreach (TorrentTools::getTorrentFiles($decodedTorrent) as $file) {
+        foreach ($torrentFiles as $file) {
             $torrentFile = new TorrentFile();
             $torrentFile->name = $file['name'];
             $torrentFile->size = $file['size'];

--- a/app/Http/Controllers/API/TorrentController.php
+++ b/app/Http/Controllers/API/TorrentController.php
@@ -74,7 +74,7 @@ class TorrentController extends BaseController
             return $this->sendError('Validation Error.', 'You Must Provide A Torrent File For Upload!');
         }
 
-        if ($requestFile->getError() !== 0 && $requestFile->getClientOriginalExtension() !== 'torrent') {
+        if ($requestFile->getError() !== 0 || $requestFile->getClientOriginalExtension() !== 'torrent') {
             return $this->sendError('Validation Error.', 'You Must Provide A Valid Torrent File For Upload!');
         }
 

--- a/app/Http/Controllers/TorrentController.php
+++ b/app/Http/Controllers/TorrentController.php
@@ -1268,6 +1268,14 @@ class TorrentController extends Controller
                 ->withErrors('You Must Provide A Valid Torrent File For Upload!')->withInput();
         }
 
+        $torrentFiles = TorrentTools::getTorrentFiles($decodedTorrent);
+        foreach ($torrentFiles as $file) {
+            if (! TorrentTools::isValidFilename($file['name'])) {
+                return \redirect()->route('upload_form', ['category_id' => $category->id])
+                    ->withErrors('Invalid Filenames In Torrent Files!')->withInput();
+            }
+        }
+
         $fileName = \uniqid('', true).'.torrent'; // Generate a unique name
         \file_put_contents(\getcwd().'/files/torrents/'.$fileName, Bencode::bencode($decodedTorrent));
 
@@ -1338,7 +1346,7 @@ class TorrentController extends Controller
         $category->num_torrent = $category->torrents_count;
         $category->save();
         // Backup the files contained in the torrent
-        foreach (TorrentTools::getTorrentFiles($decodedTorrent) as $file) {
+        foreach ($torrentFiles as $file) {
             $torrentFile = new TorrentFile();
             $torrentFile->name = $file['name'];
             $torrentFile->size = $file['size'];

--- a/app/Http/Controllers/TorrentController.php
+++ b/app/Http/Controllers/TorrentController.php
@@ -1251,15 +1251,23 @@ class TorrentController extends Controller
             return \redirect()->route('upload_form', ['category_id' => $category->id])
                 ->withErrors('You Must Provide A Torrent File For Upload!')->withInput();
         }
-        if ($requestFile->getError() != 0 && $requestFile->getClientOriginalExtension() != 'torrent') {
+
+        if ($requestFile->getError() != 0 || $requestFile->getClientOriginalExtension() != 'torrent') {
             return \redirect()->route('upload_form', ['category_id' => $category->id])
-                ->withErrors('An Unknown Error Has Occurred!')->withInput();
+                ->withErrors('You Must Provide A Valid Torrent File For Upload!')->withInput();
         }
 
         // Deplace and decode the torrent temporarily
         $decodedTorrent = TorrentTools::normalizeTorrent($requestFile);
         $infohash = Bencode::get_infohash($decodedTorrent);
-        $meta = Bencode::get_meta($decodedTorrent);
+
+        try {
+            $meta = Bencode::get_meta($decodedTorrent);
+        } catch (\Exception $e) {
+            return \redirect()->route('upload_form', ['category_id' => $category->id])
+                ->withErrors('You Must Provide A Valid Torrent File For Upload!')->withInput();
+        }
+
         $fileName = \uniqid('', true).'.torrent'; // Generate a unique name
         \file_put_contents(\getcwd().'/files/torrents/'.$fileName, Bencode::bencode($decodedTorrent));
 


### PR DESCRIPTION
Fixes #1666.

Found and fixed a possible bug in bool logic where torrent extension is checked.
`$requestFile->getError() != 0` always returned `true` in my case so the part after `&&` was never checked.

Also caught an error when `Bencode::get_meta` was called on non-torrent files.
Added a try/catch block since I noticed `API/TorrentController.php` had it already.

Attaching a .zip with examples of torrent files containing bad filenames (for testing):
- [bad_torrents.zip](https://github.com/HDInnovations/UNIT3D-Community-Edition/files/6313925/bad_torrents.zip)
