### PR TITLE
(Fix) Auto pruning with artisan auto:disable_inactive_users

### DIFF
--- a/app/Console/Commands/AutoDisableInactiveUsers.php
+++ b/app/Console/Commands/AutoDisableInactiveUsers.php
@@ -52,11 +52,11 @@ class AutoDisableInactiveUsers extends Command
 
             $current = Carbon::now();
 
-            $matches = User::whereIn('group_id', [\config('pruning.group_ids')])->get();
+            $matches = User::whereIn('group_id', \config('pruning.group_ids'))->get();
 
             $users = $matches->where('created_at', '<', $current->copy()->subDays(\config('pruning.account_age'))->toDateTimeString())
                 ->where('last_login', '<', $current->copy()->subDays(\config('pruning.last_login'))->toDateTimeString())
-                ->get();
+                ->all();
 
             foreach ($users as $user) {
                 if ($user->getSeeding() === 0) {


### PR DESCRIPTION
Two issues found:
1. `config('pruning.group_ids')` is already an array ([pruning.php#L29](https://github.com/HDInnovations/UNIT3D-Community-Edition/blob/master/config/pruning.php#L29)), but is surrounded by `[]` and causes an error:
```
Illuminate\Database\QueryException

SQLSTATE[HY093]: Invalid parameter number (SQL: select * from `users` where `group_id` in (3) and `users`.`deleted_at` is null)

at vendor/laravel/framework/src/Illuminate/Database/Connection.php:678
app/Console/Commands/AutoDisableInactiveUsers.php:55
      Illuminate\Database\Eloquent\Builder::get()
```
2. After fixing the above, another error comes up because of this commit: https://github.com/HDInnovations/UNIT3D-Community-Edition/commit/b498b446e4c49866a327bd900392046bc4845a2b
```
ArgumentCountError

Too few arguments to function Illuminate\Support\Collection::get(), 0 passed in /var/www/html/app/Console/Commands/AutoDisableInactiveUsers.php on line 59 and at least 1 expected

at vendor/laravel/framework/src/Illuminate/Collections/Collection.php:405
app/Console/Commands/AutoDisableInactiveUsers.php:59
      Illuminate\Support\Collection::get()
```
Looks like you discussed it here before: https://github.com/HDInnovations/UNIT3D-Community-Edition/pull/1233#discussion_r389991382

The confusion probably comes because of the same `->get` name:
- https://laravel.com/api/8.x/Illuminate/Database/Eloquent/Builder.html#method_get
- https://laravel.com/api/8.x/Illuminate/Database/Eloquent/Collection.html#method_get