### PR TITLE
(Fix) Torrent filter settings saving, CSRF value for jquery ajax

### DIFF
--- a/resources/js/bootstrap.js
+++ b/resources/js/bootstrap.js
@@ -15,7 +15,7 @@ try {
 
 $.ajaxSetup({
     headers: {
-        'X-CSRF-TOKEN': document.head.querySelector('meta[name="csrf-token"]'),
+        'X-CSRF-TOKEN': document.head.querySelector('meta[name="csrf-token"]').content,
     },
 });
 

--- a/resources/js/unit3d/helper.js
+++ b/resources/js/unit3d/helper.js
@@ -182,7 +182,7 @@ class uploadExtensionBuilder {
             defaults: {"language": "ENGLISH"} // defaults values for : language, resolution and year
         });
 
- 
+
 
         let matcher = name.value.toLowerCase();
 
@@ -626,7 +626,7 @@ class facetedSearchBuilder {
         }
       let localXHR = new XMLHttpRequest()
       localXHR = $.ajax({
-            url: '/filterSettings',
+            url: '/torrents/filterSettings',
             data: {
                 _token: this.csrf,
                 force: force,


### PR DESCRIPTION
Two small issues:
1. Global `X-CSRF-TOKEN` in `ajaxSetup` wasn't set correctly (equals to "HTML Element" instead of actual value)
2. The state of filters in torrent listings wasn't saved because of incorrect path (route has `torrents` prefix: [web.php#L254](https://github.com/HDInnovations/UNIT3D-Community-Edition/blob/master/routes/web.php#L254))