### PR TITLE
(Fix) Profile: optimize SQL query for uploads count

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -52,14 +52,11 @@ class UserController extends Controller
      */
     public function show($username)
     {
-        $user = User::with(['privacy', 'history'])->where('username', '=', $username)->firstOrFail();
+        $user = User::with(['privacy', 'history'])->withCount('torrents')->where('username', '=', $username)->firstOrFail();
 
         $groups = Group::all();
         $followers = Follow::where('target_id', '=', $user->id)->latest()->limit(25)->get();
-
-        $uploaded = Torrent::where('user_id', '=', $user->id)->count();
         $history = $user->history;
-
         $warnings = Warning::where('user_id', '=', $user->id)->whereNotNull('torrent')->where('active', '=', 1)->take(\config('hitrun.max_warnings'))->get();
         $hitrun = Warning::where('user_id', '=', $user->id)->latest()->paginate(10);
 
@@ -85,7 +82,6 @@ class UserController extends Controller
             'user'         => $user,
             'groups'       => $groups,
             'followers'    => $followers,
-            'uploaded'     => $uploaded,
             'history'      => $history,
             'warnings'     => $warnings,
             'hitrun'       => $hitrun,

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -56,7 +56,10 @@ class UserController extends Controller
 
         $groups = Group::all();
         $followers = Follow::where('target_id', '=', $user->id)->latest()->limit(25)->get();
+
+        $uploaded = Torrent::where('user_id', '=', $user->id)->count();
         $history = $user->history;
+
         $warnings = Warning::where('user_id', '=', $user->id)->whereNotNull('torrent')->where('active', '=', 1)->take(\config('hitrun.max_warnings'))->get();
         $hitrun = Warning::where('user_id', '=', $user->id)->latest()->paginate(10);
 
@@ -82,6 +85,7 @@ class UserController extends Controller
             'user'         => $user,
             'groups'       => $groups,
             'followers'    => $followers,
+            'uploaded'     => $uploaded,
             'history'      => $history,
             'warnings'     => $warnings,
             'hitrun'       => $hitrun,

--- a/resources/views/user/profile.blade.php
+++ b/resources/views/user/profile.blade.php
@@ -140,7 +140,7 @@
                                 <div class="text-center">
                             <span class="badge-user badge-float p-10"><i
                                         class="{{ config('other.font-awesome') }} fa-upload"></i> @lang('user.total-uploads')
-                                : <span class="text-green text-bold">{{ $uploaded }}</span></span>
+                                : <span class="text-green text-bold">{{ $user->torrents_count }}</span></span>
                                     <span class="badge-user badge-float p-10"><i
                                                 class="{{ config('other.font-awesome') }} fa-download"></i> @lang('user.total-downloads')
                                         : <span class="text-red text-bold">{{ $history->where('actual_downloaded', '>', 0)->count() }}</span></span>

--- a/resources/views/user/profile.blade.php
+++ b/resources/views/user/profile.blade.php
@@ -140,7 +140,7 @@
                                 <div class="text-center">
                             <span class="badge-user badge-float p-10"><i
                                         class="{{ config('other.font-awesome') }} fa-upload"></i> @lang('user.total-uploads')
-                                : <span class="text-green text-bold">{{ $user->torrents->count() }}</span></span>
+                                : <span class="text-green text-bold">{{ $uploaded }}</span></span>
                                     <span class="badge-user badge-float p-10"><i
                                                 class="{{ config('other.font-awesome') }} fa-download"></i> @lang('user.total-downloads')
                                         : <span class="text-red text-bold">{{ $history->where('actual_downloaded', '>', 0)->count() }}</span></span>


### PR DESCRIPTION
Solves the problem of Profile pages not being rendered for users with lots of uploads (12500+).
<details>

![2021-04-29_202259](https://user-images.githubusercontent.com/82098328/116593283-97c5ad80-a929-11eb-81b2-3d70841e3b9b.png)
</details>

Probably the initial MySQL query hits some limit and fails (without logging any errors).
It may be fixable by editing server settings, but since we need only the counter, it can be optimized. No need to do a costly `select * from torrents`.

<details>
<summary>Before</summary>

![2021-04-29_180143](https://user-images.githubusercontent.com/82098328/116594224-a5c7fe00-a92a-11eb-8561-8eb503528b04.png)
</details>
<details>
<summary>After</summary>

![2021-04-29_200458](https://user-images.githubusercontent.com/82098328/116594301-b8423780-a92a-11eb-9c1f-4c2c44eebfc0.png)
</details>

There are probably other places where such `->count()` calls can be replaced with better queries.
Laravel Debugbar can help identify them. If I have time, I'll work on it in future.