### PR TITLE
(Fix) Add subtitle file validation, remove .ico, edit rules

### DIFF
--- a/app/Http/Controllers/SubtitleController.php
+++ b/app/Http/Controllers/SubtitleController.php
@@ -95,7 +95,7 @@ class SubtitleController extends Controller
             'title'       => 'required',
             'file_name'   => 'required',
             'file_size'   => 'required',
-            'extension'   => 'required',
+            'extension'   => 'required|in:.srt,.ass,.sup,.zip',
             'language_id' => 'required',
             'user_id'     => 'required',
             'torrent_id'  => 'required',

--- a/resources/lang/en/subtitle.php
+++ b/resources/lang/en/subtitle.php
@@ -17,19 +17,18 @@ return [
     'delete-confirm'              => 'Are You Sure You Want To Delete This?',
     'note'                        => 'Note',
     'note-help'                   => 'Extra Info for this subtitle',
-    'rules-title'                 => 'Subtitle Rules!',
+    'rules-title'                 => 'Subtitle Rules',
     'rules'                       => '<ul>
-                                        <li>Only proper subtitles are allowed to be uploaded (Correct frame rate. translation, spelling, timing).</li>
-                                        <li>No google translated / machine translated / incorrect subtitles allowed.</li>
-                                        <li>Subtitle must be in sync with the video.</li>
-                                        <li>.srt, .ico and .zip only allowed. <b>(.zip is only allowed when bundeling subtitles of the same language for a TV Season Pack.)</b></li>
-                                        <li>Repeated uploads of junk sub will constitute a violation and subject to disciplinary action.</li>
-                                        <li>Keep the note of the subtitle short. NO urls/links are allowed.</li>
-                                        <li>All Subtitles must be confirmed, verified, timed correctly for the specific Torrent/Video.</li>
+                                        <li>Only proper subtitles are allowed (correct frame rate, translation, spelling, timing)</li>
+                                        <li>No Google-translated, machine-translated and incorrect subtitles</li>
+                                        <li>Subtitles must be in sync with the video</li>
+                                        <li>ZIP archives are only allowed for SUB+IDX or as bundles of the same language for a TV season pack</li>
+                                        <li>Repeated uploads of junk subs will constitute a violation and subject to a disciplinary action</li>
+                                        <li>Keep the Note of the subtitle short, NO urls/links are allowed</li>
                                       </ul>',
     'size'                        => 'Size',
     'subtitle-file'               => 'Subtitle File',
-    'subtitle-file-types'         => 'Accepted files are ICO, SRT, SUP, ASS and ZIP',
+    'subtitle-file-types'         => 'Accepted files are SRT, ASS, SUP and ZIP',
     'uploaded'                    => 'Uploaded',
     'uploader'                    => 'Uploader',
 ];

--- a/resources/views/subtitle/create.blade.php
+++ b/resources/views/subtitle/create.blade.php
@@ -42,7 +42,7 @@
                 <div class="form-group">
                     <label for="subtitle_file" class="col-sm-2 control-label">@lang('subtitle.subtitle-file')</label>
                     <div class="col-sm-9">
-                        <input class="form-control" name="subtitle_file" accept=".srt,.ico,.zip,.ass,.sup"  type="file" id="subtitle_file">
+                        <input class="form-control" name="subtitle_file" accept=".srt,.ass,.sup,.zip" type="file" id="subtitle_file">
                         <span class="help-block">@lang('subtitle.subtitle-file-types')</span>
                     </div>
                 </div>


### PR DESCRIPTION
Fixes the following issues with subtitles:
1. Remove .ICO from allowed extensions (not a subtitle file)
2. Add backend check for allowed extensions
3. Improve rules text