### PR TITLE
(Fix) Demo data generation with demo:seed

### DIFF
--- a/app/Console/Commands/DemoSeed.php
+++ b/app/Console/Commands/DemoSeed.php
@@ -60,6 +60,9 @@ class DemoSeed extends Command
                 'chatroom_id'    => 1,
                 'group_id'       => \rand(1, 20),
                 'chat_status_id' => 1,
+                'image'          => null,
+                'custom_css'     => null,
+                'locale'         => 'en',
             ])->id;
 
             // random boolean
@@ -70,10 +73,16 @@ class DemoSeed extends Command
                 $this->info('Creating Movie Torrents for Account ID #'.$uid);
 
                 try {
+                    $year = 2021;
+
+                    if (\array_key_exists('release_date', $movie)) {
+                        $year = intval(\substr($movie['release_date'], 0, 4));
+                    }
+
                     Torrent::factory()->create([
                         'user_id'       => $uid,
                         'tmdb'          => $id,
-                        'name'          => $movie['title'].' ('.\substr($movie['release_date'], 0, 4).')',
+                        'name'          => $movie['title'].' ('.$year.')',
                         'slug'          => Str::slug($movie['title']),
                         'description'   => $movie['overview'],
                         'category_id'   => 1,
@@ -81,7 +90,7 @@ class DemoSeed extends Command
                         'resolution_id' => \rand(1, 10),
                         'featured'      => false,
                         'sticky'        => 0,
-                        'release_year'  => \substr($movie['release_date'], 0, 4),
+                        'release_year'  => $year,
                         'mediainfo'     => '
 Complete name                            : Double.Impact.1991.1080p.BluRay.DD+5.1.x264-LoRD.mkv
 Format                                   : Matroska
@@ -236,6 +245,8 @@ Menu
                 } catch (Exception $e) {
                     $abort = true;
 
+                    $this->warn($e);
+
                     break;
                 }
             }
@@ -248,6 +259,7 @@ Menu
         if ($abort) {
             $this->error('Aborted ...');
             $this->alert('Demo data was only PARTIALLY seeded! This is likely due to an API Request timeout.');
+            $this->alert('Ensure TMDB api key is set and run "php artisan config:clear"');
         } else {
             $this->alert('Demo data has been successfully seeded!');
         }


### PR DESCRIPTION
Solves some issues with `php artisan demo:seed`:

1. Error when parsing movie data because `release_date` is not set (movie is Planned, [example](https://www.themoviedb.org/movie/602315)):
```
Creating User Account
Creating Movie Torrents for Account ID #40
PDOException: SQLSTATE[HY000]: General error: 1366 Incorrect integer value: '' for column 'release_year' at row 1 in /var/www/html/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/PDOStatement.php:112
Stack trace:
#0 /var/www/html/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/PDOStatement.php(112): PDOStatement->execute()
#1 /var/www/html/vendor/laravel/framework/src/Illuminate/Database/Connection.php(471): Doctrine\DBAL\Driver\PDOStatement->execute()
#2 /var/www/html/vendor/laravel/framework/src/Illuminate/Database/Connection.php(671): Illuminate\Database\Connection->Illuminate\Database\{closure}()
#3 /var/www/html/vendor/laravel/framework/src/Illuminate/Database/Connection.php(638): Illuminate\Database\Connection->runQueryCallback()
#4 /var/www/html/vendor/laravel/framework/src/Illuminate/Database/Connection.php(472): Illuminate\Database\Connection->run()
...

Next Illuminate\Database\QueryException: SQLSTATE[HY000]: General error: 1366 Incorrect integer value: '' for column 'release_year' at row 1 (SQL: insert into `torrents` (`name`, `slug`, `description`, `mediainfo`, `info_hash`, `file_name`, `num_file`, `size`, `nfo`, `leechers`, `seeders`, `times_completed`, `category_id`, `announce`, `user_id`, `imdb`, `tvdb`, `tmdb`, `mal`, `igdb`, `type_id`, `resolution_id`, `stream`, `free`, `doubleup`, `highspeed`, `featured`, `status`, `moderated_at`, `moderated_by`, `anon`, `sticky`, `sd`, `internal`, `release_year`, `created_at`, `bumped_at`, `updated_at`) values (The Gangster, The Cop, The Devil (), the-gangster-the-cop-the-devil, Planned English language remake of the original South Korean film., <MEDIAINFO>, temporibus, sit, 411354, 5345353.9, Ratione eos ut perspiciatis aut provident. Nihil quod fugiat aliquam nihil. Excepturi qui aut provident veniam magnam iure dignissimos., 383, 710079, 78332912, 1, deleniti, 40, 61217, 680633, 602315, 69, 5, 4, 2, 0, 0, 0, 0, 0, 1, 2021-04-27 10:19:50, 1, 0, 0, 0, 1, , 2021-04-27 10:19:50, 2021-04-27 10:19:50, 2021-04-27 10:19:50)) in /var/www/html/vendor/laravel/framework/src/Illuminate/Database/Connection.php:678
Stack trace:
#0 /var/www/html/vendor/laravel/framework/src/Illuminate/Database/Connection.php(638): Illuminate\Database\Connection->runQueryCallback()
#1 /var/www/html/vendor/laravel/framework/src/Illuminate/Database/Connection.php(472): Illuminate\Database\Connection->run()
#2 /var/www/html/vendor/laravel/framework/src/Illuminate/Database/Connection.php(424): Illuminate\Database\Connection->statement()
#3 /var/www/html/vendor/laravel/framework/src/Illuminate/Database/Query/Processors/Processor.php(32): Illuminate\Database\Connection->insert()
#4 /var/www/html/vendor/laravel/framework/src/Illuminate/Database/Query/Builder.php(2882): Illuminate\Database\Query\Processors\Processor->processInsertGetId()
...
```
2. Users are created with gibberish values for `image` (leads to broken avatars), `custom_css` and `locale` (better to leave them blank/default)
3. It's better to output `Exception $e` so that the dev can understand the problem (in my case - API key was invalid/not set)
4. Added a note about `artisan config:clear` since it may help resolve api key issue