### PR TITLE
(Add) Flush Peers for Users

### DIFF
--- a/app/Console/Commands/AutoResetUserFlushes.php
+++ b/app/Console/Commands/AutoResetUserFlushes.php
@@ -35,11 +35,13 @@ class AutoResetUserFlushes extends Command
     /**
      * Execute the console command.
      *
-     * @return int
+     * @return mixed
      */
     public function handle()
     {
         // Updates own_flushes for each user
         User::where('own_flushes', '<', '2')->update(['own_flushes' => '2']);
+
+        $this->comment('Automated Reset User Flushes Command Complete');
     }
 }

--- a/app/Console/Commands/AutoResetUserFlushes.php
+++ b/app/Console/Commands/AutoResetUserFlushes.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * NOTICE OF LICENSE.
+ *
+ * UNIT3D Community Edition is open-sourced software licensed under the GNU Affero General Public License v3.0
+ * The details is bundled with this project in the file LICENSE.txt.
+ *
+ * @project    UNIT3D Community Edition
+ *
+ * @author     HDVinnie <hdinnovations@protonmail.com>
+ * @license    https://www.gnu.org/licenses/agpl-3.0.en.html/ GNU Affero General Public License v3.0
+ */
+
+namespace App\Console\Commands;
+
+use App\Models\User;
+use Illuminate\Console\Command;
+
+class AutoResetUserFlushes extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'auto:reset_user_flushes';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Resets the daily limit for users to flush their own peers.';
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        // Updates own_flushes for each user
+        User::where('own_flushes', '<', '2')->update(['own_flushes' => '2']);
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -57,6 +57,7 @@ class Kernel extends ConsoleKernel
         $schedule->command('auto:correct_history')->daily();
         $schedule->command('auto:sync_peers')->daily();
         $schedule->command('auto:email-blacklist-update')->weekends();
+        $schedule->command('auto:reset_user_flushes')->daily();
         //$schedule->command('auto:ban_disposable_users')->weekends();
         //$schedule->command('backup:clean')->daily();
         //$schedule->command('backup:run')->daily();

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -2015,29 +2015,29 @@ class UserController extends Controller
      */
     public function flushOwnGhostPeers(Request $request, $username): \Illuminate\Http\RedirectResponse
     {
-	    // Authorized User
+        // Authorized User
         $user = User::where('username', '=', $username)->firstOrFail();
         \abort_unless($request->user()->id == $user->id, 403);
 
         // Check if User can flush
         if ($request->user()->own_flushes == 0){
             return \redirect()->back()->withErrors('You can only flush twice a day!');
-        }else{
-            $new_value = $request->user()->own_flushes - 1;
-            User::where('username', '=', $username)->update(['own_flushes' => $new_value]);
         }
 
-        $carbon = new Carbon();
-        
-        // Get Peer List from User
-	    $peers = Peer::select(['id', 'info_hash', 'user_id', 'updated_at'])->where('user_id', '=', $request->user()->id)->where('updated_at', '<', $carbon->copy()->subMinutes(70)->toDateTimeString())->get();
-	
-	    // Return with Error if no Peer exists
-	    if ($peers->isEmpty()) {
-	        return \redirect()->back()->withErrors('No Peers found! Please wait at least 70 Minutes after the last announce from the client!');
-	    }
+        $new_value = $request->user()->own_flushes - 1;
+        User::where('username', '=', $username)->update(['own_flushes' => $new_value]);
 
-	    // Iterate over Peers
+        $carbon = new Carbon();
+
+        // Get Peer List from User
+        $peers = Peer::select(['id', 'info_hash', 'user_id', 'updated_at'])->where('user_id', '=', $request->user()->id)->where('updated_at', '<', $carbon->copy()->subMinutes(70)->toDateTimeString())->get();
+
+        // Return with Error if no Peer exists
+        if ($peers->isEmpty()) {
+            return \redirect()->back()->withErrors('No Peers found! Please wait at least 70 Minutes after the last announce from the client!');
+        }
+
+        // Iterate over Peers
         foreach ($peers as $peer) {
             $history = History::where('info_hash', '=', $peer->info_hash)->where('user_id', '=', $peer->user_id)->first();
             if ($history) {
@@ -2047,6 +2047,6 @@ class UserController extends Controller
             $peer->delete();
         }
 
-	    return \redirect()->back()->withSuccess('Peers were flushed successfully!');
+        return \redirect()->back()->withSuccess('Peers were flushed successfully!');
     }
 }

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -2009,7 +2009,7 @@ class UserController extends Controller
     }
 
     /**
-     * Flushes own Peers
+     * Flushes own Peers.
      *
      * @param \App\Models\User $username
      */
@@ -2020,7 +2020,7 @@ class UserController extends Controller
         \abort_unless($request->user()->id == $user->id, 403);
 
         // Check if User can flush
-        if ($request->user()->own_flushes == 0){
+        if ($request->user()->own_flushes == 0) {
             return \redirect()->back()->withErrors('You can only flush twice a day!');
         }
 

--- a/database/migrations/2021_07_08_135537_add_flush_own_peers_to_users_table.php
+++ b/database/migrations/2021_07_08_135537_add_flush_own_peers_to_users_table.php
@@ -14,7 +14,7 @@ class AddFlushOwnPeersToUsersTable extends Migration
     public function up()
     {
         Schema::table('users', function (Blueprint $table) {
-            $table->tinyInteger('own_flushes')->default('2');;
+            $table->tinyInteger('own_flushes')->default('2');
         });
     }
 

--- a/database/migrations/2021_07_08_135537_add_flush_own_peers_to_users_table.php
+++ b/database/migrations/2021_07_08_135537_add_flush_own_peers_to_users_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddFlushOwnPeersToUsersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->tinyInteger('own_flushes')->default('2');;
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('own_flushes');
+        });
+    }
+}

--- a/resources/views/user/buttons/stats.blade.php
+++ b/resources/views/user/buttons/stats.blade.php
@@ -23,6 +23,9 @@
         <a href="{{ route('user_seeds', ['username' => $user->username]) }}" class="btn btn-sm btn-primary">
             @lang('user.seeds')
         </a>
+        <a href="{{ route('flush_own_ghost_peers', ['username' => $user->username]) }}" class="btn btn-sm btn-danger">
+            @lang('staff.flush-ghost-peers')
+        </a>
         @if(auth()->user()->id == $user->id)
             @if(!$route || $route != 'profile')
                 <a href="{{ route('download_history_torrents', ['username' => $user->username]) }}" role="button"

--- a/routes/web.php
+++ b/routes/web.php
@@ -299,6 +299,7 @@ Route::group(['middleware' => 'language'], function () {
             Route::post('/{username}/userFilters', 'UserController@myFilter')->name('myfilter');
             Route::get('/{username}/downloadHistoryTorrents', 'UserController@downloadHistoryTorrents')->name('download_history_torrents');
             Route::get('/{username}/seeds', 'UserController@seeds')->name('user_seeds');
+            Route::get('/{username}/flushOwnGhostPeers', 'UserController@flushOwnGhostPeers')->name('flush_own_ghost_peers');
             Route::get('/{username}/resurrections', 'UserController@resurrections')->name('user_resurrections');
             Route::get('/{username}/requested', 'UserController@requested')->name('user_requested');
             Route::get('/{username}/active', 'UserController@active')->name('user_active');


### PR DESCRIPTION
**Please only merge it if tested beforehand.**

This PR Adds the option for users to flush their own "ghost peers".

![grafik](https://user-images.githubusercontent.com/34812414/124930979-1150da80-e002-11eb-8c9a-eeed698d40ca.png)

There is a limit of 2 flushes per day.

Announce has to be at least 70 minutes old.

A new column `own_flushes` is created in the `users` table with the type `tinyInteger`.

Auto Reset is done with the command `auto:reset_user_flushes` which is being executed daily.

**It's also ok if you don't merge this.**