### PR TITLE
(Feature) Custom Torrent Banner for "No-Meta Torrents"

### DIFF
--- a/app/Http/Controllers/TorrentController.php
+++ b/app/Http/Controllers/TorrentController.php
@@ -1048,7 +1048,7 @@ class TorrentController extends Controller
             $path_cover = \public_path('/files/img/'.$filename_cover);
             Image::make($image_cover->getRealPath())->fit(960, 540)->encode('jpg', 90)->save($path_cover);
         }
-        
+
         $tmdbScraper = new TMDBScraper();
         if ($torrent->category->tv_meta && ($torrent->tmdb || $torrent->tmdb != 0)) {
             $tmdbScraper->tv($torrent->tmdb);
@@ -1362,7 +1362,7 @@ class TorrentController extends Controller
             $path_cover = \public_path('/files/img/'.$filename_cover);
             Image::make($image_cover->getRealPath())->fit(960, 540)->encode('jpg', 90)->save($path_cover);
         }
-        
+
         // check for trusted user and update torrent
         if ($user->group->is_trusted) {
             $appurl = \config('app.url');

--- a/app/Http/Controllers/TorrentController.php
+++ b/app/Http/Controllers/TorrentController.php
@@ -1041,6 +1041,14 @@ class TorrentController extends Controller
             Image::make($image_cover->getRealPath())->fit(400, 600)->encode('jpg', 90)->save($path_cover);
         }
 
+        // Banner Image for No-Meta Torrents
+        if ($request->hasFile('torrent-banner') == true) {
+            $image_cover = $request->file('torrent-banner');
+            $filename_cover = 'torrent-banner_'.$torrent->id.'.jpg';
+            $path_cover = \public_path('/files/img/'.$filename_cover);
+            Image::make($image_cover->getRealPath())->fit(960, 540)->encode('jpg', 90)->save($path_cover);
+        }
+        
         $tmdbScraper = new TMDBScraper();
         if ($torrent->category->tv_meta && ($torrent->tmdb || $torrent->tmdb != 0)) {
             $tmdbScraper->tv($torrent->tmdb);
@@ -1347,6 +1355,14 @@ class TorrentController extends Controller
             Image::make($image_cover->getRealPath())->fit(400, 600)->encode('jpg', 90)->save($path_cover);
         }
 
+        // Banner Image for No-Meta Torrents
+        if ($request->hasFile('torrent-banner') == true) {
+            $image_cover = $request->file('torrent-banner');
+            $filename_cover = 'torrent-banner_'.$torrent->id.'.jpg';
+            $path_cover = \public_path('/files/img/'.$filename_cover);
+            Image::make($image_cover->getRealPath())->fit(960, 540)->encode('jpg', 90)->save($path_cover);
+        }
+        
         // check for trusted user and update torrent
         if ($user->group->is_trusted) {
             $appurl = \config('app.url');

--- a/resources/views/torrent/edit_torrent.blade.php
+++ b/resources/views/torrent/edit_torrent.blade.php
@@ -109,6 +109,10 @@
                         <label for="torrent-cover">Cover @lang('torrent.file') (@lang('torrent.optional'))</label>
                         <input class="upload-form-file" type="file" accept=".jpg, .jpeg" name="torrent-cover">
                     </div>
+                    <div class="form-group">
+                        <label for="torrent-banner">Banner @lang('torrent.file') (@lang('torrent.optional'))</label>
+                        <input class="upload-form-file" type="file" accept=".jpg, .jpeg" name="torrent-banner">
+                    </div>
                     @endif
 
                     @if ($torrent->category->movie_meta || $torrent->category->tv_meta)

--- a/resources/views/torrent/partials/no_meta.blade.php
+++ b/resources/views/torrent/partials/no_meta.blade.php
@@ -11,6 +11,10 @@
         <div class="tags">
             {{ $torrent->category->name }}
         </div>
+        @if(file_exists(public_path().'/files/img/torrent-banner_'.$torrent->id.'.jpg')) 
+        <div class="movie-backdrop" style="background-image: url({{ url('files/img/torrent-banner_' . $torrent->id . '.jpg') }});"></div>
+        @else
         <div class="movie-backdrop" style="background-image: url('https://via.placeholder.com/960x540');"></div>
+        @endif
     </div>
 </div>

--- a/resources/views/torrent/upload.blade.php
+++ b/resources/views/torrent/upload.blade.php
@@ -71,6 +71,10 @@
                         <label for="torrent-cover">Cover @lang('torrent.file') (@lang('torrent.optional'))</label>
                         <input class="upload-form-file" type="file" accept=".jpg, .jpeg" name="torrent-cover">
                     </div>
+                    <div class="form-group">
+                        <label for="torrent-banner">Banner @lang('torrent.file') (@lang('torrent.optional'))</label>
+                        <input class="upload-form-file" type="file" accept=".jpg, .jpeg" name="torrent-banner">
+                    </div>
                     @endif
 
                     <div class="form-group">


### PR DESCRIPTION
This PR adds the option to upload a banner image for no-meta torrents.

How it should roughly look:
![grafik](https://user-images.githubusercontent.com/34812414/121064503-f6533680-c7c7-11eb-9823-9f669034eefa.png)

I didn't touch the TorrentController of the API, as I don't have the knowledge how to use it / test it.