### PR TITLE
(Fix) Better breakdown and calculation of profile stats, show negative values

### DIFF
--- a/app/Helpers/StringHelper.php
+++ b/app/Helpers/StringHelper.php
@@ -45,9 +45,13 @@ class StringHelper
         return $string;
     }
 
-    public static function formatBytes($bytes, $precision = 2)
+    public static function formatBytes($bytes = 0, $precision = 2)
     {
-        $bytes = \max($bytes, 0);
+        $minus = false;
+        if ($bytes < 0) {
+            $minus = true;
+            $bytes = $bytes * -1;
+        }
         $suffix = 'B';
         $value = $bytes;
         if ($bytes >= self::PIB) {
@@ -67,7 +71,12 @@ class StringHelper
             $value = $bytes / self::KIB;
         }
 
-        return \round($value, $precision).' '.$suffix;
+        $result = \round($value, $precision);
+        if ($minus) {
+            $result = $result * -1;
+        }
+
+        return $result.' '.$suffix;
     }
 
     /**

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -59,16 +59,22 @@ class UserController extends Controller
         $hitrun = Warning::where('user_id', '=', $user->id)->latest()->paginate(10);
 
         $bonupload = BonTransactions::where('sender', '=', $user->id)->where([['name', 'like', '%Upload%']])->sum('cost');
-        $bondownload = BonTransactions::where('sender', '=', $user->id)->where([['name', 'like', '%Download%']])->sum('cost');
+        //$bondownload = BonTransactions::where('sender', '=', $user->id)->where([['name', 'like', '%Download%']])->sum('cost');
 
         //  With Multipliers
         $hisUplCre = History::where('user_id', '=', $user->id)->sum('uploaded');
         //  Without Multipliers
         $hisUpl = History::where('user_id', '=', $user->id)->sum('actual_uploaded');
-        $total = $hisUplCre - $hisUpl;
 
-        $realupload = ($user->uploaded - $bonupload) - $total;
-        $realdownload = $user->downloaded + $bondownload;
+        $defUpl = \config('other.default_upload');
+        $multiUpload = $hisUplCre - $hisUpl;
+        $manUpload = $user->uploaded - $hisUplCre - $defUpl - $bonupload;
+        $realupload = $user->getUploaded();
+
+        $hisDown = History::where('user_id', '=', $user->id)->sum('actual_downloaded');
+        $defDown = \config('other.default_download');
+        $freeDownload = $hisDown + $defDown - $user->downloaded;
+        $realdownload = $user->getDownloaded();
 
         $invitedBy = Invite::where('accepted_by', '=', $user->id)->first();
 
@@ -83,12 +89,20 @@ class UserController extends Controller
             'history'      => $history,
             'warnings'     => $warnings,
             'hitrun'       => $hitrun,
-            'bonupload'    => $bonupload,
-            'realupload'   => $realupload,
-            'bondownload'  => $bondownload,
+
+            //'bondownload'  => $bondownload,
             'realdownload' => $realdownload,
-            'his_upl_cre'  => $hisUplCre,
+            'def_download' => $defDown,
+            'his_down'     => $hisDown,
+            'free_down'    => $freeDownload,
+
+            'realupload'   => $realupload,
+            'def_upload'   => $defUpl,
             'his_upl'      => $hisUpl,
+            'multi_upload' => $multiUpload,
+            'bonupload'    => $bonupload,
+            'man_upload'   => $manUpload,
+
             'requested'    => $requested,
             'filled'       => $filled,
             'invitedBy'    => $invitedBy,

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -901,7 +901,7 @@ class User extends Authenticatable
      */
     public function getSeedbonus()
     {
-        return \number_format($this->seedbonus, 2, '.', ' ');
+        return \number_format($this->seedbonus, 0, '.', ' ');
     }
 
     /**

--- a/resources/sass/main/_custom.scss
+++ b/resources/sass/main/_custom.scss
@@ -5670,6 +5670,16 @@ a.view-torrent:visited {
     color: #8768e0;
 }
 
+.user-info {
+    td {
+        vertical-align: middle !important;
+    }
+
+    .list-inline > li {
+        padding: 3px 0;
+    }
+}
+
 .profile-footer {
     height: auto;
     min-height: 70px;

--- a/resources/views/user/profile.blade.php
+++ b/resources/views/user/profile.blade.php
@@ -159,7 +159,7 @@
 
                     <h3><i class="{{ config('other.font-awesome') }} fa-unlock"></i> @lang('user.public-info')</h3>
                 <div style="word-wrap: break-word; display: table; width: 100%;">
-                    <table class="table table-condensed table-striped table-bordered">
+                    <table class="table user-info table-condensed table-striped table-bordered">
                         <tbody>
                         <tr>
                             <td colspan="2" class="text-bold">
@@ -199,41 +199,41 @@
                         </tr>
                         @if (auth()->user()->isAllowed($user,'profile','show_profile_torrent_ratio'))
             <tr>
-                <td class="col-md-2">@lang('common.download')</td>
+                <td class="col-md-2">@lang('user.download-recorded')</td>
                 <td>
+                    <span class="badge-extra text-blue" data-toggle="tooltip" title=""
+                          data-original-title="@lang('user.download-recorded')">{{ $realdownload }}</span> =
+                    <span class="badge-extra text-info" data-toggle="tooltip" title=""
+                          data-original-title="Default Starter Download">{{ App\Helpers\StringHelper::formatBytes($def_download , 2) }}</span> +
                     <span class="badge-extra text-red" data-toggle="tooltip" title=""
-                          data-original-title="@lang('user.download-recorded')">{{ $user->getDownloaded() }}</span>
-                    +
-                    <span class="badge-extra text-orange" data-toggle="tooltip" title=""
-                          data-original-title="@lang('user.download-bon')">{{ App\Helpers\StringHelper::formatBytes($bondownload , 2) }}</span> =
-                    <span class="badge-extra text-blue" data-toggle="tooltip" title=""
-                          data-original-title="@lang('user.download-true')">{{ App\Helpers\StringHelper::formatBytes($realdownload , 2) }}</span></td>
+                          data-original-title="@lang('user.download-true')">{{ App\Helpers\StringHelper::formatBytes($his_down , 2) }}</span> −
+                    <span class="badge-extra text-green" data-toggle="tooltip" title=""
+                          data-original-title="Freeleech Downloads">{{ App\Helpers\StringHelper::formatBytes($free_down , 2) }}</span>
+                </td>
             </tr>
             <tr>
-                <td>Recorded @lang('common.upload')</td>
+                <td>@lang('user.upload-recorded')</td>
                 <td>
+                    <span class="badge-extra text-blue" data-toggle="tooltip" title=""
+                          data-original-title="@lang('user.upload-recorded')">{{ $user->getUploaded() }}</span> =
                     <span class="badge-extra text-info" data-toggle="tooltip" title=""
-                          data-original-title="Default Starter Upload">{{ App\Helpers\StringHelper::formatBytes(config('other.default_upload') , 2) }}</span> +
+                          data-original-title="Default Starter Upload">{{ App\Helpers\StringHelper::formatBytes($def_upload , 2) }}</span> +
                     <span class="badge-extra text-green" data-toggle="tooltip" title=""
-                          data-original-title="True Client Upload">{{ App\Helpers\StringHelper::formatBytes($his_upl , 2) }}</span> +
+                          data-original-title="@lang('user.upload-true')">{{ App\Helpers\StringHelper::formatBytes($his_upl , 2) }}</span> +
                     <span class="badge-extra text-info" data-toggle="tooltip" title=""
-                          data-original-title="Upload From Multipliers">{{ App\Helpers\StringHelper::formatBytes($his_upl_cre - $his_upl , 2) }}</span> +
+                          data-original-title="Upload from Multipliers">{{ App\Helpers\StringHelper::formatBytes($multi_upload , 2) }}</span> +
                     <span class="badge-extra text-orange" data-toggle="tooltip" title=""
-                          data-original-title="@lang('user.upload-bon')">{{ App\Helpers\StringHelper::formatBytes($bonupload , 2) }}</span> =
-                    <span class="badge-extra text-green" data-toggle="tooltip" title=""
-                          data-original-title="Recorded Account Upload">{{ $user->getUploaded() }}</span></td>
+                          data-original-title="@lang('user.upload-bon')">{{ App\Helpers\StringHelper::formatBytes($bonupload , 2) }}</span> +
+                    <span class="badge-extra text-pink" data-toggle="tooltip" title=""
+                          data-original-title="Manually Added or Misc">{{ App\Helpers\StringHelper::formatBytes($man_upload , 2) }}</span>
+                </td>
             </tr>
             <tr>
-                <td>Real @lang('common.upload')</td>
+                <td>@lang('user.upload-true')</td>
                 <td>
                     <span class="badge-extra text-green" data-toggle="tooltip" title=""
-                          data-original-title="Recorded Account Upload">{{ $user->getUploaded() }}</span> -
-                    <span class="badge-extra text-info" data-toggle="tooltip" title=""
-                          data-original-title="Upload From Multipliers">{{ App\Helpers\StringHelper::formatBytes($his_upl_cre - $his_upl , 2) }}</span> -
-                    <span class="badge-extra text-orange" data-toggle="tooltip" title=""
-                          data-original-title="@lang('user.upload-bon')">{{ App\Helpers\StringHelper::formatBytes($bonupload , 2) }}</span> =
-                    <span class="badge-extra text-blue" data-toggle="tooltip" title=""
-                          data-original-title="@lang('user.upload-true')">{{ App\Helpers\StringHelper::formatBytes($realupload , 2) }}</span></td>
+                          data-original-title="@lang('user.upload-true')">{{ App\Helpers\StringHelper::formatBytes($his_upl , 2) }}</span>
+                </td>
             </tr>
             <tr>
                 <td>@lang('common.ratio')</td>
@@ -250,13 +250,13 @@
             <tr>
                 <td>@lang('user.total-seedtime')</td>
                 <td>
-                    <span class="badge-user group-member">{{ App\Helpers\StringHelper::timeElapsed($history->sum('seedtime')) }} ( @lang('user.all-torrents') )</span>
+                    <span class="badge-user group-member">{{ App\Helpers\StringHelper::timeElapsed($history->sum('seedtime')) }}</span> <span>(@lang('user.all-torrents'))</span>
                 </td>
             </tr>
             <tr>
                 <td>@lang('user.avg-seedtime')</td>
                 <td>
-                    <span class="badge-user group-member">{{ App\Helpers\StringHelper::timeElapsed(round($history->sum('seedtime') / max(1, $history->count()))) }} ( @lang('user.per-torrent') )</span>
+                    <span class="badge-user group-member">{{ App\Helpers\StringHelper::timeElapsed(round($history->sum('seedtime') / max(1, $history->count()))) }}</span> <span>(@lang('user.per-torrent'))</span>
                 </td>
             </tr>
             <tr>
@@ -288,32 +288,32 @@
                                 </li>
                                 <li>
           <span class="badge-extra"><strong>@lang('user.tips-received'):</strong>
-            <span class="text-pink text-bold">{{ number_format($user->bonReceived()->where('name', '=', 'tip')->sum('cost'), 2) }} @lang('bon.bon')</span>
+            <span class="text-pink text-bold">{{ \number_format($user->bonReceived()->where('name', '=', 'tip')->sum('cost'), 0, '.', ' ') }} @lang('bon.bon')</span>
           </span>
                                 </li>
                                 <li>
           <span class="badge-extra"><strong>@lang('user.tips-given'):</strong>
-            <span class="text-pink text-bold">{{ number_format($user->bonGiven()->where('name', '=', 'tip')->sum('cost'), 2) }} @lang('bon.bon')</span>
+            <span class="text-pink text-bold">{{ \number_format($user->bonGiven()->where('name', '=', 'tip')->sum('cost'), 0, '.', ' ') }} @lang('bon.bon')</span>
           </span>
                                 </li>
                                 <li>
           <span class="badge-extra"><strong>@lang('user.gift-received'):</strong>
-            <span class="text-pink text-bold">{{ number_format($user->bonReceived()->where('name', '=', 'gift')->sum('cost'), 2) }} @lang('bon.bon')</span>
+            <span class="text-pink text-bold">{{ \number_format($user->bonReceived()->where('name', '=', 'gift')->sum('cost'), 0, '.', ' ') }} @lang('bon.bon')</span>
           </span>
                                 </li>
                                 <li>
           <span class="badge-extra"><strong>@lang('user.gift-given'):</strong>
-            <span class="text-pink text-bold">{{ number_format($user->bonGiven()->where('name', '=', 'gift')->sum('cost'), 2) }} @lang('bon.bon')</span>
+            <span class="text-pink text-bold">{{ \number_format($user->bonGiven()->where('name', '=', 'gift')->sum('cost'), 0, '.', ' ') }} @lang('bon.bon')</span>
           </span>
                                 </li>
                                 <li>
           <span class="badge-extra"><strong>@lang('user.bounty-received'):</strong>
-            <span class="text-pink text-bold">{{ number_format($user->bonReceived()->where('name', '=', 'request')->sum('cost'), 2) }} @lang('bon.bon')</span>
+            <span class="text-pink text-bold">{{ \number_format($user->bonReceived()->where('name', '=', 'request')->sum('cost'), 0, '.', ' ') }} @lang('bon.bon')</span>
           </span>
                                 </li>
                                 <li>
           <span class="badge-extra"><strong>@lang('user.bounty-given'):</strong>
-            <span class="text-pink text-bold">{{ number_format($user->bonGiven()->where('name', '=', 'request')->sum('cost'), 2) }} @lang('bon.bon')</span>
+            <span class="text-pink text-bold">{{ \number_format($user->bonGiven()->where('name', '=', 'request')->sum('cost'), 0, '.', ' ') }} @lang('bon.bon')</span>
           </span>
                                 </li>
                             </ul>
@@ -538,7 +538,7 @@
         <div class="block">
             <h3><i class="{{ config('other.font-awesome') }} fa-lock"></i> @lang('user.private-info')</h3>
             <div style="word-wrap: break-word; display: table; width: 100%;">
-                <table class="table table-condensed table-striped table-bordered">
+                <table class="table user-info table-condensed table-striped table-bordered">
                 <tbody>
                 <tr>
                     <td colspan="2" class="text-bold">
@@ -667,7 +667,7 @@
                 <div class="block">
                     <h3><i class="{{ config('other.font-awesome') }} fa-bell"></i> @lang('user.important-info')</h3>
                     <div class="table-responsive">
-                        <table class="table table-condensed table-striped table-bordered">
+                        <table class="table user-info table-condensed table-striped table-bordered">
                             <thead>
                             <tr>
                                 <th colspan="4" class="text-bold">


### PR DESCRIPTION
Provides a better understanding of what Profile download/upload stats consist of.
It was noticed that Profile stats sometimes can be different from a sum of History records (even after default/bonus/multiplier upload is added).
Having this last Misc number can help understand possible issues with calculations. One reason may be: manual edits by Admins/Moderators (since these values are shown when clicking Edit User).
I also rounded BON points to integers (below) since it's easier to read this way. Made thousand separators consistent (thin spaces).

![2021-06-01_233705](https://user-images.githubusercontent.com/82098328/120387443-9cb7bb80-c332-11eb-8fc9-2ae3334431b9.png)