### PR TITLE
(Fix) Check filenames properly, use separate function without '/'

### DIFF
--- a/app/Helpers/TorrentTools.php
+++ b/app/Helpers/TorrentTools.php
@@ -136,6 +136,33 @@ class TorrentTools
     }
 
     /**
+     * Returns file and folder names from the torrent.
+     *
+     * @param $decodedTorrent
+     *
+     * @return array
+     */
+    public static function getFilenameArray($decodedTorrent)
+    {
+        $filenames = [];
+
+        if (\array_key_exists('files', $decodedTorrent['info']) && (\is_countable($decodedTorrent['info']['files']) ? \count($decodedTorrent['info']['files']) : 0)) {
+            foreach ($decodedTorrent['info']['files'] as $k => $file) {
+                $count = \is_countable($file['path']) ? \count($file['path']) : 0;
+                for ($i = 0; $i < $count; $i++) {
+                    if (! \in_array($file['path'][$i], $filenames)) {
+                        $filenames[] = $file['path'][$i];
+                    }
+                }
+            }
+        } else {
+            $filenames[] = $decodedTorrent['info']['name'];
+        }
+
+        return $filenames;
+    }
+
+    /**
      * Returns the sha1 (hash) of the torrent.
      *
      * @param $decodedTorrent

--- a/app/Http/Controllers/API/TorrentController.php
+++ b/app/Http/Controllers/API/TorrentController.php
@@ -88,9 +88,8 @@ class TorrentController extends BaseController
             return $this->sendError('Validation Error.', 'You Must Provide A Valid Torrent File For Upload!');
         }
 
-        $torrentFiles = TorrentTools::getTorrentFiles($decodedTorrent);
-        foreach ($torrentFiles as $file) {
-            if (! TorrentTools::isValidFilename($file['name'])) {
+        foreach (TorrentTools::getFilenameArray($decodedTorrent) as $name) {
+            if (! TorrentTools::isValidFilename($name)) {
                 return $this->sendError('Validation Error.', 'Invalid Filenames In Torrent Files!');
             }
         }
@@ -188,7 +187,7 @@ class TorrentController extends BaseController
         $category->num_torrent = $category->torrents_count;
         $category->save();
         // Backup the files contained in the torrent
-        foreach ($torrentFiles as $file) {
+        foreach (TorrentTools::getTorrentFiles($decodedTorrent) as $file) {
             $torrentFile = new TorrentFile();
             $torrentFile->name = $file['name'];
             $torrentFile->size = $file['size'];

--- a/app/Http/Controllers/TorrentController.php
+++ b/app/Http/Controllers/TorrentController.php
@@ -1268,9 +1268,8 @@ class TorrentController extends Controller
                 ->withErrors('You Must Provide A Valid Torrent File For Upload!')->withInput();
         }
 
-        $torrentFiles = TorrentTools::getTorrentFiles($decodedTorrent);
-        foreach ($torrentFiles as $file) {
-            if (! TorrentTools::isValidFilename($file['name'])) {
+        foreach (TorrentTools::getFilenameArray($decodedTorrent) as $name) {
+            if (! TorrentTools::isValidFilename($name)) {
                 return \redirect()->route('upload_form', ['category_id' => $category->id])
                     ->withErrors('Invalid Filenames In Torrent Files!')->withInput();
             }
@@ -1346,7 +1345,7 @@ class TorrentController extends Controller
         $category->num_torrent = $category->torrents_count;
         $category->save();
         // Backup the files contained in the torrent
-        foreach ($torrentFiles as $file) {
+        foreach (TorrentTools::getTorrentFiles($decodedTorrent) as $file) {
             $torrentFile = new TorrentFile();
             $torrentFile->name = $file['name'];
             $torrentFile->size = $file['size'];


### PR DESCRIPTION
Fixes #1728.

My bad, I should've done more testing with various multi-file torrents.
Didn't notice the existing function outputs file paths with "/" (leads to Invalid Filenames error).