### PR TITLE
(Fix) Prevent CSP error caused by inline void javascript in left menu

### DIFF
--- a/resources/sass/nav/nav.scss
+++ b/resources/sass/nav/nav.scss
@@ -191,6 +191,10 @@ body {
   box-shadow: 0 1px 4px 0 rgba(0, 0, 0, 0.2);
 }
 
+#hoe-left-panel .hoe-has-menu > a {
+  cursor: pointer;
+}
+
 #hoe-left-panel .profile-box {
   border-bottom: 1px solid #efefef;
   min-height: 50px;

--- a/resources/views/partials/side_nav.blade.php
+++ b/resources/views/partials/side_nav.blade.php
@@ -14,7 +14,7 @@
 
 
         <li class="hoe-has-menu">
-            <a href="javascript:void(0)">
+            <a>
                 <i class="{{ config('other.font-awesome') }} fa-download" style=" font-size: 18px; color: #ffffff;"></i>
                 <span class="menu-text">@lang('torrent.torrents')</span>
                 <span class="selected"></span>
@@ -61,7 +61,7 @@
 
 
         <li class="hoe-has-menu">
-            <a href="javascript:void(0)">
+            <a>
                 <i class="{{ config('other.font-awesome') }} fa-upload" style=" font-size: 18px; color: #ffffff;"></i>
                 <span class="menu-text">@lang('common.publish')</span>
                 <span class="selected"></span>
@@ -81,7 +81,7 @@
 
 
         <li class="hoe-has-menu">
-            <a href="javascript:void(0)">
+            <a>
                 <i class="{{ config('other.font-awesome') }} fa-user" style=" font-size: 18px; color: #ffffff;"></i>
                 <span class="menu-text">@lang('common.other')</span>
                 <span class="selected"></span>


### PR DESCRIPTION
If you have Expanded menu enabled in profile and Content Security Policy is enabled, clicking menu groups will produce this error:

![2021-05-05_190933](https://user-images.githubusercontent.com/82098328/117173812-d0580200-add5-11eb-8902-7131219c5507.png)
_screenshot from https://unit3d.site/_

It's caused by inline `javascript:void(0)` inside `href` attributes.

Note: `<a>` tags without `href` are considered valid: https://stackoverflow.com/a/19167175
I added `cursor: pointer` to compensate the missing style.