### PR TITLE
(Fix) Remove line breaks from BBcode, fix URLs without scheme in Linkify, add noreferrer

### DIFF
--- a/app/Helpers/Bbcode.php
+++ b/app/Helpers/Bbcode.php
@@ -117,26 +117,13 @@ class Bbcode
 
         'quote' => [
             'pattern' => '/\[quote\](.*?)\[\/quote\]/s',
-            'replace' => '<ul class="media-list comments-list">
-                          <li class="media" style="border-left-width: 5px; border-left-style: solid; border-left-color: #01bc8c;">
-                          <div class="media-body">
-                          <div class="pt-5">$1</div>
-                          </div>
-                          </li>
-                          </ul>',
+            'replace' => '<ul class="media-list comments-list"><li class="media" style="border-left-width: 5px; border-left-style: solid; border-left-color: #01bc8c;"><div class="media-body"><div class="pt-5">$1</div></div></li></ul>',
             'content' => '$1',
         ],
 
         'namedquote' => [
             'pattern' => '/\[quote\=(.*?)\](.*)\[\/quote\]/s',
-            'replace' => '<ul class="media-list comments-list">
-                          <li class="media" style="border-left-width: 5px; border-left-style: solid; border-left-color: #01bc8c;">
-                          <div class="media-body">
-                          <strong><span><i class="fas fa-quote-left"></i> Quoting $1 :</span></strong>
-                          <div class="pt-5">$2</div>
-                          </div>
-                          </li>
-                          </ul>',
+            'replace' => '<ul class="media-list comments-list"><li class="media" style="border-left-width: 5px; border-left-style: solid; border-left-color: #01bc8c;"><div class="media-body"><strong><span><i class="fas fa-quote-left"></i> Quoting $1 :</span></strong><div class="pt-5">$2</div></div></li></ul>',
             'content' => '$2',
         ],
 
@@ -250,22 +237,19 @@ class Bbcode
 
         'youtube' => [
             'pattern' => '/\[youtube\](.*?)\[\/youtube\]/s',
-            'replace' => '<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/$1?rel=0"
-                            frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>',
+            'replace' => '<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/$1?rel=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>',
             'content' => '$1',
         ],
 
         'video' => [
             'pattern' => '/\[video\](.*?)\[\/video\]/s',
-            'replace' => '<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/$1?rel=0"
-                            frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>',
+            'replace' => '<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/$1?rel=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>',
             'content' => '$1',
         ],
 
         'video-youtube' => [
             'pattern' => '/\[video="youtube"\](.*?)\[\/video\]/s',
-            'replace' => '<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/$1?rel=0"
-                            frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>',
+            'replace' => '<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/$1?rel=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>',
             'content' => '$1',
         ],
 

--- a/app/Helpers/Linkify.php
+++ b/app/Helpers/Linkify.php
@@ -14,6 +14,8 @@
 namespace App\Helpers;
 
 use VStelmakh\UrlHighlight\UrlHighlight;
+use VStelmakh\UrlHighlight\Validator\Validator;
+use VStelmakh\UrlHighlight\Highlighter\HtmlHighlighter;
 
 class Linkify
 {
@@ -22,7 +24,21 @@ class Linkify
      */
     public function linky($text)
     {
-        $urlHighlight = new UrlHighlight();
+        $validator = new Validator(
+            false, // bool - if should use top level domain to match urls without scheme
+            [],    // string[] - array of blacklisted schemes
+            [],    // string[] - array of whitelisted schemes
+            true   // bool - if should match emails (if match by TLD set to "false" - will match only "mailto" urls)
+        );
+
+        $highlighter = new HtmlHighlighter(
+            'http', // string - scheme to use for urls matched by top level domain
+            ['rel' => 'noopener noreferrer'], // string[] - key/value map of tag attributes
+            '',     // string - content to add before highlight: {here}<a...
+            ''      // string - content to add after highlight: ...</a>{here}
+        );
+
+        $urlHighlight = new UrlHighlight($validator, $highlighter);
 
         return $urlHighlight->highlightUrls($text);
     }


### PR DESCRIPTION
Fixes these issues:
1. Extra `<br>` tags are added to forum quotes and youtube embeds (which breaks formatting and Linkify behavior)
2. Linkifier converted some text that shouldn't be a link, like "[My.Little.House](http://little.house/).HDTV". Since `.house` is a top level domain, it became a link. I disabled matching URLs that don't have a scheme (http/https/ftp and so on)
3. It's best to use `noopener noreferrer` attributes to prevent official websites to see where the links have been posted