### PR TITLE
(Fix) Allow pressing Enter in input fields, fix user's torrent search

### DIFF
--- a/resources/js/unit3d/custom.js
+++ b/resources/js/unit3d/custom.js
@@ -44,11 +44,3 @@ $(document).ready(function() {
 $(document).ready(function() {
     $('[data-toggle="tooltip"]').tooltip();
 });
-$(document).ready(function() {
-    $(window).keydown(function(event){
-        if((event.keyCode == 13) && ($(event.target)[0]!=$("textarea")[0])) {
-            event.preventDefault();
-            return false;
-        }
-    });
-});

--- a/resources/views/user/private/active.blade.php
+++ b/resources/views/user/private/active.blade.php
@@ -18,7 +18,7 @@
 @endsection
 
 @section('content')
-    
+
     <div class="container-fluid">
         <div class="block">
             @include('user.buttons.stats')
@@ -31,7 +31,7 @@
             </div>
             <div class="button-holder some-padding">
                 <div class="button-left">
-    
+
                 </div>
                 <div class="button-right">
                     <span class="badge-user"><strong>@lang('user.total-download'):</strong>
@@ -48,9 +48,7 @@
             </div>
             <hr class="some-padding">
             <div class="container well search mt-5">
-                <form role="form" method="GET" action="UserController@myFilters"
-                    class="form-horizontal form-condensed form-torrent-search form-bordered">
-                    @csrf
+                <div class="form-horizontal form-condensed form-torrent-search form-bordered">
                     <div class="mx-0 mt-5 form-group fatten-me">
                         <label for="name" class="mt-5 col-sm-1 label label-default fatten-me">@lang('torrent.name')</label>
                         <div class="col-sm-9 fatten-me">
@@ -103,7 +101,7 @@
                             </select>
                         </div>
                     </div>
-                </form>
+                </div>
             </div>
             <span id="filterHeader"></span>
             <div id="userFilter" userName="{{ $user->username }}" userId="{{ $user->id }}" view="active">

--- a/resources/views/user/private/downloads.blade.php
+++ b/resources/views/user/private/downloads.blade.php
@@ -19,7 +19,7 @@
 @endsection
 
 @section('content')
-    
+
     <div class="container-fluid">
         <div class="block">
             @include('user.buttons.stats')
@@ -32,7 +32,7 @@
             </div>
             <div class="button-holder some-padding">
                 <div class="button-left">
-    
+
                 </div>
                 <div class="button-right">
                     <span class="badge-user"><strong>@lang('user.total-download'):</strong>
@@ -49,9 +49,7 @@
             </div>
             <hr class="some-padding">
             <div class="container well search mt-5">
-                <form role="form" method="GET" action="UserController@myFilters"
-                    class="form-horizontal form-condensed form-torrent-search form-bordered">
-                    @csrf
+                <div class="form-horizontal form-condensed form-torrent-search form-bordered">
                     <div class="mx-0 mt-5 form-group fatten-me">
                         <label for="name" class="mt-5 col-sm-1 label label-default fatten-me">@lang('torrent.name')</label>
                         <div class="col-sm-9 fatten-me">
@@ -105,7 +103,7 @@
                             </select>
                         </div>
                     </div>
-                </form>
+                </div>
             </div>
             <span id="filterHeader"></span>
             <div id="userFilter" userName="{{ $user->username }}" userId="{{ $user->id }}" view="downloads">

--- a/resources/views/user/private/requests.blade.php
+++ b/resources/views/user/private/requests.blade.php
@@ -19,7 +19,7 @@
 @endsection
 
 @section('content')
-    
+
     <div class="container-fluid">
         <div class="block">
             @include('user.buttons.other')
@@ -32,9 +32,7 @@
             </div>
             <hr class="some-padding">
             <div class="container well search mt-5">
-                <form role="form" method="GET" action="UserController@myFilters"
-                    class="form-horizontal form-condensed form-torrent-search form-bordered">
-                    @csrf
+                <div class="form-horizontal form-condensed form-torrent-search form-bordered">
                     <div class="mx-0 mt-5 form-group fatten-me">
                         <label for="name" class="mt-5 col-sm-1 label label-default fatten-me">@lang('torrent.name')</label>
                         <div class="col-sm-9 fatten-me">
@@ -100,7 +98,7 @@
                             </select>
                         </div>
                     </div>
-                </form>
+                </div>
             </div>
             <span id="filterHeader"></span>
             <div id="userFilter" userName="{{ $user->username }}" userId="{{ $user->id }}" view="requests">

--- a/resources/views/user/private/resurrections.blade.php
+++ b/resources/views/user/private/resurrections.blade.php
@@ -20,7 +20,7 @@
 @endsection
 
 @section('content')
-    
+
     <div class="container-fluid">
         <div class="block">
             @include('user.buttons.other')
@@ -33,9 +33,7 @@
             </div>
             <hr class="some-padding">
             <div class="container well search mt-5">
-                <form role="form" method="GET" action="UserController@myFilters"
-                    class="form-horizontal form-condensed form-torrent-search form-bordered">
-                    @csrf
+                <div class="form-horizontal form-condensed form-torrent-search form-bordered">
                     <div class="mx-0 mt-5 form-group fatten-me">
                         <label for="name" class="mt-5 col-sm-1 label label-default fatten-me">@lang('torrent.name')</label>
                         <div class="col-sm-9 fatten-me">
@@ -86,7 +84,7 @@
                             </select>
                         </div>
                     </div>
-                </form>
+                </div>
             </div>
             <span id="filterHeader"></span>
             <div id="userFilter" userName="{{ $user->username }}" userId="{{ $user->id }}" view="resurrections">

--- a/resources/views/user/private/seeds.blade.php
+++ b/resources/views/user/private/seeds.blade.php
@@ -18,7 +18,7 @@
 @endsection
 
 @section('content')
-    
+
     <div class="container-fluid">
         <div class="block">
             @include('user.buttons.stats')
@@ -31,7 +31,7 @@
             </div>
             <div class="button-holder some-padding">
                 <div class="button-left">
-    
+
                 </div>
                 <div class="button-right">
                     <span class="badge-user"><strong>@lang('user.total-download'):</strong>
@@ -48,9 +48,7 @@
             </div>
             <hr class="some-padding">
             <div class="container well search mt-5">
-                <form role="form" method="GET" action="UserController@myFilters"
-                    class="form-horizontal form-condensed form-torrent-search form-bordered">
-                    @csrf
+                <div class="form-horizontal form-condensed form-torrent-search form-bordered">
                     <div class="mx-0 mt-5 form-group fatten-me">
                         <label for="name" class="mt-5 col-sm-1 label label-default fatten-me">@lang('torrent.name')</label>
                         <div class="col-sm-9 fatten-me">
@@ -155,7 +153,7 @@
                             </select>
                         </div>
                     </div>
-                </form>
+                </div>
             </div>
             <span id="filterHeader"></span>
             <div id="userFilter" userName="{{ $user->username }}" userId="{{ $user->id }}" view="seeds">

--- a/resources/views/user/private/torrents.blade.php
+++ b/resources/views/user/private/torrents.blade.php
@@ -31,7 +31,7 @@
             </div>
             <div class="button-holder some-padding">
                 <div class="button-left">
-    
+
                 </div>
                 <div class="button-right">
                     <span class="badge-user"><strong>@lang('user.total-download'):</strong>
@@ -48,9 +48,7 @@
             </div>
             <hr class="some-padding">
             <div class="container well search mt-5">
-                <form role="form" method="GET" action="UserController@myFilters"
-                    class="form-horizontal form-condensed form-torrent-search form-bordered">
-                    @csrf
+                <div class="form-horizontal form-condensed form-torrent-search form-bordered">
                     <div class="mx-0 mt-5 form-group fatten-me">
                         <label for="name" class="mt-5 col-sm-1 label label-default fatten-me">@lang('torrent.name')</label>
                         <div class="col-sm-9 fatten-me">
@@ -131,7 +129,7 @@
                             </select>
                         </div>
                     </div>
-                </form>
+                </div>
             </div>
             <span id="filterHeader"></span>
             <div id="userFilter" userName="{{ $user->username }}" userId="{{ $user->id }}" view="history">
@@ -223,8 +221,8 @@
                         {{ $history->links() }}
                     </div>
                 </div>
-    
-    
+
+
             </div>
         </div>
     @endsection

--- a/resources/views/user/private/unsatisfieds.blade.php
+++ b/resources/views/user/private/unsatisfieds.blade.php
@@ -20,7 +20,7 @@
 @endsection
 
 @section('content')
-    
+
     <div class="container-fluid">
         <div class="block">
             @include('user.buttons.stats')
@@ -33,7 +33,7 @@
             </div>
             <div class="button-holder some-padding">
                 <div class="button-left">
-    
+
                 </div>
                 <div class="button-right">
                     <span class="badge-user"><strong>@lang('user.total-download'):</strong>
@@ -50,9 +50,7 @@
             </div>
             <hr class="some-padding">
             <div class="container well search mt-5">
-                <form role="form" method="GET" action="UserController@myFilters"
-                    class="form-horizontal form-condensed form-torrent-search form-bordered">
-                    @csrf
+                <div class="form-horizontal form-condensed form-torrent-search form-bordered">
                     <div class="mx-0 mt-5 form-group fatten-me">
                         <label for="name" class="mt-5 col-sm-1 label label-default fatten-me">@lang('torrent.name')</label>
                         <div class="col-sm-9 fatten-me">
@@ -104,7 +102,7 @@
                             </select>
                         </div>
                     </div>
-                </form>
+                </div>
             </div>
             <span id="filterHeader"></span>
             <div id="userFilter" userName="{{ $user->username }}" userId="{{ $user->id }}" view="unsatisfieds">

--- a/resources/views/user/private/uploads.blade.php
+++ b/resources/views/user/private/uploads.blade.php
@@ -19,7 +19,7 @@
 @endsection
 
 @section('content')
-    
+
     <div class="container-fluid">
         <div class="block">
             @include('user.buttons.stats')
@@ -32,7 +32,7 @@
             </div>
             <div class="button-holder some-padding">
                 <div class="button-left">
-    
+
                 </div>
                 <div class="button-right">
                     <span class="badge-user"><strong>@lang('user.total-download'):</strong>
@@ -49,9 +49,7 @@
             </div>
             <hr class="some-padding">
             <div class="container well search mt-5">
-                <form role="form" method="GET" action="UserController@myFilters"
-                    class="form-horizontal form-condensed form-torrent-search form-bordered">
-                    @csrf
+                <div class="form-horizontal form-condensed form-torrent-search form-bordered">
                     <div class="mx-0 mt-5 form-group fatten-me">
                         <label for="name" class="mt-5 col-sm-1 label label-default fatten-me">@lang('torrent.name')</label>
                         <div class="col-sm-9 fatten-me">
@@ -86,7 +84,7 @@
                     <div class="mx-0 mt-5 form-group fatten-me">
                         <label for="name"
                             class="mt-5 col-sm-1 label label-default fatten-me">@lang('torrent.filters')</label>
-    
+
                         <div class="col-sm-10">
                             <span class="badge-user">
                                 <label class="inline">
@@ -141,7 +139,7 @@
                             </select>
                         </div>
                     </div>
-                </form>
+                </div>
             </div>
             <span id="filterHeader"></span>
             <div id="userFilter" userName="{{ $user->username }}" userId="{{ $user->id }}" view="uploads">


### PR DESCRIPTION
The code added in https://github.com/HDInnovations/UNIT3D-Community-Edition/commit/f50612c for #849 (before Livewire was implemented) causes the following issues:
- Can't initiate search in forums by pressing Enter (only by clicking the button with mouse)
- Can't add new list items in BBcode textareas (since Enter is blocked)

Possibly some other issues too. Removing this global block solves them.
Replacing `<form>` with `<div>` doesn't break formatting, userSearch works fine.