### PR TITLE
(Fix) Custom "No-Meta Torrents" Banner not displayed in "Featured"

### DIFF
--- a/resources/views/blocks/featured.blade.php
+++ b/resources/views/blocks/featured.blade.php
@@ -52,6 +52,8 @@
                                 "{{ isset($meta->backdrop) ? \tmdb_image('back_small', $meta->backdrop) : 'https://via.placeholder.com/533x300' }}">
                             @elseif ($feature->torrent->category->game_meta && isset($meta) && $meta->artworks)
                                 "https://images.igdb.com/igdb/image/upload/t_screenshot_med/{{ $meta->artworks[0]['image_id'] }}.jpg">
+                            @elseif ($feature->torrent->category->no_meta && file_exists(public_path().'/files/img/torrent-banner_'.$feature->torrent->id.'.jpg'))
+                                "{{'/files/img/torrent-banner_'.$feature->torrent->id.'.jpg'}}">
                             @else
                                 "{{'https://via.placeholder.com/533x300'}}">
                             @endif


### PR DESCRIPTION
This PR Adds the missing "No-Meta" Custom Banner for the PR https://github.com/HDInnovations/UNIT3D-Community-Edition/pull/1797

Example:
![grafik](https://user-images.githubusercontent.com/34812414/121217281-fdd71600-c881-11eb-92cd-ff1911630acb.png)


Many Greetings