### PR TITLE
(Fix) Add missing poster image size to Helpers

### DIFF
--- a/app/Helpers/Helpers.php
+++ b/app/Helpers/Helpers.php
@@ -88,6 +88,7 @@ if (! function_exists('tmdbImage')) {
             'back_small'   => 'w780',
             'poster_big'   => 'w500',
             'poster_mid'   => 'w342',
+            'poster_small' => 'w92',
             'cast_face'    => 'w138_and_h175_face',
             'cast_mid'     => 'w185',
             'cast_big'     => 'w300',


### PR DESCRIPTION
Forgot to add this cover image size in this PR (when refactoring the function): #1766
Full-sized images were used in torrent listings if users enabled "Show Posters" setting 🤦‍♂️ 