### PR TITLE
(Refactor) Polls markup and styles, don't auto-add question mark

### DIFF
--- a/app/Models/Poll.php
+++ b/app/Models/Poll.php
@@ -96,7 +96,7 @@ class Poll extends Model
     }
 
     /**
-     * Set The Poll's Title, Adds A Question Mark (?) If Needed.
+     * Set The Poll's Title.
      *
      * @param $title
      *
@@ -104,10 +104,6 @@ class Poll extends Model
      */
     public function setTitleAttribute($title)
     {
-        if (\substr($title, -1) !== '?') {
-            return $this->attributes['title'] = $title.'?';
-        }
-
         return $this->attributes['title'] = $title;
     }
 

--- a/resources/sass/main/_custom.scss
+++ b/resources/sass/main/_custom.scss
@@ -8484,6 +8484,33 @@ div.header div.inner_content h1 {
 /*! purgecss end ignore */
 
 // Caterories / Polls Design
+.poll-title {
+    font-size: 18px;
+    font-weight: bold;
+    margin-top: 0;
+}
+
+.poll-item {
+    margin: 15px 0;
+}
+
+.poll-item input {
+    margin-top: 6px !important;
+}
+
+.poll-item .badge-user {
+    font-size: 16px;
+}
+
+.poll-note {
+    margin-top: 15px;
+}
+
+.poll.form-group {
+    margin-top: 15px;
+    margin-bottom: 0;
+}
+
 div.blocks {
     display: flex;
     justify-content: space-between;

--- a/resources/views/blocks/poll.blade.php
+++ b/resources/views/blocks/poll.blade.php
@@ -3,64 +3,53 @@
         <div class="clearfix visible-sm-block"></div>
         <div class="panel panel-chat shoutbox">
             <div class="panel-heading">
-                <h4><i class="{{ config('other.font-awesome') }} fa-chart-pie"></i>@lang('blocks.latest-poll') - - {{ $poll->title }}</h4>
+                <h4><i class="{{ config('other.font-awesome') }} fa-chart-pie"></i> @lang('poll.poll')</h4>
             </div>
             <div class="panel-body">
-                <div class="forum-categories">
-                    <div class="forum-category">
-                        <div class="forum-category-title col-md-12">
-                            <div class="forum-category-childs">
-                                <form class="form-horizontal" method="POST" action="/polls/vote">
-                                    @csrf
-                                    @if (count($errors) > 0)
-                                        <div class="alert alert-danger">
-                                            <ul>
-                                                @foreach ($errors->all() as $error)
-                                                    <li>{{ $error }}</li>
-                                                @endforeach
-                                            </ul>
-                                        </div>
-                                    @endif
-    
-                                    {!! csrf_field() !!}
-    
-                                    @if ($poll->multiple_choice)
-                                        @foreach ($poll->options as $option)
-                                            <a class="forum-category-childs-forum col-md-4">
-                                                <div class="checkbox">
-                                                    <label>
-                                                        <input type="checkbox" name="option[]" value="{{ $option->id }}">
-                                                        <span class="badge-user">{{ $option->name }}</span>
-                                                    </label>
-                                                </div>
-                                            </a>
-                                        @endforeach
-                                    @else
-                                        @foreach ($poll->options as $option)
-                                            <a class="forum-category-childs-forum col-md-4">
-                                                <div class="radio">
-                                                    <label>
-                                                        <input type="radio" name="option[]" value="{{ $option->id }}" required>
-                                                        <span class="badge-user">{{ $option->name }}</span>
-                                                    </label>
-                                                </div>
-                                            </a>
-                                        @endforeach
-                                    @endif
-    
-                                    <div class="form-group">
-                                        <div class="col-md-12">
-                                            <button type="submit" class="btn btn-primary">@lang('poll.vote')</button>
-                                        </div>
-                                    </div>
-                                </form>
-                                @if ($poll->multiple_choice)
-                                    <span class="badge-user text-bold text-red">@lang('poll.multiple-choice')</span>
-                                @endif
+                <h3 class="poll-title">{{ $poll->title }}</h3>
+                    <form class="form-horizontal" method="POST" action="/polls/vote">
+                        @csrf
+                        @if (count($errors) > 0)
+                            <div class="alert alert-danger">
+                                <ul>
+                                    @foreach ($errors->all() as $error)
+                                        <li>{{ $error }}</li>
+                                    @endforeach
+                                </ul>
+                            </div>
+                        @endif
+
+                        {!! csrf_field() !!}
+
+                        @if ($poll->multiple_choice)
+                            @foreach ($poll->options as $option)
+                                <div class="poll-item">
+                                    <label>
+                                        <input type="checkbox" name="option[]" value="{{ $option->id }}">
+                                        <span class="badge-user">{{ $option->name }}</span>
+                                    </label>
+                                </div>
+                            @endforeach
+                        @else
+                            @foreach ($poll->options as $option)
+                                <div class="poll-item">
+                                    <label>
+                                        <input type="radio" name="option[]" value="{{ $option->id }}" required>
+                                        <span class="badge-user">{{ $option->name }}</span>
+                                    </label>
+                                </div>
+                            @endforeach
+                        @endif
+
+                        <div class="poll form-group">
+                            <div class="col-md-12">
+                                <button type="submit" class="btn btn-primary">@lang('poll.vote')</button>
                             </div>
                         </div>
-                    </div>
-                </div>
+                    </form>
+                    @if ($poll->multiple_choice)
+                        <span class="badge-user text-bold text-red poll-note">@lang('poll.multiple-choice')</span>
+                    @endif
             </div>
         </div>
     </div>

--- a/resources/views/poll/forms/vote.blade.php
+++ b/resources/views/poll/forms/vote.blade.php
@@ -14,29 +14,25 @@
 
     @if ($poll->multiple_choice)
         @foreach ($poll->options as $option)
-            <a class="forum-category-childs-forum col-md-4">
-                <div class="checkbox">
-                    <label>
-                        <input type="checkbox" name="option[]" value="{{ $option->id }}">
-                        <span class="badge-user">{{ $option->name }}</span>
-                    </label>
-                </div>
-            </a>
+            <div class="poll-item">
+                <label>
+                    <input type="checkbox" name="option[]" value="{{ $option->id }}">
+                    <span class="badge-user">{{ $option->name }}</span>
+                </label>
+            </div>
         @endforeach
     @else
         @foreach ($poll->options as $option)
-            <a class="forum-category-childs-forum col-md-4">
-                <div class="radio">
-                    <label>
-                        <input type="radio" name="option[]" value="{{ $option->id }}" required>
-                        <span class="badge-user">{{ $option->name }}</span>
-                    </label>
-                </div>
-            </a>
+            <div class="poll-item">
+                <label>
+                    <input type="radio" name="option[]" value="{{ $option->id }}" required>
+                    <span class="badge-user">{{ $option->name }}</span>
+                </label>
+            </div>
         @endforeach
     @endif
 
-    <div class="form-group">
+    <div class="poll form-group">
         <div class="col-md-12">
             <button type="submit" class="btn btn-primary">@lang('poll.vote')</button>
             <a class="btn btn-success" href="{{ route('poll_results', ['id' => $poll->id]) }}" role="button"><i

--- a/resources/views/poll/show.blade.php
+++ b/resources/views/poll/show.blade.php
@@ -18,18 +18,21 @@
 @endsection
 
 @section('content')
-    <div class="box container">
+    <div class="container">
         <div class="page-title">
-            <h1>{{ $poll->title }}</h1>
+            <h1>@lang('poll.poll')</h1>
         </div>
-        <hr>
-        <div class="forum-categories">
-            <div class="forum-category">
-                <div class="forum-category-title col-md-12">
-                    <div class="forum-category-childs">
+
+        <div class="row">
+            <div class="col-md-12">
+                <div class="panel panel-chat">
+                    <div class="panel-heading">
+                        <h1 class="panel-title">{{ $poll->title }}</h1>
+                    </div>
+                    <div class="panel-body">
                         @include('poll.forms.vote')
                         @if ($poll->multiple_choice)
-                            <span class="badge-user text-bold text-red">@lang('poll.multiple-choice')</span>
+                            <span class="badge-user text-bold text-red poll-note">@lang('poll.multiple-choice')</span>
                         @endif
                     </div>
                 </div>


### PR DESCRIPTION
1. Fixes current look of polls (homepage block and separate page). It's better to have options on new lines (especially if the titles are long).

    Before:
    ![2021-05-18_192909](https://user-images.githubusercontent.com/82098328/118690704-fab3b180-b810-11eb-9a37-c285538a913d.png)

    After:
    ![2021-05-18_193904](https://user-images.githubusercontent.com/82098328/118691081-6269fc80-b811-11eb-9f72-3708e20a43a3.png)

2. Don't auto-add question mark at the end of poll title. It's counter-intuitive and doesn't allow to create titles like: "Yes or no? You decide!"