### PR TITLE
(Fix) Upload page: ajax preview description, save values, don't replace

### DIFF
--- a/resources/js/unit3d/helper.js
+++ b/resources/js/unit3d/helper.js
@@ -159,135 +159,146 @@ class uploadExtensionBuilder {
     }
     hook() {
         let name = document.querySelector('#title');
-        let torrent = document.querySelector('#torrent');
-        let release;
-        if (!name.value) {
-            const fileEndings = ['.mkv.torrent', '.mp4.torrent', '.torrent'];
-          let newValue = torrent.value
-          // strip path
-            newValue = newValue.split('\\').pop().split('/').pop();
-            // remove file endings
-            fileEndings.forEach(function (e) {
-                newValue = newValue.replace(e, '');
+        let tmdb = document.querySelector('#autotmdb');
+        let imdb = document.querySelector('#autoimdb');
+
+        if (!name.value.trim() && !tmdb.value.trim() && !imdb.value.trim()) {
+            let torrent = document.querySelector('#torrent');
+            let release;
+            if (!name.value) {
+                const fileEndings = ['.mkv.torrent', '.mp4.torrent', '.torrent'];
+            let newValue = torrent.value
+            // strip path
+                newValue = newValue.split('\\').pop().split('/').pop();
+                // remove file endings
+                fileEndings.forEach(function (e) {
+                    newValue = newValue.replace(e, '');
+                });
+                // replace dots with spaces
+                name.value = this.removeDots(newValue);
+            }
+
+            /* PARSING */
+            release = title_parser.parse(name.value, {
+                strict: true, // if no main tags found, will throw an exception
+                flagged: true, // add flags to generated relese name (like STV, REMASTERED, READNFO)
+                erase: [], // add expressions to erase before parsing
+                defaults: {"language": "ENGLISH"} // defaults values for : language, resolution and year
             });
-            // replace dots with spaces
-            name.value = this.removeDots(newValue);
-        }
-
-        /* PARSING */
-        release = title_parser.parse(name.value, {
-            strict: true, // if no main tags found, will throw an exception
-            flagged: true, // add flags to generated relese name (like STV, REMASTERED, READNFO)
-            erase: [], // add expressions to erase before parsing
-            defaults: {"language": "ENGLISH"} // defaults values for : language, resolution and year
-        });
 
 
 
-        let matcher = name.value.toLowerCase();
+            let matcher = name.value.toLowerCase();
 
-        // Torrent Category
-        if (release.type === "Movie") {
-            $("#autocat").val(1);
-        } else if (release.type === "TV Show") {
-            $("#autocat").val(2);
-        }
-
-        // Torrent Type
-        if (matcher.indexOf("bd50") > 0 || matcher.indexOf("bd25") > 0 || matcher.indexOf("untouched") > 0 || matcher.indexOf("dvd5") > 0 || matcher.indexOf("dvd9") > 0 || matcher.indexOf("mpeg-2") > 0 || matcher.indexOf("avc") > 0 || matcher.indexOf("vc-1") > 0) {
-            $("#autotype").val(1);
-        }
-        if (matcher.indexOf("remux") > 0) {
-            $("#autotype").val(2);
-        }
-        if (matcher.indexOf("x264") > 0) {
-            $("#autotype").val(3);
-        }
-        if (matcher.indexOf("x265") > 0) {
-            $("#autotype").val(3);
-        }
-        if (matcher.indexOf("webdl") > 0 || matcher.indexOf("web-dl") > 0) {
-            $("#autotype").val(4);
-        }
-        if (matcher.indexOf("web-rip") > 0 || matcher.indexOf("webrip") > 0) {
-            $("#autotype").val(5);
-        }
-        if (matcher.indexOf("hdtv") > 0) {
-            $("#autotype").val(6);
-        }
-
-        // Torrent Resolution
-        $("#autores").val(release.resolution);
-
-        // Torrent Season (TV Only)
-        $("#season_number").val(release.season);
-
-        // Torrent Episode (TV Only)
-        $("#episode_number").val(release.episode);
-
-        // Torrent TMDB ID
-        if (release.type === "Movie") {
-            theMovieDb.search.getMovie({ "query": release.title, "year": release.year }, successCB, errorCB);
-        } else if (release.type === "TV Show") {
-            theMovieDb.search.getTv({ "query": release.title }, successCB, errorCB);
-        }
-
-        function successCB(data) {
-            data = JSON.parse(data);
+            // Torrent Category
             if (release.type === "Movie") {
-                if (data.results && data.results.length > 0) {
-                    $("#autotmdb").val(data.results[0].id);
-                    $("#apimatch").val('Found Match: ' + data.results[0].title + ' (' + data.results[0].release_date + ')');
-                    theMovieDb.movies.getKeywords({ "id": data.results[0].id }, success, error);
-                    theMovieDb.movies.getExternalIds({ "id": data.results[0].id }, s, e);
-                }
+                $("#autocat").val(1);
             } else if (release.type === "TV Show") {
-                if (data.results && data.results.length > 0) {
-                    $("#autotmdb").val(data.results[0].id);
-                    $("#apimatch").val('Found Match: ' + data.results[0].name + ' (' + data.results[0].first_air_date + ')');
-                    theMovieDb.tv.getKeywords({ "id": data.results[0].id }, success, error);
-                    theMovieDb.tv.getExternalIds({ "id": data.results[0].id }, s, e);
+                $("#autocat").val(2);
+            }
+
+            // Torrent Type
+            if (matcher.indexOf("bd50") > 0 || matcher.indexOf("bd25") > 0 || matcher.indexOf("untouched") > 0 || matcher.indexOf("dvd5") > 0 || matcher.indexOf("dvd9") > 0 || matcher.indexOf("mpeg-2") > 0 || matcher.indexOf("avc") > 0 || matcher.indexOf("vc-1") > 0) {
+                $("#autotype").val(1);
+            }
+            if (matcher.indexOf("remux") > 0) {
+                $("#autotype").val(2);
+            }
+            if (matcher.indexOf("x264") > 0) {
+                $("#autotype").val(3);
+            }
+            if (matcher.indexOf("x265") > 0) {
+                $("#autotype").val(3);
+            }
+            if (matcher.indexOf("webdl") > 0 || matcher.indexOf("web-dl") > 0) {
+                $("#autotype").val(4);
+            }
+            if (matcher.indexOf("web-rip") > 0 || matcher.indexOf("webrip") > 0) {
+                $("#autotype").val(5);
+            }
+            if (matcher.indexOf("hdtv") > 0) {
+                $("#autotype").val(6);
+            }
+
+            // Torrent Resolution
+            if (release.resolution) {
+                $("#autores").val(release.resolution);
+            }
+
+            // Torrent Season (TV Only)
+            if (release.season) {
+                $("#season_number").val(release.season);
+            }
+
+            // Torrent Episode (TV Only)
+            if (release.episode) {
+                $("#episode_number").val(release.episode);
+            }
+
+            // Torrent TMDB ID
+            if (release.type === "Movie") {
+                theMovieDb.search.getMovie({ "query": release.title, "year": release.year }, successCB, errorCB);
+            } else if (release.type === "TV Show") {
+                theMovieDb.search.getTv({ "query": release.title }, successCB, errorCB);
+            }
+
+            function successCB(data) {
+                data = JSON.parse(data);
+                if (release.type === "Movie") {
+                    if (data.results && data.results.length > 0) {
+                        $("#autotmdb").val(data.results[0].id);
+                        $("#apimatch").val('Found Match: ' + data.results[0].title + ' (' + data.results[0].release_date + ')');
+                        theMovieDb.movies.getKeywords({ "id": data.results[0].id }, success, error);
+                        theMovieDb.movies.getExternalIds({ "id": data.results[0].id }, s, e);
+                    }
+                } else if (release.type === "TV Show") {
+                    if (data.results && data.results.length > 0) {
+                        $("#autotmdb").val(data.results[0].id);
+                        $("#apimatch").val('Found Match: ' + data.results[0].name + ' (' + data.results[0].first_air_date + ')');
+                        theMovieDb.tv.getKeywords({ "id": data.results[0].id }, success, error);
+                        theMovieDb.tv.getExternalIds({ "id": data.results[0].id }, s, e);
+                    }
                 }
             }
-        }
-        function errorCB(data) {
-            console.log("Error callback: " + data);
-        }
-
-        //Torrent Keywords
-        function success(data) {
-            data = JSON.parse(data);
-            if (release.type === "Movie") {
-                let tags = data.keywords.map(({ name }) => name).join(', ');
-                $("#autokeywords").val(tags);
-            } else if (release.type === "TV Show") {
-                let tags = data.results.map(({ name }) => name).join(', ');
-                $("#autokeywords").val(tags);
+            function errorCB(data) {
+                console.log("Error callback: " + data);
             }
-        }
-        function error(data) {
-            console.log("Error callback: " + data);
-        }
 
-        //Torrent External IDs
-        function s(data) {
-            data = JSON.parse(data);
-            let imdb = data.imdb_id;
-            imdb = imdb.substring(2);
-            if (release.type === "Movie") {
-                $("#autoimdb").val(imdb);
-            } else if (release.type === "TV Show") {
-                $("#autoimdb").val(imdb);
-                $("#autotvdb").val(data.tvdb_id);
+            //Torrent Keywords
+            function success(data) {
+                data = JSON.parse(data);
+                if (release.type === "Movie") {
+                    let tags = data.keywords.map(({ name }) => name).join(', ');
+                    $("#autokeywords").val(tags);
+                } else if (release.type === "TV Show") {
+                    let tags = data.results.map(({ name }) => name).join(', ');
+                    $("#autokeywords").val(tags);
+                }
             }
-        }
-        function e(data) {
-            console.log("Error callback: " + data);
-        }
+            function error(data) {
+                console.log("Error callback: " + data);
+            }
 
-        // Torrent Stream Optimized?
-        if (release.container === "MP4" && release.audio === "AAC") {
-            document.getElementById("stream").checked = true;
+            //Torrent External IDs
+            function s(data) {
+                data = JSON.parse(data);
+                let imdb = data.imdb_id;
+                imdb = imdb.substring(2);
+                if (release.type === "Movie") {
+                    $("#autoimdb").val(imdb);
+                } else if (release.type === "TV Show") {
+                    $("#autoimdb").val(imdb);
+                    $("#autotvdb").val(data.tvdb_id);
+                }
+            }
+            function e(data) {
+                console.log("Error callback: " + data);
+            }
+
+            // Torrent Stream Optimized?
+            if (release.container === "MP4" && release.audio === "AAC") {
+                document.getElementById("stream").checked = true;
+            }
         }
     }
 }

--- a/resources/views/torrent/upload.blade.php
+++ b/resources/views/torrent/upload.blade.php
@@ -31,13 +31,10 @@
             </div>
         </div>
     @else
-        @if (Session::has('previewContent'))
-            <div class="torrent box container">
-                <h2 class="text-center">Upload Description Preview</h2>
-                <div class="preview col-md-12"> @joypixels(Session::get('previewContent')) </div>
-                <hr>
-            </div>
-        @endif
+        <div class="torrent box container" id="preview-box" style="display:none">
+            <h2 class="text-center mt-10">Upload Description Preview</h2>
+            <div class="preview col-md-12" id="preview-content"></div>
+        </div>
         <div class="torrent box container">
             <div class="alert alert-info text-center">
                 <h2 class="mt-10"><strong>@lang('torrent.announce-url'):</strong>
@@ -55,7 +52,7 @@
 
             <div class="upload col-md-12">
                 <h2 class="upload-title">@lang('torrent.torrent')</h2>
-                <form name="upload" class="upload-form" method="POST" action="{{ route('upload') }}"
+                <form name="upload" class="upload-form" id="upload-form" method="POST" action="{{ route('upload') }}"
                       enctype="multipart/form-data">
                     @csrf
                     <div class="form-group">
@@ -71,7 +68,7 @@
                     <div class="form-group">
                         <label for="name">@lang('torrent.title')</label>
                         <label for="title"></label>
-                        <input type="text" name="name" id="title" class="form-control" value="{{ $title ?? old('name') }}" required>
+                        <input type="text" name="name" id="title" class="form-control" value="{{ !empty($title) ? $title : old('name') }}" required>
                     </div>
 
                     <div class="form-group">
@@ -94,7 +91,7 @@
                             <select name="type_id" id="autotype" class="form-control" required>
                                 <option hidden="" disabled="disabled" selected="selected" value="">--Select Type--</option>
                                 @foreach ($types as $type)
-                                    <option value="{{ $type->id }}" @if (old('type')==$type->name) selected="selected"@endif>
+                                    <option value="{{ $type->id }}" @if (old('type_id')==$type->id) selected="selected"@endif>
                                         {{ $type->name }}
                                     </option>
                                 @endforeach
@@ -102,7 +99,7 @@
                         </label>
                     </div>
 
-                    @php $data = App\Models\Category::where('id', '=', $category_id ?? old('category_id'))->first();@endphp
+                    @php $data = App\Models\Category::where('id', '=', !empty($category_id) ? $category_id : old('category_id'))->first();@endphp
                     @if ($data->movie_meta || $data->tv_meta)
                     <div class="form-group">
                         <label for="resolution_ids">@lang('torrent.resolution')</label>
@@ -110,7 +107,7 @@
                             <select name="resolution_id" id="autores" class="form-control">
                                 <option hidden="" disabled="disabled" selected="selected" value="">--Select Resolution--</option>
                                 @foreach ($resolutions as $resolution)
-                                    <option value="{{ $resolution->id }}" @if (old('resolution')==$resolution->name) selected="selected" @endif>
+                                    <option value="{{ $resolution->id }}" @if (old('resolution_id')==$resolution->id) selected="selected" @endif>
                                         {{ $resolution->name }}
                                     </option>
                                 @endforeach
@@ -142,7 +139,7 @@
                             <label for="name">TMDB ID <b>(@lang('request.required'))</b></label>
                             <label>
                                 <input type="text" name="apimatch" id="apimatch" class="form-control" value="" disabled>
-                                <input type="number" name="tmdb" id="autotmdb" class="form-control" value="{{ $tmdb ?? old('tmdb') }}" required>
+                                <input type="number" name="tmdb" id="autotmdb" class="form-control" value="{{ !empty($tmdb) ? $tmdb : old('tmdb') }}" required>
                             </label>
                         </div>
                     @else
@@ -153,7 +150,7 @@
                         <div class="form-group">
                             <label for="name">IMDB ID <b>(@lang('torrent.optional'))</b></label>
                             <label>
-                                <input type="number" name="imdb" id="autoimdb" class="form-control" value="{{ $imdb ?? old('imdb') }}" required>
+                                <input type="number" name="imdb" id="autoimdb" class="form-control" value="{{ !empty($imdb) ? $imdb : old('imdb') }}" required>
                             </label>
                         </div>
                     @else
@@ -196,7 +193,7 @@
                     <div class="form-group">
                         <label for="name">@lang('torrent.keywords') (<i>@lang('torrent.keywords-example')</i>)</label>
                         <label>
-                            <input type="text" name="keywords" id="autokeywords" class="form-control">
+                            <input type="text" name="keywords" id="autokeywords" class="form-control" value="{{ old('keywords') }}">
                         </label>
                     </div>
 
@@ -216,10 +213,10 @@
 
                     <label for="anonymous" class="control-label">@lang('common.anonymous')?</label>
                     <div class="radio-inline">
-                        <label><input type="radio" name="anonymous" value="1">@lang('common.yes')</label>
+                        <label><input type="radio" name="anonymous" value="1"{{ old('anonymous') ? ' checked' : '' }}>@lang('common.yes')</label>
                     </div>
                     <div class="radio-inline">
-                        <label><input type="radio" name="anonymous" checked="checked" value="0">@lang('common.no')</label>
+                        <label><input type="radio" name="anonymous" value="0"{{ !old('anonymous') ? ' checked' : '' }}>@lang('common.no')</label>
                     </div>
 
                     @if ($data->movie_meta || $data->tv_meta)
@@ -227,20 +224,20 @@
 
                         <label for="stream" class="control-label">@lang('torrent.stream-optimized')?</label>
                         <div class="radio-inline">
-                            <label><input type="radio" name="stream" id="stream" value="1">@lang('common.yes')</label>
+                            <label><input type="radio" name="stream" id="stream" value="1"{{ old('stream') ? ' checked' : '' }}>@lang('common.yes')</label>
                         </div>
                         <div class="radio-inline">
-                            <label><input type="radio" name="stream" id="stream" checked="checked" value="0">@lang('common.no')</label>
+                            <label><input type="radio" name="stream" id="stream" value="0"{{ !old('stream') ? ' checked' : '' }}>@lang('common.no')</label>
                         </div>
 
                         <br>
 
                         <label for="sd" class="control-label">@lang('torrent.sd-content')?</label>
                         <div class="radio-inline">
-                            <label><input type="radio" name="sd" value="1">@lang('common.yes')</label>
+                            <label><input type="radio" name="sd" value="1"{{ old('sd') ? ' checked' : '' }}>@lang('common.yes')</label>
                         </div>
                         <div class="radio-inline">
-                            <label><input type="radio" name="sd" checked="checked" value="0">@lang('common.no')</label>
+                            <label><input type="radio" name="sd" value="0"{{ !old('sd') ? ' checked' : '' }}>@lang('common.no')</label>
                         </div>
                     @else
                         <input type="hidden" name="stream" value="0">
@@ -252,10 +249,10 @@
                     @if (auth()->user()->group->is_modo || auth()->user()->group->is_internal)
                         <label for="internal" class="control-label">@lang('torrent.internal')?</label>
                         <div class="radio-inline">
-                            <label><input type="radio" name="internal" value="1">@lang('common.yes')</label>
+                            <label><input type="radio" name="internal" value="1"{{ old('internal') ? ' checked' : '' }}>@lang('common.yes')</label>
                         </div>
                         <div class="radio-inline">
-                            <label><input type="radio" name="internal" checked="checked" value="0">@lang('common.no')</label>
+                            <label><input type="radio" name="internal" value="0"{{ !old('internal') ? ' checked' : '' }}>@lang('common.no')</label>
                         </div>
 
                         <br>
@@ -266,17 +263,17 @@
                     @if (auth()->user()->group->is_modo || auth()->user()->group->is_internal)
                         <label for="freeleech" class="control-label">@lang('torrent.freeleech')?</label>
                         <div class="radio-inline">
-                            <label><input type="radio" name="free" value="1">@lang('common.yes')</label>
+                            <label><input type="radio" name="free" value="1"{{ old('free') ? ' checked' : '' }}>@lang('common.yes')</label>
                         </div>
                         <div class="radio-inline">
-                            <label><input type="radio" name="free" checked="checked" value="0">@lang('common.no')</label>
+                            <label><input type="radio" name="free" value="0"{{ !old('free') ? ' checked' : '' }}>@lang('common.no')</label>
                         </div>
                     @else
                         <input type="hidden" name="free" value="0">
                     @endif
 
                     <div class="text-center">
-                        <button type="submit" name="preview" value="true" id="preview" class="btn btn-info">
+                        <button type="button" name="preview" value="true" id="preview" class="btn btn-info">
                             @lang('common.preview')
                         </button>
                         <button type="submit" name="post" value="true" id="post" class="btn btn-success">
@@ -292,4 +289,19 @@
 
 @section('javascripts')
     <script src="{{ mix('js/imgbb.js') }}" crossorigin="anonymous"></script>
+    <script nonce="{{ Bepsvpt\SecureHeaders\SecureHeaders::nonce('script') }}">
+        $('#preview').on('click', function() {
+            var text = $('#upload-form-description').bbcode().trim();
+
+            if (text.length > 0) {
+                $.post('/upload/preview', {
+                    'description': text
+                }, function(data){
+                    document.getElementById('preview-content').innerHTML = data;
+                    document.getElementById('preview-box').removeAttribute('style');
+                    document.getElementById('main-content').scrollIntoView({behavior: 'smooth'});
+                });
+            }
+        });
+    </script>
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -247,6 +247,7 @@ Route::group(['middleware' => 'language'], function () {
         Route::group(['prefix' => 'upload'], function () {
             Route::get('/{category_id}/{title?}/{imdb?}/{tmdb?}', 'TorrentController@uploadForm')->name('upload_form');
             Route::post('/', 'TorrentController@upload')->name('upload');
+            Route::post('/preview', 'TorrentController@preview');
         });
 
         Route::group(['prefix' => 'torrents'], function () {


### PR DESCRIPTION
Some improvements for the upload page:
1. Preview description without page reload, fixes #1741
2. Correctly restore `old()` values after page reload (e.g. in case of errors). Current checks with `??` (`isset`) always return `true` and erase values because defaults are set in [TorrentController.php#L1208](https://github.com/HDInnovations/UNIT3D-Community-Edition/blob/master/app/Http/Controllers/TorrentController.php#L1208)
3. Don't trigger `uploadExtension.hook()` if any of these inputs already have values: `name`, `tmdb`, `imdb`.
It might be frustrating to see an error after page reload, select torrent file again and have name/ID values replaced. Automatic values should be set only if these inputs are empty.

<details>
<summary>Changes in helper.js</summary>

![2021-05-12_211004](https://user-images.githubusercontent.com/82098328/118025120-2265ce00-b368-11eb-8eea-ae33898c4ff5.png)
![2021-05-12_211018](https://user-images.githubusercontent.com/82098328/118025119-21cd3780-b368-11eb-800a-e4276f8236cb.png)
</details>