### PR TITLE
[Feature] Custom Torrent Poster for "No-Meta Torrents"

### DIFF
--- a/app/Http/Controllers/TorrentController.php
+++ b/app/Http/Controllers/TorrentController.php
@@ -56,6 +56,7 @@ use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 use MarcReichel\IGDBLaravel\Models\Character;
 use MarcReichel\IGDBLaravel\Models\Game;
+use Intervention\Image\Facades\Image;
 
 /**
  * @see \Tests\Todo\Feature\Http\Controllers\TorrentControllerTest
@@ -1032,6 +1033,14 @@ class TorrentController extends Controller
         }
         $torrent->save();
 
+        // Cover Image for No-Meta Torrents
+        if ($request->hasFile('torrent-cover') == true) {
+            $image_cover = $request->file('torrent-cover');
+            $filename_cover = 'torrent-cover_'.$torrent->id.'.jpg';
+            $path_cover = \public_path('/files/img/'.$filename_cover);
+            Image::make($image_cover->getRealPath())->fit(400, 600)->encode('jpg', 90)->save($path_cover);
+        }
+
         $tmdbScraper = new TMDBScraper();
         if ($torrent->category->tv_meta && ($torrent->tmdb || $torrent->tmdb != 0)) {
             $tmdbScraper->tv($torrent->tmdb);
@@ -1235,7 +1244,7 @@ class TorrentController extends Controller
 
         $fileName = \uniqid('', true).'.torrent'; // Generate a unique name
         \file_put_contents(\getcwd().'/files/torrents/'.$fileName, Bencode::bencode($decodedTorrent));
-
+        
         // Create the torrent (DB)
         $torrent = new Torrent();
         $torrent->name = $request->input('name');
@@ -1328,6 +1337,14 @@ class TorrentController extends Controller
             $tag->name = $keyword;
             $tag->torrent_id = $torrent->id;
             $tag->save();
+        }
+        
+        // Cover Image for No-Meta Torrents
+        if ($request->hasFile('torrent-cover') == true) {
+            $image_cover = $request->file('torrent-cover');
+            $filename_cover = 'torrent-cover_'.$torrent->id.'.jpg';
+            $path_cover = \public_path('/files/img/'.$filename_cover);
+            Image::make($image_cover->getRealPath())->fit(400, 600)->encode('jpg', 90)->save($path_cover);
         }
 
         // check for trusted user and update torrent

--- a/app/Http/Controllers/TorrentController.php
+++ b/app/Http/Controllers/TorrentController.php
@@ -1244,7 +1244,7 @@ class TorrentController extends Controller
 
         $fileName = \uniqid('', true).'.torrent'; // Generate a unique name
         \file_put_contents(\getcwd().'/files/torrents/'.$fileName, Bencode::bencode($decodedTorrent));
-        
+
         // Create the torrent (DB)
         $torrent = new Torrent();
         $torrent->name = $request->input('name');

--- a/app/Http/Controllers/TorrentController.php
+++ b/app/Http/Controllers/TorrentController.php
@@ -54,9 +54,9 @@ use Illuminate\Pagination\LengthAwarePaginator as Paginator;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
+use Intervention\Image\Facades\Image;
 use MarcReichel\IGDBLaravel\Models\Character;
 use MarcReichel\IGDBLaravel\Models\Game;
-use Intervention\Image\Facades\Image;
 
 /**
  * @see \Tests\Todo\Feature\Http\Controllers\TorrentControllerTest
@@ -1338,7 +1338,7 @@ class TorrentController extends Controller
             $tag->torrent_id = $torrent->id;
             $tag->save();
         }
-        
+
         // Cover Image for No-Meta Torrents
         if ($request->hasFile('torrent-cover') == true) {
             $image_cover = $request->file('torrent-cover');

--- a/resources/views/category/show.blade.php
+++ b/resources/views/category/show.blade.php
@@ -94,9 +94,17 @@
                                                          class="torrent-poster-img-small show-poster" alt="@lang('torrent.poster')">
                                                 @endif
 
-                                                @if ($torrent->category->no_meta || $torrent->category->music_meta)
+                                                @if ($torrent->category->music_meta)
                                                     <img src="https://via.placeholder.com/60x90" class="torrent-poster-img-small show-poster"
                                                          alt="@lang('torrent.poster')">
+                                                @endif
+                                                
+                                                @if ($torrent->category->no_meta)
+                                                    @if(file_exists(public_path().'/files/img/torrent-cover_'.$torrent->id.'.jpg')) 
+                                                        <img src="{{ url('files/img/torrent-cover_' . $torrent->id . '.jpg') }}" class="torrent-poster-img-small show-poster" alt="@lang('torrent.poster')">
+                                                    @else
+                                                        <img src="https://via.placeholder.com/60x90" class="torrent-poster-img-small show-poster" alt="@lang('torrent.poster')">
+                                                    @endif
                                                 @endif
                                             </div>
                                         @else

--- a/resources/views/livewire/torrent-list-search.blade.php
+++ b/resources/views/livewire/torrent-list-search.blade.php
@@ -348,7 +348,7 @@
 												<img src="{{ url('files/img/torrent-cover_' . $torrent->id . '.jpg') }}" class="torrent-poster-img-small" alt="@lang('torrent.poster')">
 											@else
 												<img src="https://via.placeholder.com/400x600" class="torrent-poster-img-small" alt="@lang('torrent.poster')">
-                                            @endif
+											@endif
 										@endif
 									</div>
 								@else

--- a/resources/views/livewire/torrent-list-search.blade.php
+++ b/resources/views/livewire/torrent-list-search.blade.php
@@ -338,9 +338,17 @@
 											     class="torrent-poster-img-small" alt="@lang('torrent.poster')">
 										@endif
 
-										@if ($torrent->category->no_meta || $torrent->category->music_meta)
+										@if ($torrent->category->music_meta)
 											<img src="https://via.placeholder.com/90x135"
 											     class="torrent-poster-img-small" alt="@lang('torrent.poster')">
+										@endif
+										
+										@if ($torrent->category->no_meta)
+											@if(file_exists(public_path().'/files/img/torrent-cover_'.$torrent->id.'.jpg')) 
+												<img src="{{ url('files/img/torrent-cover_' . $torrent->id . '.jpg') }}" class="torrent-poster-img-small" alt="@lang('torrent.poster')">
+											@else
+												<img src="https://via.placeholder.com/400x600" class="torrent-poster-img-small" alt="@lang('torrent.poster')">
+                                            @endif
 										@endif
 									</div>
 								@else

--- a/resources/views/torrent/cards.blade.php
+++ b/resources/views/torrent/cards.blade.php
@@ -352,12 +352,22 @@
                                                      class="torrent-poster-img-small show-poster" alt="@lang('torrent.poster')">
                                             @endif
 
-                                            @if ($torrent->category->no_meta || $torrent->category->music_meta)
+                                            @if ($torrent->category->music_meta)
                                                 <img src="https://via.placeholder.com/200x300" class="show-poster"
                                                      data-name='<i style="color: #a5a5a5;">N/A</i>'
                                                      data-image='<img src="https://via.placeholder.com/200x300" alt="@lang('
                                                     torrent.poster')" style="height: 1000px;">'
                                                      class="torrent-poster-img-small show-poster" alt="@lang('torrent.poster')">
+                                            @endif
+                                            
+                                            @if ($torrent->category->no_meta)
+                                            	@if(file_exists(public_path().'/files/img/torrent-cover_'.$torrent->id.'.jpg')) 
+							                        <img src="{{ url('files/img/torrent-cover_' . $torrent->id . '.jpg') }}" class="show-poster" alt="@lang('torrent.poster')">
+						                        @else
+							                        <img src="https://via.placeholder.com/200x300" class="show-poster" data-name='<i style="color: #a5a5a5;">N/A</i>'
+								                        data-image='<img src="https://via.placeholder.com/200x300" alt="@lang('torrent.poster')" style="height: 1000px;">'
+                                                        class="torrent-poster-img-small show-poster" alt="@lang('torrent.poster')">
+						                        @endif
                                             @endif
                                         </div>
                                         <div class="body_description">

--- a/resources/views/torrent/cards.blade.php
+++ b/resources/views/torrent/cards.blade.php
@@ -361,13 +361,13 @@
                                             @endif
                                             
                                             @if ($torrent->category->no_meta)
-                                            	@if(file_exists(public_path().'/files/img/torrent-cover_'.$torrent->id.'.jpg')) 
-							                        <img src="{{ url('files/img/torrent-cover_' . $torrent->id . '.jpg') }}" class="show-poster" alt="@lang('torrent.poster')">
-						                        @else
-							                        <img src="https://via.placeholder.com/200x300" class="show-poster" data-name='<i style="color: #a5a5a5;">N/A</i>'
-								                        data-image='<img src="https://via.placeholder.com/200x300" alt="@lang('torrent.poster')" style="height: 1000px;">'
+                                                @if(file_exists(public_path().'/files/img/torrent-cover_'.$torrent->id.'.jpg')) 
+                                                    <img src="{{ url('files/img/torrent-cover_' . $torrent->id . '.jpg') }}" class="show-poster" alt="@lang('torrent.poster')">
+                                                @else
+                                                        <img src="https://via.placeholder.com/200x300" class="show-poster" data-name='<i style="color: #a5a5a5;">N/A</i>'
+                                                        data-image='<img src="https://via.placeholder.com/200x300" alt="@lang('torrent.poster')" style="height: 1000px;">'
                                                         class="torrent-poster-img-small show-poster" alt="@lang('torrent.poster')">
-						                        @endif
+                                                @endif
                                             @endif
                                         </div>
                                         <div class="body_description">

--- a/resources/views/torrent/edit_torrent.blade.php
+++ b/resources/views/torrent/edit_torrent.blade.php
@@ -105,7 +105,7 @@
                     </div>
                     
                     @if ($torrent->category->no_meta)
-		            <div class="form-group">
+                    <div class="form-group">
                         <label for="torrent-cover">Cover @lang('torrent.file') (@lang('torrent.optional'))</label>
                         <input class="upload-form-file" type="file" accept=".jpg, .jpeg" name="torrent-cover">
                     </div>

--- a/resources/views/torrent/edit_torrent.blade.php
+++ b/resources/views/torrent/edit_torrent.blade.php
@@ -13,7 +13,7 @@
         <div class="col-md-10">
             <h2>@lang('common.edit'): {{ $torrent->name }}</h2>
             <div class="block">
-                <form role="form" method="POST" action="{{ route('edit', ['id' => $torrent->id]) }}">
+                <form role="form" method="POST" action="{{ route('edit', ['id' => $torrent->id]) }}" enctype="multipart/form-data">
                     @csrf
                     <div class="form-group">
                         <label for="title">@lang('torrent.title')</label>
@@ -103,6 +103,13 @@
                             </select>
                         </label>
                     </div>
+                    
+                    @if ($torrent->category->no_meta)
+		            <div class="form-group">
+                        <label for="torrent-cover">Cover @lang('torrent.file') (@lang('torrent.optional'))</label>
+                        <input class="upload-form-file" type="file" accept=".jpg, .jpeg" name="torrent-cover">
+                    </div>
+                    @endif
 
                     @if ($torrent->category->movie_meta || $torrent->category->tv_meta)
                     <div class="form-group">

--- a/resources/views/torrent/partials/no_meta.blade.php
+++ b/resources/views/torrent/partials/no_meta.blade.php
@@ -1,0 +1,16 @@
+<div class="movie-wrapper">
+    <div class="movie-overlay"></div>
+    <div class="movie-poster">
+        @if(file_exists(public_path().'/files/img/torrent-cover_'.$torrent->id.'.jpg')) 
+        <img src="{{ url('files/img/torrent-cover_' . $torrent->id . '.jpg') }}" class="img-responsive" id="meta-poster">
+        @else
+        <img src="https://via.placeholder.com/400x600" class="img-responsive" id="meta-poster">
+        @endif
+    </div>
+    <div class="meta-info">
+        <div class="tags">
+            {{ $torrent->category->name }}
+        </div>
+        <div class="movie-backdrop" style="background-image: url('https://via.placeholder.com/960x540');"></div>
+    </div>
+</div>

--- a/resources/views/torrent/torrent.blade.php
+++ b/resources/views/torrent/torrent.blade.php
@@ -35,6 +35,10 @@
         @if ($torrent->category->game_meta)
             @include('torrent.partials.game_meta')
         @endif
+        
+        @if ($torrent->category->no_meta)
+            @include('torrent.partials.no_meta')
+        @endif
 
         <div id="vue" class="torrent-buttons">
             <div class="button-overlay"></div>
@@ -96,7 +100,7 @@
                     <i class="{{ config('other.font-awesome') }} fa-fw fa-eye"></i> @lang('common.report')
                 </button>
 
-                <a role="button" class="btn btn-sm btn-primary" href="{{ route('upload_form', ['category_id' => $torrent->category_id, 'title' => \rawurlencode($torrent->name) ?? 'Unknown', 'imdb' => $torrent->imdb, 'tmdb' => $torrent->tmdb]) }}">
+                <a role="button" class="btn btn-sm btn-primary" href="{{ route('upload_form', ['category_id' => $torrent->category_id, 'title' => $torrent->name ?? 'Unknown', 'imdb' => $torrent->imdb, 'tmdb' => $torrent->tmdb]) }}">
                     <i class="{{ config('other.font-awesome') }} fa-upload"></i> @lang('common.upload')
                 </a>
             </div>

--- a/resources/views/torrent/torrent.blade.php
+++ b/resources/views/torrent/torrent.blade.php
@@ -100,7 +100,7 @@
                     <i class="{{ config('other.font-awesome') }} fa-fw fa-eye"></i> @lang('common.report')
                 </button>
 
-                <a role="button" class="btn btn-sm btn-primary" href="{{ route('upload_form', ['category_id' => $torrent->category_id, 'title' => $torrent->name ?? 'Unknown', 'imdb' => $torrent->imdb, 'tmdb' => $torrent->tmdb]) }}">
+                <a role="button" class="btn btn-sm btn-primary" href="{{ route('upload_form', ['category_id' => $torrent->category_id, 'title' => \rawurlencode($torrent->name) ?? 'Unknown', 'imdb' => $torrent->imdb, 'tmdb' => $torrent->tmdb]) }}">
                     <i class="{{ config('other.font-awesome') }} fa-upload"></i> @lang('common.upload')
                 </a>
             </div>

--- a/resources/views/torrent/upload.blade.php
+++ b/resources/views/torrent/upload.blade.php
@@ -64,6 +64,14 @@
                         <label for="nfo">NFO @lang('torrent.file') (@lang('torrent.optional'))</label>
                         <input class="upload-form-file" type="file" accept=".nfo" name="nfo">
                     </div>
+                    
+                    @php $data = App\Models\Category::where('id', '=', !empty($category_id) ? $category_id : old('category_id'))->first();@endphp
+                    @if ($data->no_meta)
+                    <div class="form-group">
+                        <label for="torrent-cover">Cover @lang('torrent.file') (@lang('torrent.optional'))</label>
+                        <input class="upload-form-file" type="file" accept=".jpg, .jpeg" name="torrent-cover">
+                    </div>
+                    @endif
 
                     <div class="form-group">
                         <label for="name">@lang('torrent.title')</label>
@@ -99,7 +107,6 @@
                         </label>
                     </div>
 
-                    @php $data = App\Models\Category::where('id', '=', !empty($category_id) ? $category_id : old('category_id'))->first();@endphp
                     @if ($data->movie_meta || $data->tv_meta)
                     <div class="form-group">
                         <label for="resolution_ids">@lang('torrent.resolution')</label>


### PR DESCRIPTION
This PR adds the option to upload a cover image for no-meta torrents.

![unknown](https://user-images.githubusercontent.com/34812414/120780433-6a6faf00-c528-11eb-947d-4ee05162597e.png)

How it works:
1. If torrent category is no meta display the cover upload form (`upload.blade.php`)
```php
@if ($data->no_meta)
<div class="form-group">
    <label for="torrent-cover">Cover @lang('torrent.file') (@lang('torrent.optional'))</label>
    <input class="upload-form-file" type="file" accept=".jpg, .jpeg" name="torrent-cover">
</div>
@endif
```
2. If the `torrent-cover` input has a file, it will be saved under `/files/img/torrent-cover_<torrent id>.jpg` (`TorrentController.php`)
```php
// Cover Image for No-Meta Torrents
if ($request->hasFile('torrent-cover') == true) {
            $image_cover = $request->file('torrent-cover');
            $filename_cover = 'torrent-cover_'.$torrent->id.'.jpg';
            $path_cover = \public_path('/files/img/'.$filename_cover);
            Image::make($image_cover->getRealPath())->fit(400, 600)->encode('jpg', 90)->save($path_cover);
 }
```
3. Generally in the view / livewire files, it will then check if the torrent is no_meta and if the cover exists. If not it will display a placeholder. ( `show.blade.php`, `torrent-list-search.php`, `cards.blade.php`)
4. Editing a torrent will also allow to upload an image, see `edit_torrent.blade.php` and `TorrentController.php`

I didn't touch the TorrentController of the API, as I don't have the knowledge how to use it.

