### PR TITLE
(Add) Use a different color for visited torrent links

### DIFF
--- a/resources/sass/main/_custom.scss
+++ b/resources/sass/main/_custom.scss
@@ -5879,6 +5879,10 @@ a.view-torrent:hover {
     -webkit-text-fill-color: transparent;
 }
 
+a.view-torrent:visited {
+    color: #8768e0;
+}
+
 .profile-footer {
     height: auto;
     min-height: 70px;

--- a/resources/sass/themes/galactic.scss
+++ b/resources/sass/themes/galactic.scss
@@ -436,9 +436,13 @@ tr.success > td {
 
 a.view-torrent,
 a.view-torrent:hover {
-    color: var(--text-color) !important;
+    color: var(--text-color);
     background: 0 0;
-    -webkit-text-fill-color: var(--text-color);
+    -webkit-text-fill-color: initial;
+}
+
+a.view-torrent:visited {
+    color: #A295FE;
 }
 
 .form-control {


### PR DESCRIPTION
It's helpful to know what torrents you've already viewed (especially on trackers with long/non-English titles).

For Light theme color is the same as in `linear-gradient` on hover:

![2021-05-18_212144](https://user-images.githubusercontent.com/82098328/118703972-52591980-b81f-11eb-9a10-bd232b272018.png)

For Dark themes color is a bit brighter (inherited by all dark themes):

![2021-05-18_212211](https://user-images.githubusercontent.com/82098328/118703997-57b66400-b81f-11eb-81d0-8ff712e07e8e.png)