### PR TITLE
(Fix) Convert unix-style line breaks to <br> for BBcode

### DIFF
--- a/app/Helpers/Bbcode.php
+++ b/app/Helpers/Bbcode.php
@@ -119,7 +119,7 @@ class Bbcode
             'pattern' => '/\[quote\](.*?)\[\/quote\]/s',
             'replace' => '<ul class="media-list comments-list">
                           <li class="media" style="border-left-width: 5px; border-left-style: solid; border-left-color: #01bc8c;">
-                          <div class="media-body">    
+                          <div class="media-body">
                           <div class="pt-5">$1</div>
                           </div>
                           </li>
@@ -131,8 +131,8 @@ class Bbcode
             'pattern' => '/\[quote\=(.*?)\](.*)\[\/quote\]/s',
             'replace' => '<ul class="media-list comments-list">
                           <li class="media" style="border-left-width: 5px; border-left-style: solid; border-left-color: #01bc8c;">
-                          <div class="media-body"> 
-                          <strong><span><i class="fas fa-quote-left"></i> Quoting $1 :</span></strong>    
+                          <div class="media-body">
+                          <strong><span><i class="fas fa-quote-left"></i> Quoting $1 :</span></strong>
                           <div class="pt-5">$2</div>
                           </div>
                           </li>
@@ -250,27 +250,33 @@ class Bbcode
 
         'youtube' => [
             'pattern' => '/\[youtube\](.*?)\[\/youtube\]/s',
-            'replace' => '<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/$1?rel=0" 
+            'replace' => '<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/$1?rel=0"
                             frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>',
             'content' => '$1',
         ],
 
         'video' => [
             'pattern' => '/\[video\](.*?)\[\/video\]/s',
-            'replace' => '<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/$1?rel=0" 
+            'replace' => '<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/$1?rel=0"
                             frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>',
             'content' => '$1',
         ],
 
         'video-youtube' => [
             'pattern' => '/\[video="youtube"\](.*?)\[\/video\]/s',
-            'replace' => '<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/$1?rel=0" 
+            'replace' => '<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/$1?rel=0"
                             frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>',
             'content' => '$1',
         ],
 
         'linebreak' => [
             'pattern' => '/\r\n/',
+            'replace' => '<br>',
+            'content' => '',
+        ],
+
+        'linebreak-nix' => [
+            'pattern' => '/\n/',
             'replace' => '<br>',
             'content' => '',
         ],


### PR DESCRIPTION
Bug was mentioned in #1542, I just didn't understand it correctly.
If you write torrent descriptions on Ubuntu, for example, they are not correctly converted to HTML (`\n` lines are left instead of `<br>`).
Adding an additional rule after `\r\n` fixes this issue.