### PR TITLE
(Fix) Set IMDB to zero by default, don't check it in js

### DIFF
--- a/resources/js/unit3d/helper.js
+++ b/resources/js/unit3d/helper.js
@@ -162,7 +162,7 @@ class uploadExtensionBuilder {
         let tmdb = document.querySelector('#autotmdb');
         let imdb = document.querySelector('#autoimdb');
 
-        if (!name.value.trim() && !tmdb.value.trim() && !imdb.value.trim()) {
+        if (!name.value.trim() && !tmdb.value.trim()) {
             let torrent = document.querySelector('#torrent');
             let release;
             if (!name.value) {

--- a/resources/views/torrent/upload.blade.php
+++ b/resources/views/torrent/upload.blade.php
@@ -150,7 +150,14 @@
                         <div class="form-group">
                             <label for="name">IMDB ID <b>(@lang('torrent.optional'))</b></label>
                             <label>
-                                <input type="number" name="imdb" id="autoimdb" class="form-control" value="{{ !empty($imdb) ? $imdb : old('imdb') }}" required>
+                                @php $imdb_val = 0;
+                                if (!empty($imdb)) {
+                                    $imdb_val = $imdb;
+                                }
+                                if (!empty(old('imdb'))) {
+                                    $imdb_val = old('imdb');
+                                } @endphp
+                                <input type="number" name="imdb" id="autoimdb" class="form-control" value="{{ $imdb_val }}">
                             </label>
                         </div>
                     @else


### PR DESCRIPTION
A small addition to previous PR #1760.

IMDB form field became empty after my recent changes, this commit makes sure "0" is there by default if it was neither passed as a GET argument, nor taken from session (in case of errors after clicking Upload).