### PR TITLE
(Refactor) Modal styles and markup, center vertically, fix Light theme styles

### DIFF
--- a/app/Helpers/Helpers.php
+++ b/app/Helpers/Helpers.php
@@ -100,3 +100,10 @@ if (! function_exists('tmdbImage')) {
         return \str_replace('/original/', '/'.$new.'/', $original);
     }
 }
+
+if (! function_exists('modalStyle')) {
+    function modal_style()
+    {
+        return (auth()->user()->style == 0) ? '' : ' modal-dark';
+    }
+}

--- a/resources/sass/main/_custom.scss
+++ b/resources/sass/main/_custom.scss
@@ -3566,8 +3566,18 @@ button.close {
 
 .modal-dialog {
     position: relative;
-    width: auto;
-    margin: 10px;
+    display: flex;
+    align-items: center;
+}
+
+.modal-dialog, .modal > form {
+    height: 100%;
+    width: 100%;
+    pointer-events: none;
+}
+
+.modal form > .form-group {
+    margin: 0;
 }
 
 .modal-content {
@@ -3577,6 +3587,13 @@ button.close {
     border-radius: 0;
     box-shadow: 0 3px 9px rgba(0, 0, 0, 0.5);
     outline: 0;
+    min-width: 600px;
+    margin: 0 auto;
+    pointer-events: auto;
+}
+
+.modal-content .table {
+    margin: 0;
 }
 
 .modal-backdrop {
@@ -3661,7 +3678,7 @@ button.close {
 @media (min-width: 768px) {
     .modal-dialog {
         width: 600px;
-        margin: 30px auto;
+        margin: 0 auto;
     }
     .modal-content {
         box-shadow: 0 5px 15px rgba(0, 0, 0, 0.5);

--- a/resources/views/Staff/application/show.blade.php
+++ b/resources/views/Staff/application/show.blade.php
@@ -126,7 +126,7 @@
                                         <form method="POST"
                                             action="{{ route('staff.applications.approve', ['id' => $application->id]) }}">
                                             @csrf
-                                            <div class="modal-dialog modal-dark">
+                                            <div class="modal-dialog{{ \modal_style() }}">
                                                 <div class="modal-content">
                                                     <div class="modal-header">
                                                         <button type="button" class="close"
@@ -167,7 +167,7 @@
                                         <form method="POST"
                                             action="{{ route('staff.applications.reject', ['id' => $application->id]) }}">
                                             @csrf
-                                            <div class="modal-dialog modal-dark">
+                                            <div class="modal-dialog{{ \modal_style() }}">
                                                 <div class="modal-content">
                                                     <div class="modal-header">
                                                         <button type="button" class="close"

--- a/resources/views/Staff/chat/room/chatroom_modals.blade.php
+++ b/resources/views/Staff/chat/room/chatroom_modals.blade.php
@@ -1,5 +1,5 @@
 <div id="editChatroom-{{ $chatroom->id }}" class="modal fade" tabindex="-1" role="dialog">
-    <div class="modal-dialog modal-dark">
+    <div class="modal-dialog{{ \modal_style() }}">
         <div class="modal-content">
 
             <div class="modal-header" style="text-align: center;">
@@ -17,8 +17,8 @@
                 </div>
 
                 <div class="modal-footer">
-                    <button class="btn btn-md btn-default" data-dismiss="modal">@lang('common.cancel')</button>
-                    <input class="btn btn-md btn-primary" type="submit">
+                    <button class="btn btn-md btn-primary" data-dismiss="modal">@lang('common.cancel')</button>
+                    <input class="btn btn-md btn-success" type="submit">
                 </div>
             </form>
         </div>
@@ -26,7 +26,7 @@
 </div>
 
 <div id="deleteChatroom-{{ $chatroom->id }}" class="modal fade" tabindex="-1" role="dialog">
-    <div class="modal-dialog modal-dark">
+    <div class="modal-dialog{{ \modal_style() }}">
         <div class="modal-content">
 
             <div class="modal-header">
@@ -38,11 +38,11 @@
                 @csrf
                 @method('DELETE')
                 <div class="modal-body">
-                    <p>Are you sure about this ?</p>
+                    <p>Are you sure about this?</p>
                 </div>
 
                 <div class="modal-footer">
-                    <button type="button" class="btn btn-md btn-default"
+                    <button type="button" class="btn btn-md btn-primary"
                         data-dismiss="modal">@lang('common.cancel')</button>
                     <input class="btn btn-md btn-danger" type="submit">
                 </div>

--- a/resources/views/Staff/chat/room/index.blade.php
+++ b/resources/views/Staff/chat/room/index.blade.php
@@ -16,18 +16,18 @@
 @section('content')
     <div class="container box">
         <h2>@lang('common.chat-rooms')</h2>
-    
+
         <button class="btn btn-primary" data-toggle="modal" data-target="#addChatroom">
             @lang('common.add') @lang('common.chat-room')
         </button>
         <div id="addChatroom" class="modal fade" tabindex="-1" role="dialog">
-            <div class="modal-dialog modal-dark">
+            <div class="modal-dialog{{ \modal_style() }}">
                 <div class="modal-content">
-    
+
                     <div class="modal-header" style="text-align: center;">
                         <h3>@lang('common.add') @lang('common.chat-room')</h3>
                     </div>
-    
+
                     <form class="form-horizontal" role="form" method="POST" action="{{ route('staff.rooms.store') }}">
                         @csrf
                         <div class="modal-body" style="text-align: center;">
@@ -36,16 +36,16 @@
                                 style="margin:0 auto; width:300px;" type="text" class="form-control" name="name" id="name"
                                 placeholder="Enter @lang('common.name') Here..." required>
                         </div>
-    
+
                         <div class="modal-footer">
-                            <button class="btn btn-md btn-default" data-dismiss="modal">@lang('common.cancel')</button>
-                            <input class="btn btn-md btn-primary" type="submit">
+                            <button class="btn btn-md btn-primary" data-dismiss="modal">@lang('common.cancel')</button>
+                            <input class="btn btn-md btn-success" type="submit">
                         </div>
                     </form>
                 </div>
             </div>
         </div>
-    
+
         <div class="table-responsive">
             <table class="table table-condensed table-striped table-bordered table-hover">
                 <thead>

--- a/resources/views/Staff/chat/status/chatstatuses_modals.blade.php
+++ b/resources/views/Staff/chat/status/chatstatuses_modals.blade.php
@@ -1,5 +1,5 @@
 <div id="editChatStatus-{{ $chatstatus->id }}" class="modal fade" tabindex="-1" role="dialog">
-    <div class="modal-dialog modal-dark">
+    <div class="modal-dialog{{ \modal_style() }}">
         <div class="modal-content">
 
             <div class="modal-header" style="text-align: center;">
@@ -23,8 +23,8 @@
                 </div>
 
                 <div class="modal-footer">
-                    <button class="btn btn-md btn-default" data-dismiss="modal">@lang('common.cancel')</button>
-                    <input class="btn btn-md btn-primary" type="submit">
+                    <button class="btn btn-md btn-primary" data-dismiss="modal">@lang('common.cancel')</button>
+                    <input class="btn btn-md btn-success" type="submit">
                 </div>
             </form>
         </div>
@@ -32,7 +32,7 @@
 </div>
 
 <div id="deleteChatStatus-{{ $chatstatus->id }}" class="modal fade" tabindex="-1" role="dialog">
-    <div class="modal-dialog modal-dark">
+    <div class="modal-dialog{{ \modal_style() }}">
         <div class="modal-content">
 
             <div class="modal-header">
@@ -44,11 +44,11 @@
                 @csrf
                 @method('DELETE')
                 <div class="modal-body">
-                    <p>Are you sure about this ?</p>
+                    <p>Are you sure about this?</p>
                 </div>
 
                 <div class="modal-footer">
-                    <button type="button" class="btn btn-md btn-default"
+                    <button type="button" class="btn btn-md btn-primary"
                         data-dismiss="modal">@lang('common.cancel')</button>
                     <input class="btn btn-md btn-danger" type="submit">
                 </div>

--- a/resources/views/Staff/chat/status/index.blade.php
+++ b/resources/views/Staff/chat/status/index.blade.php
@@ -16,18 +16,18 @@
 @section('content')
     <div class="container box">
         <h2>@lang('common.user') @lang('staff.chat') @lang('staff.statuses')</h2>
-    
+
         <button class="btn btn-primary" data-toggle="modal" data-target="#addChatStatus">
             @lang('common.add') @lang('staff.chat') @lang('staff.status')
         </button>
         <div id="addChatStatus" class="modal fade" tabindex="-1" role="dialog">
-            <div class="modal-dialog modal-dark">
+            <div class="modal-dialog{{ \modal_style() }}">
                 <div class="modal-content">
-    
+
                     <div class="modal-header" style="text-align: center;">
                         <h3>@lang('common.add') @lang('staff.chat') @lang('staff.status')</h3>
                     </div>
-    
+
                     <form class="form-horizontal" role="form" method="POST" action="{{ route('staff.statuses.store') }}">
                         @csrf
                         <div class="modal-body" style="text-align: center;">
@@ -42,16 +42,16 @@
                                 style="margin:0 auto; width:300px;" type="text" class="form-control" name="icon" id="icon"
                                 placeholder="Enter Font Awesome Code Here..." required>
                         </div>
-    
+
                         <div class="modal-footer">
-                            <button class="btn btn-md btn-default" data-dismiss="modal">@lang('common.cancel')</button>
-                            <input class="btn btn-md btn-primary" type="submit">
+                            <button class="btn btn-md btn-primary" data-dismiss="modal">@lang('common.cancel')</button>
+                            <input class="btn btn-md btn-success" type="submit">
                         </div>
                     </form>
                 </div>
             </div>
         </div>
-    
+
         <div class="table-responsive">
             <table class="table table-condensed table-striped table-bordered table-hover">
                 <thead>

--- a/resources/views/Staff/moderation/index.blade.php
+++ b/resources/views/Staff/moderation/index.blade.php
@@ -69,7 +69,7 @@
                                  aria-hidden="true">
                                 <form method="POST" action="{{ route('staff.moderation.postpone') }}">
                                     @csrf
-                                    <div class="modal-dialog modal-dark">
+                                    <div class="modal-dialog{{ \modal_style() }}">
                                         <div class="modal-content">
                                             <div class="modal-header">
                                                 <button type="button" class="close" data-dismiss="modal"
@@ -101,7 +101,7 @@
                                                 </div>
                                             </div>
                                             <div class="modal-footer">
-                                                <button class="btn btn-sm btn-default"
+                                                <button class="btn btn-sm btn-primary"
                                                         data-dismiss="modal">@lang('common.close')</button>
                                             </div>
                                         </div>
@@ -119,7 +119,7 @@
                             <div class="modal fade" id="pendreject-{{ $p->id }}" tabindex="-1" role="dialog" aria-hidden="true">
                                 <form method="POST" action="{{ route("staff.moderation.reject") }}">
                                     @csrf
-                                    <div class="modal-dialog modal-dark">
+                                    <div class="modal-dialog{{ \modal_style() }}">
                                         <div class="modal-content">
                                             <div class="modal-header">
                                                 <button type="button" class="close" data-dismiss="modal"
@@ -137,8 +137,7 @@
                                                     <input id="slug" type="hidden" name="slug" value="{{ $p->slug }}">
                                                     <label for="file_name" class="col-sm-2 control-label">@lang('torrent.torrent')</label>
                                                     <div class="col-sm-10">
-                                                        <label id="title" name="title" type="hidden">{{ $p->name }}</label>
-                                                        <p class="form-control-static">{{ $p->name }}</p>
+                                                        <p id="title" name="title" class="form-control-static">{{ $p->name }}</p>
                                                     </div>
                                                 </div>
                                                 <div class="form-group">
@@ -158,7 +157,7 @@
                                                 </div>
                                             </div>
                                             <div class="modal-footer">
-                                                <button class="btn btn-sm btn-default"
+                                                <button class="btn btn-sm btn-primary"
                                                         data-dismiss="modal">@lang('common.close')</button>
                                             </div>
                                         </div>
@@ -235,7 +234,7 @@
                                  aria-hidden="true">
                                 <form method="POST" action="{{ route('delete') }}">
                                     @csrf
-                                    <div class="modal-dialog modal-dark">
+                                    <div class="modal-dialog{{ \modal_style() }}">
                                         <div class="modal-content">
                                             <div class="modal-header">
                                                 <button type="button" class="close" data-dismiss="modal"
@@ -254,8 +253,7 @@
                                                     <label for="file_name"
                                                            class="col-sm-2 control-label">@lang('torrent.torrent')</label>
                                                     <div class="col-sm-10">
-                                                        <label id="title" name="title" type="hidden">{{ $post->name }}</label>
-                                                        <p class="form-control-static">{{ $post->name }}</p>
+                                                        <p id="title" name="title" class="form-control-static">{{ $post->name }}</p>
                                                     </div>
                                                 </div>
                                                 <div class="form-group">
@@ -273,7 +271,7 @@
                                                 </div>
                                             </div>
                                             <div class="modal-footer">
-                                                <button class="btn btn-sm btn-default"
+                                                <button class="btn btn-sm btn-primary"
                                                         data-dismiss="modal">@lang('common.close')</button>
                                             </div>
                                         </div>
@@ -348,7 +346,7 @@
                                  aria-hidden="true">
                                 <form method="POST" action="{{ route('staff.moderation.postpone') }}">
                                     @csrf
-                                    <div class="modal-dialog modal-dark">
+                                    <div class="modal-dialog{{ \modal_style() }}">
                                         <div class="modal-content">
                                             <div class="modal-header">
                                                 <button type="button" class="close" data-dismiss="modal"
@@ -380,7 +378,7 @@
                                                 </div>
                                             </div>
                                             <div class="modal-footer">
-                                                <button class="btn btn-sm btn-default" type="button"
+                                                <button class="btn btn-sm btn-primary" type="button"
                                                         data-dismiss="modal">@lang('common.close')</button>
                                             </div>
                                         </div>
@@ -401,7 +399,7 @@
                                  aria-hidden="true">
                                 <form method="POST" action=" {{ route('delete') }}">
                                     @csrf
-                                    <div class="modal-dialog modal-dark">
+                                    <div class="modal-dialog{{ \modal_style() }}">
                                         <div class="modal-content">
                                             <div class="modal-header">
                                                 <button type="button" class="close" data-dismiss="modal"
@@ -421,8 +419,7 @@
                                                     <label for="file_name"
                                                            class="col-sm-2 control-label">@lang('torrent.torrent')</label>
                                                     <div class="col-sm-10">
-                                                        <label id="title" name="title" type="hidden">{{ $reject->name }}</label>
-                                                        <p class="form-control-static">{{ $reject->name }}</p>
+                                                        <p id="title" name="title" class="form-control-static">{{ $reject->name }}</p>
                                                     </div>
                                                 </div>
                                                 <div class="form-group">
@@ -440,7 +437,7 @@
                                                 </div>
                                             </div>
                                             <div class="modal-footer">
-                                                <button class="btn btn-sm btn-default" type="button"
+                                                <button class="btn btn-sm btn-primary" type="button"
                                                         data-dismiss="modal">@lang('common.close')</button>
                                             </div>
                                         </div>

--- a/resources/views/livewire/graveyard-search.blade.php
+++ b/resources/views/livewire/graveyard-search.blade.php
@@ -398,15 +398,14 @@
 									</button>
 									<div class="modal fade" id="resurrect-{{ $torrent->id }}" tabindex="-1" role="dialog"
 									     aria-labelledby="resurrect">
-										<div class="modal-dialog modal-dark" role="document">
+										<div class="modal-dialog{{ \modal_style() }}" role="document">
 											<div class="modal-content">
 												<div class="modal-header">
 													<button type="button" class="close" data-dismiss="modal" aria-label="Close">
 														<span aria-hidden="true">&times;</span>
 													</button>
 													<h2>
-														<i
-																class="{{ config('other.font-awesome') }} fa-thumbs-up"></i>@lang('graveyard.resurrect')
+														<i class="{{ config('other.font-awesome') }} fa-thumbs-up"></i>@lang('graveyard.resurrect')
 														{{ strtolower(trans('torrent.torrent')) }} ?
 													</h2>
 												</div>
@@ -444,27 +443,27 @@
                                                         {{ config('graveyard.reward') }} @lang('torrent.freeleech') Token(s)!
                                                     </span>
 														</p>
-														<div class="btns">
-															<form id="resurrect-torrent" role="form" method="POST"
-															      action="{{ route('graveyard.store', ['id' => $torrent->id]) }}">
-																@csrf
-																@if (!$history)
-																	<label for="seedtime"></label><input hidden="seedtime" name="seedtime"
-																	                                     id="seedtime" value="{{ config('graveyard.time') }}">
-																@else
-																	<label for="seedtime"></label><input hidden="seedtime" name="seedtime"
-																	                                     id="seedtime"
-																	                                     value="{{ $history->seedtime + config('graveyard.time') }}">
-																@endif
-																<button type="submit" class="btn btn-success">
-																	@lang('graveyard.resurrect') !
-																</button>
-																<button type="button" class="btn btn-warning" data-dismiss="modal">
-																	@lang('common.cancel')
-																</button>
-															</form>
-														</div>
 													</div>
+												</div>
+												<div class="modal-footer">
+													<form id="resurrect-torrent" class="text-center" role="form" method="POST"
+													      action="{{ route('graveyard.store', ['id' => $torrent->id]) }}">
+														@csrf
+														@if (!$history)
+															<label for="seedtime"></label><input hidden="seedtime" name="seedtime"
+															                                     id="seedtime" value="{{ config('graveyard.time') }}">
+														@else
+															<label for="seedtime"></label><input hidden="seedtime" name="seedtime"
+															                                     id="seedtime"
+															                                     value="{{ $history->seedtime + config('graveyard.time') }}">
+														@endif
+														<button type="button" class="btn btn-primary" data-dismiss="modal">
+															@lang('common.cancel')
+														</button>
+														<button type="submit" class="btn btn-success">
+															@lang('graveyard.resurrect')
+														</button>
+													</form>
 												</div>
 											</div>
 										</div>

--- a/resources/views/partials/achievement_modal.blade.php
+++ b/resources/views/partials/achievement_modal.blade.php
@@ -1,6 +1,5 @@
-<div class="modal fade" id="modal-achievement" tabindex="-1" role="dialog" aria-labelledby="modal-achievement"
-    aria-hidden="true">
-    <div class="modal-dialog modal-dark modal-dialog-centered" role="document">
+<div class="modal fade" id="modal-achievement" tabindex="-1" role="dialog" aria-hidden="true">
+    <div class="modal-dialog{{ \modal_style() }} modal-dialog-centered" role="document">
         <div class="modal-content">
             <div class="modal-header mx-auto">
                 <div class="text-center">

--- a/resources/views/partials/modals.blade.php
+++ b/resources/views/partials/modals.blade.php
@@ -1,5 +1,5 @@
 <div class="modal fade" id="modal-comment-edit-{{ $comment->id }}" tabindex="-1" role="dialog" aria-hidden="true">
-    <div class="modal-dialog modal-dark">
+    <div class="modal-dialog{{ \modal_style() }}">
         <div class="modal-content">
             <meta charset="utf-8">
             <title>@lang('common.edit-your-comment')</title>

--- a/resources/views/playlist/show.blade.php
+++ b/resources/views/playlist/show.blade.php
@@ -284,7 +284,7 @@
 	</div>
 
 	<div class="modal fade" id="modal_playlist_torrent" tabindex="-1" role="dialog" aria-hidden="true">
-		<div class="modal-dialog modal-dark">
+		<div class="modal-dialog{{ \modal_style() }}">
 			<div class="modal-content">
 				<div class="container-fluid">
 					<form role="form" method="POST" action="{{ route('playlists.attach') }}">
@@ -306,11 +306,11 @@
 								</label>
 							</div>
 							<div class="form-group">
-								<input class="btn btn-primary" type="submit" value="@lang('common.save')">
+								<input class="btn btn-success" type="submit" value="@lang('common.save')">
 							</div>
 						</div>
 						<div class="modal-footer">
-							<button class="btn btn-sm btn-default" type="button" data-dismiss="modal">@lang('common.close')</button>
+							<button class="btn btn-sm btn-primary" type="button" data-dismiss="modal">@lang('common.close')</button>
 						</div>
 					</form>
 				</div>

--- a/resources/views/requests/request_modals.blade.php
+++ b/resources/views/requests/request_modals.blade.php
@@ -1,5 +1,5 @@
-<div class="modal fade" id="vote" tabindex="-1" role="dialog" aria-labelledby="vote">
-    <div class="modal-dialog modal-dark" role="document">
+<div class="modal fade" id="vote" tabindex="-1" role="dialog">
+    <div class="modal-dialog{{ \modal_style() }}" role="document">
         <div class="modal-content">
             <div class="modal-header">
                 <button type="button" class="close" data-dismiss="modal" aria-label="@lang('common.close')"><span
@@ -23,12 +23,13 @@
                             <label><input type="radio" name="anon" value="0" checked>@lang('common.no')</label>
                         </div>
                     </fieldset>
-                    <br>
-                    <div class="btns">
-                        <button type="button" class="btn btn-default"
+                </div>
+                <div class="modal-footer">
+                    <div class="text-center">
+                        <button type="button" class="btn btn-primary"
                             data-dismiss="modal">@lang('common.cancel')</button>
-                        <button type="submit" @if ($user->seedbonus < 100) disabled title='@lang('
-                                request.dont-have-bps')' @endif class="btn btn-success">@lang('request.vote')</button>
+                        <button type="submit" @if ($user->seedbonus < 100) disabled title="@lang('request.dont-have-bps')"
+                            @endif class="btn btn-success">@lang('request.vote')</button>
                     </div>
                 </div>
             </form>
@@ -36,8 +37,8 @@
     </div>
 </div>
 
-<div class="modal fade" id="fill" tabindex="-1" role="dialog" aria-labelledby="fill">
-    <div class="modal-dialog modal-dark" role="document">
+<div class="modal fade" id="fill" tabindex="-1" role="dialog">
+    <div class="modal-dialog{{ \modal_style() }}" role="document">
         <div class="modal-content">
             <div class="modal-header">
                 <button type="button" class="close" data-dismiss="modal" aria-label="@lang('common.close')"><span
@@ -62,9 +63,10 @@
                             <label><input type="radio" name="filled_anon" value="0" checked>@lang('common.no')</label>
                         </div>
                     </fieldset>
-                    <br>
-                    <div class="btns">
-                        <button type="button" class="btn btn-default"
+                </div>
+                <div class="modal-footer">
+                    <div class="text-center">
+                        <button type="button" class="btn btn-primary"
                             data-dismiss="modal">@lang('common.cancel')</button>
                         <button type="submit" class="btn btn-success">@lang('request.fill')</button>
                     </div>
@@ -74,8 +76,8 @@
     </div>
 </div>
 
-<div class="modal fade" id="reset" tabindex="-1" role="dialog" aria-labelledby="reset">
-    <div class="modal-dialog modal-dark" role="document">
+<div class="modal fade" id="reset" tabindex="-1" role="dialog">
+    <div class="modal-dialog{{ \modal_style() }}" role="document">
         <div class="modal-content">
             <div class="modal-header">
                 <button type="button" class="close" data-dismiss="modal" aria-label="@lang('common.close')"><span
@@ -86,11 +88,12 @@
                 @csrf
                 <div class="modal-body">
                     <p class="text-center">@lang('request.reset-confirmation')?</p>
-                    <div class="btns">
-                        <button type="button" class="btn btn-default"
+                </div>
+                <div class="modal-footer">
+                    <div class="text-center">
+                        <button type="button" class="btn btn-primary"
                             data-dismiss="modal">@lang('common.cancel')</button>
-                        <button type="submit" @if (!$user->group->is_modo || $torrentRequest->filled_hash == null)
-                                disabled
+                        <button type="submit" @if (!$user->group->is_modo || $torrentRequest->filled_hash == null) disabled
                             @endif class="btn btn-warning">@lang('request.reset')</button>
                     </div>
                 </div>
@@ -99,8 +102,8 @@
     </div>
 </div>
 
-<div class="modal fade" id="delete" tabindex="-1" role="dialog" aria-labelledby="delete">
-    <div class="modal-dialog modal-dark" role="document">
+<div class="modal fade" id="delete" tabindex="-1" role="dialog">
+    <div class="modal-dialog{{ \modal_style() }}" role="document">
         <div class="modal-content">
             <div class="modal-header">
                 <button type="button" class="close" data-dismiss="modal" aria-label="@lang('common.close')"><span
@@ -109,16 +112,16 @@
             </div>
             <form role="form" method="POST" action="{{ route('deleteRequest', ['id' => $torrentRequest->id]) }}">
                 @csrf
-                <div class="modal-body">
-                    <p class="text-center">@lang('request.delete-confirmation')?</p>
-                    <fieldset>
-                        <p>@lang('request.delete-filled').</p>
-                    </fieldset>
-                    <div class="btns">
-                        <button type="button" class="btn btn-default"
+                <div class="modal-body text-center">
+                    <p>@lang('request.delete-confirmation')?</p>
+                    <p>@lang('request.delete-filled').</p>
+                </div>
+                <div class="modal-footer">
+                    <div class="text-center">
+                        <button type="button" class="btn btn-primary"
                             data-dismiss="modal">@lang('common.cancel')</button>
                         <button type="submit" @if ($torrentRequest->filled_hash != null) disabled
-                            @endif class="btn btn-warning">@lang('common.delete')</button>
+                            @endif class="btn btn-danger">@lang('common.delete')</button>
                     </div>
                 </div>
             </form>
@@ -126,8 +129,8 @@
     </div>
 </div>
 
-<div class="modal fade" id="claim" tabindex="-1" role="dialog" aria-labelledby="claim">
-    <div class="modal-dialog modal-dark" role="document">
+<div class="modal fade" id="claim" tabindex="-1" role="dialog">
+    <div class="modal-dialog{{ \modal_style() }}" role="document">
         <div class="modal-content">
             <div class="modal-header">
                 <button type="button" class="close" data-dismiss="modal" aria-label="@lang('common.close')"><span
@@ -137,7 +140,7 @@
             <form role="form" method="POST" action="{{ route('claimRequest', ['id' => $torrentRequest->id]) }}">
                 @csrf
                 <div class="modal-body text-center">
-                    <p>@lang('request.claim-as-anon')?</p>
+                    <p>@lang('request.claim-as-anon')</p>
                     <br>
                     <fieldset>
                         <p>@lang('request.claim-anon-choose')</p>
@@ -148,13 +151,12 @@
                             <label><input type="radio" name="anon" value="0" checked>@lang('common.no')</label>
                         </div>
                     </fieldset>
-                    <br>
+                </div>
+                <div class="modal-footer">
                     <div class="text-center">
-                        <div class="btns">
-                            <button type="submit" class="btn btn-success">@lang('request.claim-now')!</button>
-                            <button type="button" class="btn btn-default"
-                                data-dismiss="modal">@lang('common.cancel')</button>
-                        </div>
+                        <button type="button" class="btn btn-primary"
+                            data-dismiss="modal">@lang('common.cancel')</button>
+                        <button type="submit" class="btn btn-success">@lang('request.claim-now')</button>
                     </div>
                 </div>
             </form>
@@ -163,7 +165,7 @@
 </div>
 
 <div class="modal fade" id="modal_request_report" tabindex="-1" role="dialog" aria-hidden="true">
-    <div class="modal-dialog modal-dark">
+    <div class="modal-dialog{{ \modal_style() }}">
         <div class="modal-content">
             <meta charset="utf-8">
             <title>@lang('request.report'): {{ $torrentRequest->name }}</title>
@@ -199,7 +201,7 @@
                 </form>
             </div>
             <div class="modal-footer">
-                <button class="btn btn-sm btn-default" type="button" data-dismiss="modal">@lang('common.close')</button>
+                <button class="btn btn-sm btn-primary" type="button" data-dismiss="modal">@lang('common.close')</button>
             </div>
         </div>
     </div>

--- a/resources/views/seedbox/index.blade.php
+++ b/resources/views/seedbox/index.blade.php
@@ -27,7 +27,7 @@
                     <h1>{{ $user->username }} @lang('user.seedboxes')</h1>
                 </div>
             </div>
-    
+
             <div class="some-padding">
                 <div class="well">
                     <p class="lead text-orange text-center"><i
@@ -38,7 +38,7 @@
                         &nbsp;<br><strong>@lang('user.disclaimer-info-bordered')</strong></p>
                 </div>
             </div>
-    
+
             <div class="table-responsive">
                 <button class="btn btn-md btn-success" data-toggle="modal" data-target="#seedbox">
                     <i class="{{ config('other.font-awesome') }} fa-plus"></i> Add New Seedbox
@@ -74,9 +74,9 @@
             </div>
         </div>
     </div>
-    
-    <div class="modal fade" id="seedbox" tabindex="-1" role="dialog" aria-labelledby="seedbox">
-        <div class="modal-dialog modal-dark" role="document">
+
+    <div class="modal fade" id="seedbox" tabindex="-1" role="dialog">
+        <div class="modal-dialog{{ \modal_style() }}" role="document">
             <div class="modal-content">
                 <div class="modal-header">
                     <button type="button" class="close" data-dismiss="modal" aria-label="@lang('common.close')"><span
@@ -102,9 +102,10 @@
                                 </label>
                             </div>
                         </fieldset>
-                        <br>
-                        <div class="btns">
-                            <button type="button" class="btn btn-md btn-warning"
+                    </div>
+                    <div class="modal-footer">
+                        <div class="text-center">
+                            <button type="button" class="btn btn-md btn-primary"
                                 data-dismiss="modal">@lang('common.cancel')</button>
                             <button type="submit" class="btn btn-md btn-success">@lang('common.submit')</button>
                         </div>

--- a/resources/views/subtitle/modals.blade.php
+++ b/resources/views/subtitle/modals.blade.php
@@ -1,5 +1,5 @@
 <div class="modal fade" id="modal_edit_subtitle-{{ $subtitle->id }}" tabindex="-1" role="dialog" aria-hidden="true">
-	<div class="modal-dialog modal-dark">
+	<div class="modal-dialog{{ \modal_style() }}">
 		<div class="modal-content">
 			<div class="container-fluid">
 				<form role="form" method="POST" action="{{ route('subtitles.update', ['id' =>$subtitle->id]) }}">
@@ -32,12 +32,12 @@
 								<span class="help-block">@lang('subtitle.note-help')</span>
 							</div>
 						</div>
-						<div class="form-group">
-							<input class="btn btn-primary" type="submit" value="@lang('common.save')">
-						</div>
 					</div>
 					<div class="modal-footer">
-						<button class="btn btn-sm btn-default" type="button" data-dismiss="modal">@lang('common.close')</button>
+						<div class="text-center">
+							<button class="btn btn-sm btn-primary" type="button" data-dismiss="modal">@lang('common.close')</button>
+							<input class="btn btn-success" type="submit" value="@lang('common.save')">
+						</div>
 					</div>
 				</form>
 			</div>
@@ -46,7 +46,7 @@
 </div>
 
 <div class="modal fade" id="modal_delete_subtitle-{{ $subtitle->id }}" tabindex="-1" role="dialog" aria-hidden="true">
-	<div class="modal-dialog modal-dark">
+	<div class="modal-dialog{{ \modal_style() }}">
 		<div class="modal-content">
 			<div class="container-fluid">
 				<form role="form" method="POST" action="{{ route('subtitles.destroy', ['id' => $subtitle->id]) }}">
@@ -57,15 +57,13 @@
 						<button type="button" class="close" data-dismiss="modal" aria-label="@lang('common.close')">
 							<span aria-hidden="true">×</span>
 						</button>
-						<h4 class="modal-title" id="myModalLabel">@lang('subtitle.delete-confirm')</h4>
+						<h4 class="modal-title text-center" id="myModalLabel">@lang('subtitle.delete-confirm')</h4>
 					</div>
 					<div class="modal-body text-center">
-						<div class="form-group">
-							<input class="btn btn-primary" type="submit" value="@lang('common.delete') - {{ $subtitle->language->name }} @lang('common.subtitle')">
-						</div>
+						<input class="btn btn-danger" type="submit" value="@lang('common.delete') - {{ $subtitle->language->name }} @lang('common.subtitle')">
 					</div>
 					<div class="modal-footer">
-						<button class="btn btn-sm btn-default" type="button" data-dismiss="modal">@lang('common.close')</button>
+						<button class="btn btn-sm btn-primary" type="button" data-dismiss="modal">@lang('common.close')</button>
 					</div>
 				</form>
 			</div>

--- a/resources/views/torrent/torrent_modals.blade.php
+++ b/resources/views/torrent/torrent_modals.blade.php
@@ -1,5 +1,5 @@
 <div class="modal fade" id="modal_torrent_report" tabindex="-1" role="dialog" aria-hidden="true">
-    <div class="modal-dialog modal-dark">
+    <div class="modal-dialog{{ \modal_style() }}">
         <div class="modal-content">
             <meta charset="utf-8">
             <title>@lang('common.report') {{ strtolower(trans('torrent.torrent')) }}: {{ $torrent->name }}</title>
@@ -35,15 +35,15 @@
                     </div>
                 </form>
             </div>
-        </div>
-        <div class="modal-footer">
-            <button class="btn btn-sm btn-default" type="button" data-dismiss="modal">@lang('common.close')</button>
+            <div class="modal-footer">
+                <button class="btn btn-sm btn-primary" type="button" data-dismiss="modal">@lang('common.close')</button>
+            </div>
         </div>
     </div>
 </div>
 
 <div class="modal fade" id="modal_torrent_delete" tabindex="-1" role="dialog" aria-hidden="true">
-    <div class="modal-dialog modal-dark">
+    <div class="modal-dialog{{ \modal_style() }}">
         <div class="modal-content">
             <meta charset="utf-8">
             <title>@lang('common.delete') {{ strtolower(trans('torrent.torrent')) }}: {{ $torrent->name }}</title>
@@ -76,19 +76,18 @@
                                 <input class="btn btn-danger" type="submit" value="@lang('common.delete')">
                             </div>
                         </div>
-                        <div class="modal-footer">
-                            <button class="btn btn-sm btn-default" type="button"
-                                data-dismiss="modal">@lang('common.close')</button>
-                        </div>
                     </form>
                 </div>
+            </div>
+            <div class="modal-footer">
+                <button class="btn btn-sm btn-primary" type="button" data-dismiss="modal">@lang('common.close')</button>
             </div>
         </div>
     </div>
 </div>
 
-<div id="myModal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
-    <div class="modal-dialog modal-lg modal-dark">
+<div id="myModal" class="modal fade" tabindex="-1" role="dialog" aria-hidden="true">
+    <div class="modal-dialog modal-lg{{ \modal_style() }}">
         <div class="modal-content">
             <div class="modal-header">
                 <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
@@ -117,15 +116,15 @@
                 </div>
             </div>
             <div class="modal-footer">
-                <button type="button" class="btn btn-default" data-dismiss="modal">@lang('common.close')</button>
+                <button type="button" class="btn btn-primary" data-dismiss="modal">@lang('common.close')</button>
             </div>
         </div>
     </div>
 </div>
 
 @if ($torrent->nfo != null)
-    <div class="modal fade slideExpandUp" id="modal-10" role="dialog" aria-labelledby="Modallabel3dsign">
-        <div class="modal-dialog modal-lg modal-dark" role="document">
+    <div class="modal fade slideExpandUp" id="modal-10" role="dialog">
+        <div class="modal-dialog modal-lg{{ \modal_style() }}" role="document">
             <div class="modal-content ">
                 <div class="modal-header">
                     <h4 class="modal-title" id="Modallabel3dsign">NFO</h4>
@@ -136,7 +135,7 @@
                     </pre>
                 </div>
                 <div class="modal-footer">
-                    <button class="btn btn-info" data-dismiss="modal">@lang('common.close')</button>
+                    <button class="btn btn-primary" data-dismiss="modal">@lang('common.close')</button>
                 </div>
             </div>
         </div>
@@ -146,7 +145,7 @@
 <div class="modal fade" id="postpone-{{ $torrent->id }}" tabindex="-1" role="dialog" aria-hidden="true">
     <form method="POST" action="{{ route('staff.moderation.postpone') }}">
         @csrf
-        <div class="modal-dialog modal-dark">
+        <div class="modal-dialog{{ \modal_style() }}">
             <div class="modal-content">
                 <div class="modal-header">
                     <button type="button" class="close" data-dismiss="modal" aria-label="@lang('common.close')"><span
@@ -173,7 +172,7 @@
                     </div>
                 </div>
                 <div class="modal-footer">
-                    <button class="btn btn-sm btn-default" data-dismiss="modal">@lang('common.close')</button>
+                    <button class="btn btn-sm btn-primary" data-dismiss="modal">@lang('common.close')</button>
                 </div>
             </div>
         </div>
@@ -183,7 +182,7 @@
 <div class="modal fade" id="reject-{{ $torrent->id }}" tabindex="-1" role="dialog" aria-hidden="true">
     <form method="POST" action="{{ route('staff.moderation.reject') }}">
         @csrf
-        <div class="modal-dialog modal-dark">
+        <div class="modal-dialog{{ \modal_style() }}">
             <div class="modal-content">
                 <div class="modal-header">
                     <button type="button" class="close" data-dismiss="modal" aria-label="@lang('common.close')"><span
@@ -216,7 +215,7 @@
                     </div>
                 </div>
                 <div class="modal-footer">
-                    <button class="btn btn-sm btn-default" data-dismiss="modal">@lang('common.close')</button>
+                    <button class="btn btn-sm btn-primary" data-dismiss="modal">@lang('common.close')</button>
                 </div>
             </div>
         </div>
@@ -224,7 +223,7 @@
 </div>
 
 <div class="modal fade" id="modal_playlist_torrent" tabindex="-1" role="dialog" aria-hidden="true">
-    <div class="modal-dialog modal-dark">
+    <div class="modal-dialog{{ \modal_style() }}">
         <div class="modal-content">
             <div class="container-fluid">
                 <form role="form" method="POST" action="{{ route('playlists.attach') }}">
@@ -248,11 +247,11 @@
                             </label>
                         </div>
                         <div class="form-group">
-                            <input class="btn btn-primary" type="submit" value="Save">
+                            <input class="btn btn-success" type="submit" value="Save">
                         </div>
                     </div>
                     <div class="modal-footer">
-                        <button class="btn btn-sm btn-default" type="button" data-dismiss="modal">Close</button>
+                        <button class="btn btn-sm btn-primary" type="button" data-dismiss="modal">Close</button>
                     </div>
                 </form>
             </div>

--- a/resources/views/user/user_modals.blade.php
+++ b/resources/views/user/user_modals.blade.php
@@ -1,6 +1,5 @@
-<div class="modal fade" id="modal_user_gift" tabindex="-1" role="dialog" aria-labelledby="modal_user_gift"
-    aria-hidden="true">
-    <div class="modal-dialog modal-dark modal-dialog-centered" role="document">
+<div class="modal fade" id="modal_user_gift" tabindex="-1" role="dialog" aria-hidden="true">
+    <div class="modal-dialog{{ \modal_style() }} modal-dialog-centered" role="document">
         <div class="modal-content">
             <div class="modal-header mx-auto">
                 <div class="text-center">
@@ -42,9 +41,8 @@
     </div>
 </div>
 
-<div class="modal fade" id="modal_user_note" tabindex="-1" role="dialog" aria-labelledby="modal_user_gift"
-    aria-hidden="true">
-    <div class="modal-dialog modal-dark modal-dialog-centered" role="document">
+<div class="modal fade" id="modal_user_note" tabindex="-1" role="dialog" aria-hidden="true">
+    <div class="modal-dialog{{ \modal_style() }} modal-dialog-centered" role="document">
         <div class="modal-content">
             <div class="modal-header mx-auto">
                 <div class="text-center">
@@ -65,7 +63,7 @@
                             </label>
                         </div>
                         <div class="form-group">
-                            <input class="btn btn-danger" type="submit" value="Save">
+                            <input class="btn btn-warning" type="submit" value="Save">
                         </div>
                     </form>
                 </div>
@@ -79,9 +77,8 @@
     </div>
 </div>
 
-<div class="modal fade" id="modal_user_ban" tabindex="-1" role="dialog" aria-labelledby="modal_user_gift"
-    aria-hidden="true">
-    <div class="modal-dialog modal-dark modal-dialog-centered" role="document">
+<div class="modal fade" id="modal_user_ban" tabindex="-1" role="dialog" aria-hidden="true">
+    <div class="modal-dialog{{ \modal_style() }} modal-dialog-centered" role="document">
         <div class="modal-content">
             <div class="modal-header mx-auto">
                 <div class="text-center">
@@ -115,9 +112,8 @@
     </div>
 </div>
 
-<div class="modal fade" id="modal_user_unban" tabindex="-1" role="dialog" aria-labelledby="modal_user_gift"
-    aria-hidden="true">
-    <div class="modal-dialog modal-dark modal-dialog-centered" role="document">
+<div class="modal fade" id="modal_user_unban" tabindex="-1" role="dialog" aria-hidden="true">
+    <div class="modal-dialog{{ \modal_style() }} modal-dialog-centered" role="document">
         <div class="modal-content">
             <div class="modal-header mx-auto">
                 <div class="text-center">
@@ -164,9 +160,8 @@
     </div>
 </div>
 
-<div class="modal fade" id="modal_user_report" tabindex="-1" role="dialog" aria-labelledby="modal_user_gift"
-    aria-hidden="true">
-    <div class="modal-dialog modal-dark modal-dialog-centered" role="document">
+<div class="modal fade" id="modal_user_report" tabindex="-1" role="dialog" aria-hidden="true">
+    <div class="modal-dialog{{ \modal_style() }} modal-dialog-centered" role="document">
         <div class="modal-content">
             <div class="modal-header mx-auto">
                 <div class="text-center">
@@ -200,9 +195,8 @@
     </div>
 </div>
 
-<div class="modal fade" id="modal_user_delete" tabindex="-1" role="dialog" aria-labelledby="modal_user_gift"
-    aria-hidden="true">
-    <div class="modal-dialog modal-dark modal-dialog-centered" role="document">
+<div class="modal fade" id="modal_user_delete" tabindex="-1" role="dialog" aria-hidden="true">
+    <div class="modal-dialog{{ \modal_style() }} modal-dialog-centered" role="document">
         <div class="modal-content">
             <div class="modal-header mx-auto">
                 <div class="text-center">
@@ -211,7 +205,7 @@
             </div>
             <div class="modal-body">
                 <div class="py-3">
-                    <div class="form-group">
+                    <div class="text-center">
                         <a href="{{ route('user_delete', ['username' => $user->username]) }}"><input
                                 class="btn btn-danger" type="submit" value="Yes, Delete"></a>
                     </div>
@@ -226,9 +220,8 @@
     </div>
 </div>
 
-<div class="modal fade" id="modal_user_watch" tabindex="-1" role="dialog" aria-labelledby="modal_user_gift"
-     aria-hidden="true">
-    <div class="modal-dialog modal-dark modal-dialog-centered" role="document">
+<div class="modal fade" id="modal_user_watch" tabindex="-1" role="dialog" aria-hidden="true">
+    <div class="modal-dialog{{ \modal_style() }} modal-dialog-centered" role="document">
         <div class="modal-content">
             <div class="modal-header mx-auto">
                 <div class="text-center">


### PR DESCRIPTION
Refactors the following:
1. Unreadable text in Show Files modal (using Light theme)
    ![2021-05-23_202808](https://user-images.githubusercontent.com/82098328/119270546-dcc9c080-bc05-11eb-8510-4a63a61524b0.png)
2. Broken markup in some modals:
    ![2021-05-23_202844](https://user-images.githubusercontent.com/82098328/119270563-ed7a3680-bc05-11eb-8630-7d9e06a63e06.png)
3. Duplicated titles in some modals:
    ![2021-05-23_202920](https://user-images.githubusercontent.com/82098328/119270569-fb2fbc00-bc05-11eb-89be-55eb1872234a.png)
4. Also centers modals vertically for easier access:
    ![2021-05-23_203456](https://user-images.githubusercontent.com/82098328/119270643-5cf02600-bc06-11eb-89af-657c36d113d5.png)
5. Helper function adds `modal-dark` class to all themes other than Light

Markup and styles are still inconsistent (some modals have Close button, some just X icon). So it can be refactored more later.