### PR TITLE
(Update) Improve Linkify, escape special chars for BBcode

### DIFF
--- a/app/Helpers/Linkify.php
+++ b/app/Helpers/Linkify.php
@@ -13,19 +13,17 @@
 
 namespace App\Helpers;
 
+use VStelmakh\UrlHighlight\UrlHighlight;
+
 class Linkify
 {
     /**
      * @var string
      */
-    private const REG_EX_URL = "/^(?!\[url=)(http|https|ftp|ftps)\:\/\/[a-zA-Z0-9\-\.]+\.[a-zA-Z]{2,3}(\/\S*)/";
-
     public function linky($text)
     {
-        if (\preg_match(self::REG_EX_URL, $text, $url)) {
-            return \preg_replace(self::REG_EX_URL, \sprintf("<a href='%s'>%s</a> ", $url[0], $url[0]), $text);
-        }
+        $urlHighlight = new UrlHighlight();
 
-        return $text;
+        return $urlHighlight->highlightUrls($text);
     }
 }

--- a/app/Http/Controllers/TorrentController.php
+++ b/app/Http/Controllers/TorrentController.php
@@ -1202,9 +1202,9 @@ class TorrentController extends Controller
         $linkify = new Linkify();
 
         $previewContent = $joyPixel->toImage(
-            $bbcode->parse(
-                $linkify->linky($request->input('description')
-            ), true)
+            $linkify->linky(
+                $bbcode->parse($request->input('description'), true)
+            )
         );
 
         return \response()->json($previewContent);

--- a/app/Models/Article.php
+++ b/app/Models/Article.php
@@ -119,7 +119,7 @@ class Article extends Model
      */
     public function setContentAttribute($value)
     {
-        $this->attributes['content'] = (new AntiXSS())->xss_clean($value);
+        $this->attributes['content'] = \htmlspecialchars((new AntiXSS())->xss_clean($value), ENT_NOQUOTES);
     }
 
     /**
@@ -132,6 +132,6 @@ class Article extends Model
         $bbcode = new Bbcode();
         $linkify = new Linkify();
 
-        return $bbcode->parse($linkify->linky($this->content), true);
+        return $linkify->linky($bbcode->parse($this->content, true));
     }
 }

--- a/app/Models/Comment.php
+++ b/app/Models/Comment.php
@@ -14,6 +14,7 @@
 namespace App\Models;
 
 use App\Helpers\Bbcode;
+use App\Helpers\Linkify;
 use App\Traits\Auditable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -130,7 +131,7 @@ class Comment extends Model
      */
     public function setContentAttribute($value)
     {
-        $this->attributes['content'] = (new AntiXSS())->xss_clean($value);
+        $this->attributes['content'] = \htmlspecialchars((new AntiXSS())->xss_clean($value), ENT_NOQUOTES);
     }
 
     /**
@@ -141,8 +142,9 @@ class Comment extends Model
     public function getContentHtml()
     {
         $bbcode = new Bbcode();
+        $linkify = new Linkify();
 
-        return $bbcode->parse($this->content, true);
+        return $linkify->linky($bbcode->parse($this->content, true));
     }
 
     /**

--- a/app/Models/Message.php
+++ b/app/Models/Message.php
@@ -113,7 +113,7 @@ class Message extends Model
      */
     public function setMessageAttribute($value)
     {
-        $this->attributes['message'] = (new AntiXSS())->xss_clean($value);
+        $this->attributes['message'] = \htmlspecialchars((new AntiXSS())->xss_clean($value), ENT_NOQUOTES);
     }
 
     /**

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -114,7 +114,7 @@ class Post extends Model
      */
     public function setContentAttribute($value)
     {
-        $this->attributes['content'] = (new AntiXSS())->xss_clean($value);
+        $this->attributes['content'] = \htmlspecialchars((new AntiXSS())->xss_clean($value), ENT_NOQUOTES);
     }
 
     /**
@@ -127,7 +127,7 @@ class Post extends Model
         $bbcode = new Bbcode();
         $linkify = new Linkify();
 
-        return $bbcode->parse($linkify->linky($this->content), true);
+        return $linkify->linky($bbcode->parse($this->content, true));
     }
 
     /**

--- a/app/Models/PrivateMessage.php
+++ b/app/Models/PrivateMessage.php
@@ -89,7 +89,7 @@ class PrivateMessage extends Model
      */
     public function setMessageAttribute($value)
     {
-        $this->attributes['message'] = (new AntiXSS())->xss_clean($value);
+        $this->attributes['message'] = \htmlspecialchars((new AntiXSS())->xss_clean($value), ENT_NOQUOTES);
     }
 
     /**
@@ -102,6 +102,6 @@ class PrivateMessage extends Model
         $bbcode = new Bbcode();
         $linkify = new Linkify();
 
-        return $bbcode->parse($linkify->linky($this->message), true);
+        return $linkify->linky($bbcode->parse($this->message, true));
     }
 }

--- a/app/Models/Torrent.php
+++ b/app/Models/Torrent.php
@@ -356,7 +356,7 @@ class Torrent extends Model
      */
     public function setDescriptionAttribute($value)
     {
-        $this->attributes['description'] = (new AntiXSS())->xss_clean($value);
+        $this->attributes['description'] = \htmlspecialchars((new AntiXSS())->xss_clean($value), ENT_NOQUOTES);
     }
 
     /**
@@ -369,7 +369,7 @@ class Torrent extends Model
         $bbcode = new Bbcode();
         $linkify = new Linkify();
 
-        return $bbcode->parse($linkify->linky($this->description), true);
+        return $linkify->linky($bbcode->parse($this->description, true));
     }
 
     /**

--- a/app/Models/TorrentRequest.php
+++ b/app/Models/TorrentRequest.php
@@ -218,7 +218,7 @@ class TorrentRequest extends Model
      */
     public function setDescriptionAttribute($value)
     {
-        $this->attributes['description'] = (new AntiXSS())->xss_clean($value);
+        $this->attributes['description'] = \htmlspecialchars((new AntiXSS())->xss_clean($value), ENT_NOQUOTES);
     }
 
     /**
@@ -231,7 +231,7 @@ class TorrentRequest extends Model
         $bbcode = new Bbcode();
         $linkify = new Linkify();
 
-        return $bbcode->parse($linkify->linky($this->description), true);
+        return $linkify->linky($bbcode->parse($this->description, true));
     }
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -848,7 +848,7 @@ class User extends Authenticatable
      */
     public function setSignatureAttribute($value)
     {
-        $this->attributes['signature'] = (new AntiXSS())->xss_clean($value);
+        $this->attributes['signature'] = \htmlspecialchars((new AntiXSS())->xss_clean($value), ENT_NOQUOTES);
     }
 
     /**
@@ -861,7 +861,7 @@ class User extends Authenticatable
         $bbcode = new Bbcode();
         $linkify = new Linkify();
 
-        return $bbcode->parse($linkify->linky($this->signature), true);
+        return $linkify->linky($bbcode->parse($this->signature, true));
     }
 
     /**
@@ -873,7 +873,7 @@ class User extends Authenticatable
      */
     public function setAboutAttribute($value)
     {
-        $this->attributes['about'] = (new AntiXSS())->xss_clean($value);
+        $this->attributes['about'] = \htmlspecialchars((new AntiXSS())->xss_clean($value), ENT_NOQUOTES);
     }
 
     /**
@@ -889,7 +889,7 @@ class User extends Authenticatable
         $bbcode = new Bbcode();
         $linkify = new Linkify();
 
-        return $bbcode->parse($linkify->linky($this->about), true);
+        return $linkify->linky($bbcode->parse($this->about, true));
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,8 @@
         "spiral/roadrunner": "^2.0",
         "symfony/dom-crawler": "^2.7|^3.0",
         "theodorejb/polycast": "^1.0",
-        "voku/anti-xss": "^4.1"
+        "voku/anti-xss": "^4.1",
+        "vstelmakh/url-highlight": "^3.0"
     },
     "require-dev": {
         "facade/ignition": "^2.3.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4e0e7c96f54b117afa52f209671da15f",
+    "content-hash": "3a728868e114edd406676e8ac12a8bc2",
     "packages": [
         {
             "name": "andkab/laravel-joypixels",
@@ -8683,6 +8683,64 @@
                 }
             ],
             "time": "2020-12-02T01:58:49+00:00"
+        },
+        {
+            "name": "vstelmakh/url-highlight",
+            "version": "v3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/vstelmakh/url-highlight.git",
+                "reference": "294fe9bfb36e3cacd6d93b378400ad8becefa10a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/vstelmakh/url-highlight/zipball/294fe9bfb36e3cacd6d93b378400ad8becefa10a",
+                "reference": "294fe9bfb36e3cacd6d93b378400ad8becefa10a",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "php": "^7.1 || ^8",
+                "symfony/polyfill-php72": "^1.10"
+            },
+            "require-dev": {
+                "phpbench/phpbench": "^0.16 || ^0.17",
+                "phpstan/phpstan": "^0.12",
+                "phpunit/phpunit": "^7.5.3 || ^8 || ^9",
+                "squizlabs/php_codesniffer": "^3.5",
+                "vstelmakh/covelyzer": "^0.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "VStelmakh\\UrlHighlight\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Volodymyr Stelmakh",
+                    "homepage": "https://github.com/vstelmakh"
+                }
+            ],
+            "description": "Library to parse urls from string input",
+            "homepage": "https://github.com/vstelmakh/url-highlight",
+            "keywords": [
+                "clickable",
+                "extract",
+                "html",
+                "parser",
+                "url"
+            ],
+            "support": {
+                "issues": "https://github.com/vstelmakh/url-highlight/issues",
+                "source": "https://github.com/vstelmakh/url-highlight/tree/v3.0.0"
+            },
+            "time": "2020-11-05T21:10:03+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/resources/sass/main/_custom.scss
+++ b/resources/sass/main/_custom.scss
@@ -6901,10 +6901,6 @@ time {
     color: #212121;
 }
 
-.topic .topic-posts .post article.post-content span span {
-    font-size: 2em;
-}
-
 .topic .topic-posts .post article.post-content img {
     max-width: 100%;
 }


### PR DESCRIPTION
1. Fixes issues with `<` and `>` characters in BBcode. Currently this text:
    ```
    [size=13][b]Kanojo no Ura Sekai[/b] [i]<TOSHIRO SIDE>[/i][/size]
    ```
    Produces the following HTML:
    ```html
    <span style="font-size: 13px;"><span style="font-weight: bold;">Kanojo no Ura Sekai</span>&nbsp;
    <em><toshiro side=""></toshiro></em></span>
    ```
    Notice the wrong `<toshiro>` tags.
    Also `<span>` inside `<span>` caused text to be big (wrong style removed).

2. Improves Linkify function.
    Current regex is outdated and doesn't work for domains with 4+ chars (like `unit3d.site`) because of `[a-zA-Z]{2,3}`.
    In general, finding and highlighting links is not a simple task, so it's better to use a dedicated package.
    I compared all modern ones and [vstelmakh/url-highlight](https://github.com/vstelmakh/url-highlight) seemed to be the best. See [examples](https://github.com/vstelmakh/url-highlight/blob/master/docs/examples.md).
    It works fine with existing urls, that's why it was necessary to put `->linky` last after `->parse`. Different order caused incorrect html.