### PR TITLE
(Fix) Set Light theme as default for new users

### DIFF
--- a/config/other.php
+++ b/config/other.php
@@ -156,7 +156,7 @@ return [
     | 7 = Dark Teal Theme
     | 8 = Dark Yellow Theme
     */
-    'default_style' => 2,
+    'default_style' => 0,
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
I know it's subjective but Light theme is more suitable for newly registered users, IMO.
Those who like dark styles can always change it later in their profiles.
Also Light theme is the only one that uses randomized images in footer (other themes have `background-image: none`).