### PR TITLE
(Remove) Down migrations

### DIFF
--- a/database/migrations/2017_12_10_020753_create_articles_table.php
+++ b/database/migrations/2017_12_10_020753_create_articles_table.php
@@ -33,14 +33,4 @@ class CreateArticlesTable extends Migration
             $table->integer('user_id')->index('fk_articles_users1_idx');
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::drop('articles');
-    }
 }

--- a/database/migrations/2017_12_10_020753_create_ban_table.php
+++ b/database/migrations/2017_12_10_020753_create_ban_table.php
@@ -33,14 +33,4 @@ class CreateBanTable extends Migration
             $table->timestamps();
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::drop('ban');
-    }
 }

--- a/database/migrations/2017_12_10_020753_create_bon_exchange_table.php
+++ b/database/migrations/2017_12_10_020753_create_bon_exchange_table.php
@@ -33,14 +33,4 @@ class CreateBonExchangeTable extends Migration
             $table->boolean('invite')->default(0);
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::drop('bon_exchange');
-    }
 }

--- a/database/migrations/2017_12_10_020753_create_bon_transactions_table.php
+++ b/database/migrations/2017_12_10_020753_create_bon_transactions_table.php
@@ -34,14 +34,4 @@ class CreateBonTransactionsTable extends Migration
             $table->timestamp('date_actioned')->default(DB::raw('CURRENT_TIMESTAMP'));
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::drop('bon_transactions');
-    }
 }

--- a/database/migrations/2017_12_10_020753_create_bookmarks_table.php
+++ b/database/migrations/2017_12_10_020753_create_bookmarks_table.php
@@ -30,14 +30,4 @@ class CreateBookmarksTable extends Migration
             $table->timestamps();
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::drop('bookmarks');
-    }
 }

--- a/database/migrations/2017_12_10_020753_create_categories_table.php
+++ b/database/migrations/2017_12_10_020753_create_categories_table.php
@@ -32,14 +32,4 @@ class CreateCategoriesTable extends Migration
             $table->integer('num_torrent')->default(0);
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::drop('categories');
-    }
 }

--- a/database/migrations/2017_12_10_020753_create_clients_table.php
+++ b/database/migrations/2017_12_10_020753_create_clients_table.php
@@ -31,14 +31,4 @@ class CreateClientsTable extends Migration
             $table->timestamps();
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::drop('clients');
-    }
 }

--- a/database/migrations/2017_12_10_020753_create_comments_table.php
+++ b/database/migrations/2017_12_10_020753_create_comments_table.php
@@ -34,14 +34,4 @@ class CreateCommentsTable extends Migration
             $table->timestamps();
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::drop('comments');
-    }
 }

--- a/database/migrations/2017_12_10_020753_create_failed_login_attempts_table.php
+++ b/database/migrations/2017_12_10_020753_create_failed_login_attempts_table.php
@@ -31,14 +31,4 @@ class CreateFailedLoginAttemptsTable extends Migration
             $table->timestamps();
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::drop('failed_login_attempts');
-    }
 }

--- a/database/migrations/2017_12_10_020753_create_featured_torrents_table.php
+++ b/database/migrations/2017_12_10_020753_create_featured_torrents_table.php
@@ -30,14 +30,4 @@ class CreateFeaturedTorrentsTable extends Migration
             $table->timestamps();
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::drop('featured_torrents');
-    }
 }

--- a/database/migrations/2017_12_10_020753_create_files_table.php
+++ b/database/migrations/2017_12_10_020753_create_files_table.php
@@ -30,14 +30,4 @@ class CreateFilesTable extends Migration
             $table->bigInteger('torrent_id')->unsigned()->index('fk_files_torrents1_idx');
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::drop('files');
-    }
 }

--- a/database/migrations/2017_12_10_020753_create_follows_table.php
+++ b/database/migrations/2017_12_10_020753_create_follows_table.php
@@ -30,14 +30,4 @@ class CreateFollowsTable extends Migration
             $table->timestamps();
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::drop('follows');
-    }
 }

--- a/database/migrations/2017_12_10_020753_create_forums_table.php
+++ b/database/migrations/2017_12_10_020753_create_forums_table.php
@@ -40,14 +40,4 @@ class CreateForumsTable extends Migration
             $table->timestamps();
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::drop('forums');
-    }
 }

--- a/database/migrations/2017_12_10_020753_create_graveyard_table.php
+++ b/database/migrations/2017_12_10_020753_create_graveyard_table.php
@@ -32,14 +32,4 @@ class CreateGraveyardTable extends Migration
             $table->timestamps();
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::drop('graveyard');
-    }
 }

--- a/database/migrations/2017_12_10_020753_create_groups_table.php
+++ b/database/migrations/2017_12_10_020753_create_groups_table.php
@@ -39,14 +39,4 @@ class CreateGroupsTable extends Migration
             $table->boolean('autogroup')->default(0);
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::drop('groups');
-    }
 }

--- a/database/migrations/2017_12_10_020753_create_history_table.php
+++ b/database/migrations/2017_12_10_020753_create_history_table.php
@@ -40,14 +40,4 @@ class CreateHistoryTable extends Migration
             $table->dateTime('completed_at')->nullable();
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::drop('history');
-    }
 }

--- a/database/migrations/2017_12_10_020753_create_invites_table.php
+++ b/database/migrations/2017_12_10_020753_create_invites_table.php
@@ -35,14 +35,4 @@ class CreateInvitesTable extends Migration
             $table->timestamps();
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::drop('invites');
-    }
 }

--- a/database/migrations/2017_12_10_020753_create_jobs_table.php
+++ b/database/migrations/2017_12_10_020753_create_jobs_table.php
@@ -34,14 +34,4 @@ class CreateJobsTable extends Migration
             $table->index(['queue', 'reserved_at']);
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::drop('jobs');
-    }
 }

--- a/database/migrations/2017_12_10_020753_create_likes_table.php
+++ b/database/migrations/2017_12_10_020753_create_likes_table.php
@@ -32,14 +32,4 @@ class CreateLikesTable extends Migration
             $table->timestamps();
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::drop('likes');
-    }
 }

--- a/database/migrations/2017_12_10_020753_create_log_activities_table.php
+++ b/database/migrations/2017_12_10_020753_create_log_activities_table.php
@@ -34,14 +34,4 @@ class CreateLogActivitiesTable extends Migration
             $table->timestamps();
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::drop('log_activities');
-    }
 }

--- a/database/migrations/2017_12_10_020753_create_notifications_table.php
+++ b/database/migrations/2017_12_10_020753_create_notifications_table.php
@@ -34,14 +34,4 @@ class CreateNotificationsTable extends Migration
             $table->index(['notifiable_id', 'notifiable_type']);
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::drop('notifications');
-    }
 }

--- a/database/migrations/2017_12_10_020753_create_options_table.php
+++ b/database/migrations/2017_12_10_020753_create_options_table.php
@@ -31,14 +31,4 @@ class CreateOptionsTable extends Migration
             $table->timestamps();
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::drop('options');
-    }
 }

--- a/database/migrations/2017_12_10_020753_create_pages_table.php
+++ b/database/migrations/2017_12_10_020753_create_pages_table.php
@@ -31,14 +31,4 @@ class CreatePagesTable extends Migration
             $table->timestamps();
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::drop('pages');
-    }
 }

--- a/database/migrations/2017_12_10_020753_create_password_resets_table.php
+++ b/database/migrations/2017_12_10_020753_create_password_resets_table.php
@@ -29,14 +29,4 @@ class CreatePasswordResetsTable extends Migration
             $table->dateTime('created_at')->nullable();
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::drop('password_resets');
-    }
 }

--- a/database/migrations/2017_12_10_020753_create_peers_table.php
+++ b/database/migrations/2017_12_10_020753_create_peers_table.php
@@ -39,14 +39,4 @@ class CreatePeersTable extends Migration
             $table->integer('user_id')->nullable()->index('fk_peers_users1_idx');
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::drop('peers');
-    }
 }

--- a/database/migrations/2017_12_10_020753_create_permissions_table.php
+++ b/database/migrations/2017_12_10_020753_create_permissions_table.php
@@ -33,14 +33,4 @@ class CreatePermissionsTable extends Migration
             $table->boolean('start_topic');
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::drop('permissions');
-    }
 }

--- a/database/migrations/2017_12_10_020753_create_personal_freeleech_table.php
+++ b/database/migrations/2017_12_10_020753_create_personal_freeleech_table.php
@@ -29,14 +29,4 @@ class CreatePersonalFreeleechTable extends Migration
             $table->timestamps();
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::drop('personal_freeleech');
-    }
 }

--- a/database/migrations/2017_12_10_020753_create_polls_table.php
+++ b/database/migrations/2017_12_10_020753_create_polls_table.php
@@ -33,14 +33,4 @@ class CreatePollsTable extends Migration
             $table->timestamps();
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::drop('polls');
-    }
 }

--- a/database/migrations/2017_12_10_020753_create_posts_table.php
+++ b/database/migrations/2017_12_10_020753_create_posts_table.php
@@ -31,14 +31,4 @@ class CreatePostsTable extends Migration
             $table->integer('topic_id')->index('fk_posts_topics1_idx');
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::drop('posts');
-    }
 }

--- a/database/migrations/2017_12_10_020753_create_private_messages_table.php
+++ b/database/migrations/2017_12_10_020753_create_private_messages_table.php
@@ -35,14 +35,4 @@ class CreatePrivateMessagesTable extends Migration
             $table->index(['sender_id', 'read']);
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::drop('private_messages');
-    }
 }

--- a/database/migrations/2017_12_10_020753_create_reports_table.php
+++ b/database/migrations/2017_12_10_020753_create_reports_table.php
@@ -35,14 +35,4 @@ class CreateReportsTable extends Migration
             $table->timestamps();
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::drop('reports');
-    }
 }

--- a/database/migrations/2017_12_10_020753_create_request_bounty_table.php
+++ b/database/migrations/2017_12_10_020753_create_request_bounty_table.php
@@ -30,14 +30,4 @@ class CreateRequestBountyTable extends Migration
             $table->timestamps();
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::drop('request_bounty');
-    }
 }

--- a/database/migrations/2017_12_10_020753_create_request_claims_table.php
+++ b/database/migrations/2017_12_10_020753_create_request_claims_table.php
@@ -31,14 +31,4 @@ class CreateRequestClaimsTable extends Migration
             $table->timestamps();
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::drop('request_claims');
-    }
 }

--- a/database/migrations/2017_12_10_020753_create_requests_table.php
+++ b/database/migrations/2017_12_10_020753_create_requests_table.php
@@ -44,14 +44,4 @@ class CreateRequestsTable extends Migration
             $table->dateTime('approved_when')->nullable();
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::drop('requests');
-    }
 }

--- a/database/migrations/2017_12_10_020753_create_rss_table.php
+++ b/database/migrations/2017_12_10_020753_create_rss_table.php
@@ -29,14 +29,4 @@ class CreateRssTable extends Migration
             $table->timestamps();
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::drop('rss');
-    }
 }

--- a/database/migrations/2017_12_10_020753_create_sessions_table.php
+++ b/database/migrations/2017_12_10_020753_create_sessions_table.php
@@ -32,14 +32,4 @@ class CreateSessionsTable extends Migration
             $table->integer('last_activity');
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::drop('sessions');
-    }
 }

--- a/database/migrations/2017_12_10_020753_create_shoutbox_table.php
+++ b/database/migrations/2017_12_10_020753_create_shoutbox_table.php
@@ -31,14 +31,4 @@ class CreateShoutboxTable extends Migration
             $table->timestamps();
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::dropIfExists('shoutbox');
-    }
 }

--- a/database/migrations/2017_12_10_020753_create_tag_torrent_table.php
+++ b/database/migrations/2017_12_10_020753_create_tag_torrent_table.php
@@ -29,14 +29,4 @@ class CreateTagTorrentTable extends Migration
             $table->primary(['torrent_id', 'tag_id']);
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::drop('tag_torrent');
-    }
 }

--- a/database/migrations/2017_12_10_020753_create_tags_table.php
+++ b/database/migrations/2017_12_10_020753_create_tags_table.php
@@ -29,14 +29,4 @@ class CreateTagsTable extends Migration
             $table->string('slug')->nullable();
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::drop('tags');
-    }
 }

--- a/database/migrations/2017_12_10_020753_create_thanks_table.php
+++ b/database/migrations/2017_12_10_020753_create_thanks_table.php
@@ -30,14 +30,4 @@ class CreateThanksTable extends Migration
             $table->timestamps();
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::drop('thanks');
-    }
 }

--- a/database/migrations/2017_12_10_020753_create_topics_table.php
+++ b/database/migrations/2017_12_10_020753_create_topics_table.php
@@ -45,14 +45,4 @@ class CreateTopicsTable extends Migration
             $table->integer('forum_id')->index('fk_topics_forums1_idx');
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::drop('topics');
-    }
 }

--- a/database/migrations/2017_12_10_020753_create_torrents_table.php
+++ b/database/migrations/2017_12_10_020753_create_torrents_table.php
@@ -59,14 +59,4 @@ class CreateTorrentsTable extends Migration
             $table->timestamps();
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::drop('torrents');
-    }
 }

--- a/database/migrations/2017_12_10_020753_create_types_table.php
+++ b/database/migrations/2017_12_10_020753_create_types_table.php
@@ -30,14 +30,4 @@ class CreateTypesTable extends Migration
             $table->integer('position');
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::drop('types');
-    }
 }

--- a/database/migrations/2017_12_10_020753_create_user_activations_table.php
+++ b/database/migrations/2017_12_10_020753_create_user_activations_table.php
@@ -30,14 +30,4 @@ class CreateUserActivationsTable extends Migration
             $table->timestamps();
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::drop('user_activations');
-    }
 }

--- a/database/migrations/2017_12_10_020753_create_user_notes_table.php
+++ b/database/migrations/2017_12_10_020753_create_user_notes_table.php
@@ -31,14 +31,4 @@ class CreateUserNotesTable extends Migration
             $table->timestamps();
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::drop('user_notes');
-    }
 }

--- a/database/migrations/2017_12_10_020753_create_users_table.php
+++ b/database/migrations/2017_12_10_020753_create_users_table.php
@@ -61,14 +61,4 @@ class CreateUsersTable extends Migration
             $table->timestamps();
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::drop('users');
-    }
 }

--- a/database/migrations/2017_12_10_020753_create_voters_table.php
+++ b/database/migrations/2017_12_10_020753_create_voters_table.php
@@ -31,14 +31,4 @@ class CreateVotersTable extends Migration
             $table->timestamps();
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::drop('voters');
-    }
 }

--- a/database/migrations/2017_12_10_020753_create_warnings_table.php
+++ b/database/migrations/2017_12_10_020753_create_warnings_table.php
@@ -33,14 +33,4 @@ class CreateWarningsTable extends Migration
             $table->timestamps();
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::drop('warnings');
-    }
 }

--- a/database/migrations/2017_12_10_020754_add_foreign_keys_to_articles_table.php
+++ b/database/migrations/2017_12_10_020754_add_foreign_keys_to_articles_table.php
@@ -27,16 +27,4 @@ class AddForeignKeysToArticlesTable extends Migration
             $table->foreign('user_id', 'fk_articles_users1')->references('id')->on('users')->onUpdate('RESTRICT')->onDelete('RESTRICT');
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::table('articles', function (Blueprint $table) {
-            $table->dropForeign('fk_articles_users1');
-        });
-    }
 }

--- a/database/migrations/2017_12_10_020754_add_foreign_keys_to_ban_table.php
+++ b/database/migrations/2017_12_10_020754_add_foreign_keys_to_ban_table.php
@@ -28,17 +28,4 @@ class AddForeignKeysToBanTable extends Migration
             $table->foreign('created_by', 'foreign_staff_ban_user_id')->references('id')->on('users')->onUpdate('RESTRICT')->onDelete('CASCADE');
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::table('ban', function (Blueprint $table) {
-            $table->dropForeign('foreign_ban_user_id');
-            $table->dropForeign('foreign_staff_ban_user_id');
-        });
-    }
 }

--- a/database/migrations/2017_12_10_020754_add_foreign_keys_to_clients_table.php
+++ b/database/migrations/2017_12_10_020754_add_foreign_keys_to_clients_table.php
@@ -27,16 +27,4 @@ class AddForeignKeysToClientsTable extends Migration
             $table->foreign('user_id')->references('id')->on('users')->onUpdate('RESTRICT')->onDelete('CASCADE');
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::table('clients', function (Blueprint $table) {
-            $table->dropForeign('clients_user_id_foreign');
-        });
-    }
 }

--- a/database/migrations/2017_12_10_020754_add_foreign_keys_to_comments_table.php
+++ b/database/migrations/2017_12_10_020754_add_foreign_keys_to_comments_table.php
@@ -28,17 +28,4 @@ class AddForeignKeysToCommentsTable extends Migration
             $table->foreign('user_id', 'fk_comments_users_1')->references('id')->on('users')->onUpdate('CASCADE')->onDelete('RESTRICT');
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::table('comments', function (Blueprint $table) {
-            $table->dropForeign('fk_comments_articles_1');
-            $table->dropForeign('fk_comments_users_1');
-        });
-    }
 }

--- a/database/migrations/2017_12_10_020754_add_foreign_keys_to_history_table.php
+++ b/database/migrations/2017_12_10_020754_add_foreign_keys_to_history_table.php
@@ -28,17 +28,4 @@ class AddForeignKeysToHistoryTable extends Migration
             $table->foreign('user_id')->references('id')->on('users')->onUpdate('RESTRICT')->onDelete('CASCADE');
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::table('history', function (Blueprint $table) {
-            $table->dropForeign('history_info_hash_foreign');
-            $table->dropForeign('history_user_id_foreign');
-        });
-    }
 }

--- a/database/migrations/2017_12_10_020754_add_foreign_keys_to_peers_table.php
+++ b/database/migrations/2017_12_10_020754_add_foreign_keys_to_peers_table.php
@@ -28,17 +28,4 @@ class AddForeignKeysToPeersTable extends Migration
             $table->foreign('user_id', 'fk_peers_users1')->references('id')->on('users')->onUpdate('RESTRICT')->onDelete('RESTRICT');
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::table('peers', function (Blueprint $table) {
-            $table->dropForeign('fk_peers_torrents1');
-            $table->dropForeign('fk_peers_users1');
-        });
-    }
 }

--- a/database/migrations/2017_12_10_020754_add_foreign_keys_to_reports_table.php
+++ b/database/migrations/2017_12_10_020754_add_foreign_keys_to_reports_table.php
@@ -28,17 +28,4 @@ class AddForeignKeysToReportsTable extends Migration
             $table->foreign('staff_id', 'foreign_staff_user_id')->references('id')->on('users')->onUpdate('RESTRICT')->onDelete('CASCADE');
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::table('reports', function (Blueprint $table) {
-            $table->dropForeign('foreign_reporting_user_id');
-            $table->dropForeign('foreign_staff_user_id');
-        });
-    }
 }

--- a/database/migrations/2017_12_10_020754_add_foreign_keys_to_rss_table.php
+++ b/database/migrations/2017_12_10_020754_add_foreign_keys_to_rss_table.php
@@ -27,16 +27,4 @@ class AddForeignKeysToRssTable extends Migration
             $table->foreign('userID', 'rss_user_id')->references('id')->on('users')->onUpdate('RESTRICT')->onDelete('RESTRICT');
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::table('rss', function (Blueprint $table) {
-            $table->dropForeign('rss_user_id');
-        });
-    }
 }

--- a/database/migrations/2017_12_10_020754_add_foreign_keys_to_torrents_table.php
+++ b/database/migrations/2017_12_10_020754_add_foreign_keys_to_torrents_table.php
@@ -27,16 +27,4 @@ class AddForeignKeysToTorrentsTable extends Migration
             $table->foreign('category_id', 'category_id')->references('id')->on('categories')->onUpdate('RESTRICT')->onDelete('CASCADE');
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::table('torrents', function (Blueprint $table) {
-            $table->dropForeign('category_id');
-        });
-    }
 }

--- a/database/migrations/2017_12_10_020754_add_foreign_keys_to_voters_table.php
+++ b/database/migrations/2017_12_10_020754_add_foreign_keys_to_voters_table.php
@@ -27,16 +27,4 @@ class AddForeignKeysToVotersTable extends Migration
             $table->foreign('poll_id')->references('id')->on('polls')->onUpdate('RESTRICT')->onDelete('CASCADE');
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::table('voters', function (Blueprint $table) {
-            $table->dropForeign('voters_poll_id_foreign');
-        });
-    }
 }

--- a/database/migrations/2017_12_10_020754_add_foreign_keys_to_warnings_table.php
+++ b/database/migrations/2017_12_10_020754_add_foreign_keys_to_warnings_table.php
@@ -29,18 +29,4 @@ class AddForeignKeysToWarningsTable extends Migration
             $table->foreign('warned_by')->references('id')->on('users')->onUpdate('RESTRICT')->onDelete('CASCADE');
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::table('warnings', function (Blueprint $table) {
-            $table->dropForeign('warnings_torrent_foreign');
-            $table->dropForeign('warnings_user_id_foreign');
-            $table->dropForeign('warnings_warned_by_foreign');
-        });
-    }
 }

--- a/database/migrations/2017_12_21_123452_add_custom_css_to_users_table.php
+++ b/database/migrations/2017_12_21_123452_add_custom_css_to_users_table.php
@@ -28,16 +28,4 @@ class AddCustomCssToUsersTable extends Migration
             $table->string('custom_css')->after('nav')->nullable();
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::table('users', function (Blueprint $table) {
-            //
-        });
-    }
 }

--- a/database/migrations/2017_12_27_000000_add_locale_column.php
+++ b/database/migrations/2017_12_27_000000_add_locale_column.php
@@ -27,16 +27,4 @@ class AddLocaleColumn extends Migration
             $table->string('locale')->default(config('app.locale'));
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::table('users', function ($table) {
-            $table->dropColumn('locale');
-        });
-    }
 }

--- a/database/migrations/2018_01_23_095412_add_implemented_to_topics_table.php
+++ b/database/migrations/2018_01_23_095412_add_implemented_to_topics_table.php
@@ -28,16 +28,4 @@ class AddImplementedToTopicsTable extends Migration
             $table->boolean('implemented')->default(0)->after('suggestion');
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::table('topics', function (Blueprint $table) {
-            //
-        });
-    }
 }

--- a/database/migrations/2018_01_25_000000_add_twostep_to_users_table.php
+++ b/database/migrations/2018_01_25_000000_add_twostep_to_users_table.php
@@ -28,16 +28,4 @@ class AddTwoStepToUsersTable extends Migration
             $table->boolean('twostep')->default(0)->after('stat_hidden');
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::table('users', function (Blueprint $table) {
-            //
-        });
-    }
 }

--- a/database/migrations/2018_02_06_142024_add_last_reply_at_to_topics_table.php
+++ b/database/migrations/2018_02_06_142024_add_last_reply_at_to_topics_table.php
@@ -28,16 +28,4 @@ class AddLastReplyAtToTopicsTable extends Migration
             $table->timestamp('last_reply_at')->nullable()->after('last_post_user_username');
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::table('topics', function (Blueprint $table) {
-            //
-        });
-    }
 }

--- a/database/migrations/2018_02_14_000000_add_is_internal_to_groups_table.php
+++ b/database/migrations/2018_02_14_000000_add_is_internal_to_groups_table.php
@@ -28,16 +28,4 @@ class AddIsInternalToGroupsTable extends Migration
             $table->boolean('is_internal')->after('effect')->default(0);
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::table('groups', function (Blueprint $table) {
-            //
-        });
-    }
 }

--- a/database/migrations/2018_03_13_000000_add_position_to_categories_table.php
+++ b/database/migrations/2018_03_13_000000_add_position_to_categories_table.php
@@ -28,16 +28,4 @@ class AddPositionToCategoriesTable extends Migration
             $table->integer('position')->after('slug');
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::table('categories', function (Blueprint $table) {
-            //
-        });
-    }
 }

--- a/database/migrations/2018_03_21_000000_add_censor_to_users_table.php
+++ b/database/migrations/2018_03_21_000000_add_censor_to_users_table.php
@@ -28,16 +28,4 @@ class AddCensorToUsersTable extends Migration
             $table->boolean('censor')->default(0)->after('rsskey');
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::table('users', function (Blueprint $table) {
-            //
-        });
-    }
 }

--- a/database/migrations/2018_03_27_000000_add_chat_hidden_to_users_table.php
+++ b/database/migrations/2018_03_27_000000_add_chat_hidden_to_users_table.php
@@ -28,16 +28,4 @@ class AddChatHiddenToUsersTable extends Migration
             $table->boolean('chat_hidden')->default(0)->after('censor');
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::table('chat_hidden', function (Blueprint $table) {
-            //
-        });
-    }
 }

--- a/database/migrations/2018_04_19_221542_create_failed_jobs_table.php
+++ b/database/migrations/2018_04_19_221542_create_failed_jobs_table.php
@@ -33,14 +33,4 @@ class CreateFailedJobsTable extends Migration
             $table->timestamp('failed_at')->useCurrent();
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::dropIfExists('failed_jobs');
-    }
 }

--- a/database/migrations/2018_04_21_181026_create_wishes_table.php
+++ b/database/migrations/2018_04_21_181026_create_wishes_table.php
@@ -33,14 +33,4 @@ class CreateWishesTable extends Migration
             $table->timestamps();
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::dropIfExists('wishes');
-    }
 }

--- a/database/migrations/2018_04_22_195516_alter_reports_table.php
+++ b/database/migrations/2018_04_22_195516_alter_reports_table.php
@@ -30,17 +30,4 @@ class AlterReportsTable extends Migration
             $table->integer('torrent_id')->unsigned();
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::table('reports', function (Blueprint $table) {
-            $table->dropColumn('reported_user');
-            $table->dropColumn('torrent_id');
-        });
-    }
 }

--- a/database/migrations/2018_04_28_021651_alter_shoutbox_table.php
+++ b/database/migrations/2018_04_28_021651_alter_shoutbox_table.php
@@ -34,14 +34,4 @@ class AlterShoutboxTable extends Migration
             $table->timestamps();
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::dropIfExists('messages');
-    }
 }

--- a/database/migrations/2018_04_28_022305_create_chatrooms_table.php
+++ b/database/migrations/2018_04_28_022305_create_chatrooms_table.php
@@ -30,14 +30,4 @@ class CreateChatroomsTable extends Migration
             $table->timestamps();
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::dropIfExists('chatrooms');
-    }
 }

--- a/database/migrations/2018_04_28_022344_add_chatroom_id_to_users_table.php
+++ b/database/migrations/2018_04_28_022344_add_chatroom_id_to_users_table.php
@@ -28,16 +28,4 @@ class AddChatroomIdToUsersTable extends Migration
             $table->integer('chatroom_id')->unsigned()->default(1)->after('rsskey');
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::table('users', function (Blueprint $table) {
-            //
-        });
-    }
 }

--- a/database/migrations/2018_05_04_101711_create_chat_statuses_table.php
+++ b/database/migrations/2018_05_04_101711_create_chat_statuses_table.php
@@ -32,14 +32,4 @@ class CreateChatStatusesTable extends Migration
             $table->timestamps();
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::dropIfExists('chat_statuses');
-    }
 }

--- a/database/migrations/2018_05_04_102055_add_chat_status_id_to_users_table.php
+++ b/database/migrations/2018_05_04_102055_add_chat_status_id_to_users_table.php
@@ -28,16 +28,4 @@ class AddChatStatusIdToUsersTable extends Migration
             $table->integer('chat_status_id')->unsigned()->default(1);
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::table('users', function (Blueprint $table) {
-            $table->dropColumn('chat_status_id');
-        });
-    }
 }

--- a/database/migrations/2018_05_07_183534_add_can_upload_to_groups_table.php
+++ b/database/migrations/2018_05_07_183534_add_can_upload_to_groups_table.php
@@ -28,16 +28,4 @@ class AddCanUploadToGroupsTable extends Migration
             $table->boolean('can_upload')->after('is_freeleech')->default(1);
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::table('groups', function (Blueprint $table) {
-            //
-        });
-    }
 }

--- a/database/migrations/2018_05_15_223339_add_receiver_id_column_to_messages_table.php
+++ b/database/migrations/2018_05_15_223339_add_receiver_id_column_to_messages_table.php
@@ -28,16 +28,4 @@ class AddReceiverIdColumnToMessagesTable extends Migration
             $table->integer('receiver_id')->after('chatroom_id')->unsigned()->nullable();
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::table('messages', function (Blueprint $table) {
-            $table->dropColumn('receiver_id');
-        });
-    }
 }

--- a/database/migrations/2018_05_18_144651_rename_ban_table.php
+++ b/database/migrations/2018_05_18_144651_rename_ban_table.php
@@ -25,14 +25,4 @@ class RenameBanTable extends Migration
     {
         Schema::rename('ban', 'bans');
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::rename('bans', 'ban');
-    }
 }

--- a/database/migrations/2018_05_21_022459_add_torrent_layout_to_users_table.php
+++ b/database/migrations/2018_05_21_022459_add_torrent_layout_to_users_table.php
@@ -28,16 +28,4 @@ class AddTorrentLayoutToUsersTable extends Migration
             $table->boolean('torrent_layout')->default(0)->after('nav');
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::table('users', function (Blueprint $table) {
-            $table->dropColumn('torrent_layout');
-        });
-    }
 }

--- a/database/migrations/2018_05_21_192858_alter_peers_table.php
+++ b/database/migrations/2018_05_21_192858_alter_peers_table.php
@@ -27,16 +27,4 @@ class AlterPeersTable extends Migration
             $table->renameColumn('hash', 'info_hash');
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::table('peers', function ($table) {
-            $table->renameColumn('info_hash', 'hash');
-        });
-    }
 }

--- a/database/migrations/2018_05_22_224911_alter_private_messages_table.php
+++ b/database/migrations/2018_05_22_224911_alter_private_messages_table.php
@@ -27,16 +27,4 @@ class AlterPrivateMessagesTable extends Migration
             $table->renameColumn('reciever_id', 'receiver_id');
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::table('private_messages', function ($table) {
-            $table->renameColumn('receiver_id', 'reciever_id');
-        });
-    }
 }

--- a/database/migrations/2018_05_31_120936_create_albums_table.php
+++ b/database/migrations/2018_05_31_120936_create_albums_table.php
@@ -29,9 +29,4 @@ class CreateAlbumsTable extends Migration
             $table->timestamps();
         });
     }
-
-    public function down()
-    {
-        Schema::dropIfExists('albums');
-    }
 }

--- a/database/migrations/2018_05_31_120955_create_images_table.php
+++ b/database/migrations/2018_05_31_120955_create_images_table.php
@@ -31,9 +31,4 @@ class CreateImagesTable extends Migration
             $table->timestamps();
         });
     }
-
-    public function down()
-    {
-        Schema::dropIfExists('images');
-    }
 }

--- a/database/migrations/2018_06_11_110000_create_topic_subscriptions_table.php
+++ b/database/migrations/2018_06_11_110000_create_topic_subscriptions_table.php
@@ -32,14 +32,4 @@ class CreateTopicSubscriptionsTable extends Migration
             $table->unique(['user_id', 'topic_id']);
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::dropIfExists('topic_subscriptions');
-    }
 }

--- a/database/migrations/2018_07_12_114125_add_soft_deletes_to_warnings.php
+++ b/database/migrations/2018_07_12_114125_add_soft_deletes_to_warnings.php
@@ -29,16 +29,4 @@ class AddSoftDeletesToWarnings extends Migration
             $table->softDeletes()->after('deleted_by');
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::table('warnings', function (Blueprint $table) {
-            //
-        });
-    }
 }

--- a/database/migrations/2018_08_19_212319_create_git_updates_table.php
+++ b/database/migrations/2018_08_19_212319_create_git_updates_table.php
@@ -31,14 +31,4 @@ class CreateGitUpdatesTable extends Migration
             $table->timestamps();
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::dropIfExists('git_updates');
-    }
 }

--- a/database/migrations/2018_09_08_153849_add_soft_deletes_to_user_table.php
+++ b/database/migrations/2018_09_08_153849_add_soft_deletes_to_user_table.php
@@ -30,16 +30,4 @@ class AddSoftDeletesToUserTable extends Migration
             $table->softDeletes();
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::table('users', function (Blueprint $table) {
-            //
-        });
-    }
 }

--- a/database/migrations/2018_09_24_205852_add_internal_to_torrents_table.php
+++ b/database/migrations/2018_09_24_205852_add_internal_to_torrents_table.php
@@ -28,16 +28,4 @@ class AddInternalToTorrentsTable extends Migration
             $table->boolean('internal')->default(0)->after('sd');
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::table('torrents', function (Blueprint $table) {
-            //
-        });
-    }
 }

--- a/database/migrations/2018_09_29_163937_add_anon_to_requests_table.php
+++ b/database/migrations/2018_09_29_163937_add_anon_to_requests_table.php
@@ -29,16 +29,4 @@ class AddAnonToRequestsTable extends Migration
             $table->boolean('filled_anon')->default(0)->after('filled_when');
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::table('requests', function (Blueprint $table) {
-            //
-        });
-    }
 }

--- a/database/migrations/2018_09_29_164525_add_anon_to_request_bounty_table.php
+++ b/database/migrations/2018_09_29_164525_add_anon_to_request_bounty_table.php
@@ -28,16 +28,4 @@ class AddAnonToRequestBountyTable extends Migration
             $table->boolean('anon')->default(0)->after('requests_id');
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::table('request_bounty', function (Blueprint $table) {
-            //
-        });
-    }
 }

--- a/database/migrations/2018_11_09_010002_add_immune_to_history_table.php
+++ b/database/migrations/2018_11_09_010002_add_immune_to_history_table.php
@@ -30,16 +30,4 @@ class AddImmuneToHistoryTable extends Migration
             $table->boolean('prewarn')->default(0)->index()->after('hitrun');
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::table('history', function (Blueprint $table) {
-            //
-        });
-    }
 }

--- a/database/migrations/2018_12_03_024251_create_applications_table.php
+++ b/database/migrations/2018_12_03_024251_create_applications_table.php
@@ -36,14 +36,4 @@ class CreateApplicationsTable extends Migration
             $table->timestamps();
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::dropIfExists('applications');
-    }
 }

--- a/database/migrations/2018_12_03_032701_create_application_image_proofs_table.php
+++ b/database/migrations/2018_12_03_032701_create_application_image_proofs_table.php
@@ -31,14 +31,4 @@ class CreateApplicationImageProofsTable extends Migration
             $table->timestamps();
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::dropIfExists('application_image_proofs');
-    }
 }

--- a/database/migrations/2018_12_03_032712_create_application_url_proofs_table.php
+++ b/database/migrations/2018_12_03_032712_create_application_url_proofs_table.php
@@ -31,14 +31,4 @@ class CreateApplicationUrlProofsTable extends Migration
             $table->timestamps();
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::dropIfExists('application_url_proofs');
-    }
 }

--- a/database/migrations/2018_12_06_012908_update_tag_torrent_table.php
+++ b/database/migrations/2018_12_06_012908_update_tag_torrent_table.php
@@ -32,14 +32,4 @@ class UpdateTagTorrentTable extends Migration
             $table->string('tag_name')->index();
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        //
-    }
 }

--- a/database/migrations/2018_1_10_020753_create_freeleech_tokens_table.php
+++ b/database/migrations/2018_1_10_020753_create_freeleech_tokens_table.php
@@ -30,14 +30,4 @@ class CreateFreeleechTokensTable extends Migration
             $table->timestamps();
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::drop('freeleech_tokens');
-    }
 }

--- a/database/migrations/2018_1_20_070937_create_two_step_auth_table.php
+++ b/database/migrations/2018_1_20_070937_create_two_step_auth_table.php
@@ -34,14 +34,4 @@ class CreateTwoStepAuthTable extends Migration
             $table->timestamps();
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::drop('twostep_auth');
-    }
 }

--- a/database/migrations/2019_01_09_151754_alter_categories_table.php
+++ b/database/migrations/2019_01_09_151754_alter_categories_table.php
@@ -34,14 +34,4 @@ class AlterCategoriesTable extends Migration
             $table->dropColumn('meta');
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        //
-    }
 }

--- a/database/migrations/2019_01_09_175336_add_incognito_to_groups_table.php
+++ b/database/migrations/2019_01_09_175336_add_incognito_to_groups_table.php
@@ -28,16 +28,4 @@ class AddIncognitoToGroupsTable extends Migration
             $table->boolean('is_incognito')->default(0)->after('can_upload');
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::table('groups', function (Blueprint $table) {
-            //
-        });
-    }
 }

--- a/database/migrations/2019_01_10_102512_add_request_id_to_reports_table.php
+++ b/database/migrations/2019_01_10_102512_add_request_id_to_reports_table.php
@@ -29,17 +29,4 @@ class AddRequestIdToReportsTable extends Migration
             $table->integer('torrent_id')->unsigned()->default(0)->change();
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::table('reports', function (Blueprint $table) {
-            $table->dropColumn('request_id');
-            $table->integer('torrent_id')->unsigned()->change();
-        });
-    }
 }

--- a/database/migrations/2019_01_11_001150_alter_rss_table.php
+++ b/database/migrations/2019_01_11_001150_alter_rss_table.php
@@ -38,21 +38,4 @@ class AlterRssTable extends Migration
             $table->timestamps();
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::dropIfExists('rss');
-        Schema::create('rss', function (Blueprint $table) {
-            $table->integer('id', true);
-            $table->integer('userID')->index('userID');
-            $table->string('category')->nullable();
-            $table->timestamps();
-            $table->foreign('userID', 'rss_user_id')->references('id')->on('users')->onUpdate('RESTRICT')->onDelete('RESTRICT');
-        });
-    }
 }

--- a/database/migrations/2019_01_17_213210_add_torrent_filters_to_users_table.php
+++ b/database/migrations/2019_01_17_213210_add_torrent_filters_to_users_table.php
@@ -28,16 +28,4 @@ class AddTorrentFiltersToUsersTable extends Migration
             $table->boolean('torrent_filters')->default(0)->index()->after('torrent_layout');
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::table('users', function (Blueprint $table) {
-            $table->dropColumn('torrent_filters');
-        });
-    }
 }

--- a/database/migrations/2019_01_23_034500_alter_bon_transactions_table.php
+++ b/database/migrations/2019_01_23_034500_alter_bon_transactions_table.php
@@ -28,16 +28,4 @@ class AlterBonTransactionsTable extends Migration
             $table->integer('post_id')->nullable()->index()->after('torrent_id');
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::table('bon_transactions', function (Blueprint $table) {
-            //
-        });
-    }
 }

--- a/database/migrations/2019_01_24_033802_rename_topic_subscriptions_table.php
+++ b/database/migrations/2019_01_24_033802_rename_topic_subscriptions_table.php
@@ -34,16 +34,4 @@ class RenameTopicSubscriptionsTable extends Migration
             $table->index('topic_id');
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::table('topic_subscriptions', function (Blueprint $table) {
-            //
-        });
-    }
 }

--- a/database/migrations/2019_01_24_190220_alter_torrents_table.php
+++ b/database/migrations/2019_01_24_190220_alter_torrents_table.php
@@ -28,16 +28,4 @@ class AlterTorrentsTable extends Migration
             $table->string('igdb')->default(0)->index()->after('mal');
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::table('torrents', function (Blueprint $table) {
-            //
-        });
-    }
 }

--- a/database/migrations/2019_01_27_005216_create_user_privacy_table.php
+++ b/database/migrations/2019_01_27_005216_create_user_privacy_table.php
@@ -63,14 +63,4 @@ class CreateUserPrivacyTable extends Migration
             $table->foreign('user_id')->references('id')->on('users')->onUpdate('RESTRICT')->onDelete('CASCADE');
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::dropIfExists('user_privacy');
-    }
 }

--- a/database/migrations/2019_01_28_031842_alter_groups_table.php
+++ b/database/migrations/2019_01_28_031842_alter_groups_table.php
@@ -44,16 +44,4 @@ class AlterGroupsTable extends Migration
         DB::table('groups')->whereRaw(' id=15')->update(['level' => 20]);
         DB::table('groups')->whereRaw(' id=2')->update(['level' => 10]);
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::table('groups', function (Blueprint $table) {
-            $table->dropColumn('level');
-        });
-    }
 }

--- a/database/migrations/2019_01_28_225127_create_user_notifications_table.php
+++ b/database/migrations/2019_01_28_225127_create_user_notifications_table.php
@@ -59,14 +59,4 @@ class CreateUserNotificationsTable extends Migration
             $table->foreign('user_id')->references('id')->on('users')->onUpdate('RESTRICT')->onDelete('CASCADE');
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::dropIfExists('user_notifications');
-    }
 }

--- a/database/migrations/2019_01_29_054104_alter_users_tables.php
+++ b/database/migrations/2019_01_29_054104_alter_users_tables.php
@@ -28,16 +28,4 @@ class AlterUsersTables extends Migration
             $table->boolean('block_notifications')->default(0)->index()->after('private_profile');
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::table('users', function (Blueprint $table) {
-            //
-        });
-    }
 }

--- a/database/migrations/2019_02_04_041644_create_user_echoes_table.php
+++ b/database/migrations/2019_02_04_041644_create_user_echoes_table.php
@@ -34,14 +34,4 @@ class CreateUserEchoesTable extends Migration
             $table->foreign('user_id')->references('id')->on('users')->onUpdate('RESTRICT')->onDelete('CASCADE');
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::dropIfExists('user_echoes');
-    }
 }

--- a/database/migrations/2019_02_05_220444_create_bots_table.php
+++ b/database/migrations/2019_02_05_220444_create_bots_table.php
@@ -51,14 +51,4 @@ class CreateBotsTable extends Migration
             $table->timestamps();
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::dropIfExists('bots');
-    }
 }

--- a/database/migrations/2019_02_06_005248_add_bot_id_to_messages_table.php
+++ b/database/migrations/2019_02_06_005248_add_bot_id_to_messages_table.php
@@ -28,16 +28,4 @@ class AddBotIdToMessagesTable extends Migration
             $table->integer('bot_id')->after('receiver_id')->unsigned()->nullable();
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::table('messages', function (Blueprint $table) {
-            $table->dropColumn('bot_id');
-        });
-    }
 }

--- a/database/migrations/2019_02_06_075938_create_bot_transactions_table.php
+++ b/database/migrations/2019_02_06_075938_create_bot_transactions_table.php
@@ -38,16 +38,4 @@ class CreateBotTransactionsTable extends Migration
             $table->foreign('bot_id')->references('id')->on('bots')->onUpdate('RESTRICT')->onDelete('CASCADE');
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::table('bot_transactions', function (Blueprint $table) {
-            $table->dropIfExists('bot_transactions');
-        });
-    }
 }

--- a/database/migrations/2019_02_07_022409_create_user_audibles_table.php
+++ b/database/migrations/2019_02_07_022409_create_user_audibles_table.php
@@ -35,14 +35,4 @@ class CreateUserAudiblesTable extends Migration
             $table->foreign('user_id')->references('id')->on('users')->onUpdate('RESTRICT')->onDelete('CASCADE');
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::dropIfExists('user_audibles');
-    }
 }

--- a/database/migrations/2019_02_10_010213_fix_chat_related_tables.php
+++ b/database/migrations/2019_02_10_010213_fix_chat_related_tables.php
@@ -35,16 +35,4 @@ class FixChatRelatedTables extends Migration
             $table->integer('target_id')->change();
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::table('user_echoes', function (Blueprint $table) {
-            //
-        });
-    }
 }

--- a/database/migrations/2019_02_21_133950_add_is_owner_to_groups_table.php
+++ b/database/migrations/2019_02_21_133950_add_is_owner_to_groups_table.php
@@ -28,16 +28,4 @@ class AddIsOwnerToGroupsTable extends Migration
             $table->boolean('is_owner')->after('is_internal')->default(0);
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::table('groups', function (Blueprint $table) {
-            //
-        });
-    }
 }

--- a/database/migrations/2019_02_21_221047_add_request_to_user_privacy_table.php
+++ b/database/migrations/2019_02_21_221047_add_request_to_user_privacy_table.php
@@ -33,16 +33,4 @@ class AddRequestToUserPrivacyTable extends Migration
             $table->boolean('show_requested')->index()->default(1)->after('show_rank');
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::table('user_privacy', function (Blueprint $table) {
-            //
-        });
-    }
 }

--- a/database/migrations/2019_03_20_214306_alter_users_table.php
+++ b/database/migrations/2019_03_20_214306_alter_users_table.php
@@ -28,16 +28,4 @@ class AlterUsersTable extends Migration
             $table->boolean('read_rules')->default(0)->index()->after('ratings');
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::table('users', function (Blueprint $table) {
-            //
-        });
-    }
 }

--- a/database/migrations/2019_06_17_172554_add_last_action_to_users_table.php
+++ b/database/migrations/2019_06_17_172554_add_last_action_to_users_table.php
@@ -28,16 +28,4 @@ class AddLastActionToUsersTable extends Migration
             $table->dateTime('last_action')->after('last_login')->nullable();
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::table('users', function (Blueprint $table) {
-            $table->dropColumn('last_action');
-        });
-    }
 }

--- a/database/migrations/2019_07_09_225645_add_release_year_to_torrents_table.php
+++ b/database/migrations/2019_07_09_225645_add_release_year_to_torrents_table.php
@@ -28,16 +28,4 @@ class AddReleaseYearToTorrentsTable extends Migration
             $table->year('release_year')->nullable()->index();
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::table('torrents', function (Blueprint $table) {
-            $table->dropColumn('release_year');
-        });
-    }
 }

--- a/database/migrations/2019_07_30_210848_create_tv_table.php
+++ b/database/migrations/2019_07_30_210848_create_tv_table.php
@@ -44,14 +44,4 @@ class CreateTvTable extends Migration
             $table->timestamps();
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::dropIfExists('tv');
-    }
 }

--- a/database/migrations/2019_07_30_210849_create_seasons_table.php
+++ b/database/migrations/2019_07_30_210849_create_seasons_table.php
@@ -24,14 +24,4 @@ class CreateSeasonsTable extends Migration
             $table->timestamps();
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::dropIfExists('seasons');
-    }
 }

--- a/database/migrations/2019_07_30_210850_create_cast_table.php
+++ b/database/migrations/2019_07_30_210850_create_cast_table.php
@@ -23,14 +23,4 @@ class CreateCastTable extends Migration
             $table->string('still')->nullable();
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::dropIfExists('person');
-    }
 }

--- a/database/migrations/2019_07_30_210850_create_collection_table.php
+++ b/database/migrations/2019_07_30_210850_create_collection_table.php
@@ -24,14 +24,4 @@ class CreateCollectionTable extends Migration
             $table->timestamps();
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::dropIfExists('collection');
-    }
 }

--- a/database/migrations/2019_07_30_210850_create_companies_table.php
+++ b/database/migrations/2019_07_30_210850_create_companies_table.php
@@ -23,14 +23,4 @@ class CreateCompaniesTable extends Migration
             $table->string('origin_country')->nullable();
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::dropIfExists('companies');
-    }
 }

--- a/database/migrations/2019_07_30_210850_create_episodes_table.php
+++ b/database/migrations/2019_07_30_210850_create_episodes_table.php
@@ -30,14 +30,4 @@ class CreateEpisodesTable extends Migration
             $table->timestamps();
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::dropIfExists('episodes');
-    }
 }

--- a/database/migrations/2019_07_30_210850_create_genres_table.php
+++ b/database/migrations/2019_07_30_210850_create_genres_table.php
@@ -18,14 +18,4 @@ class CreateGenresTable extends Migration
             $table->string('name')->index();
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::dropIfExists('genres');
-    }
 }

--- a/database/migrations/2019_07_30_210850_create_movie_table.php
+++ b/database/migrations/2019_07_30_210850_create_movie_table.php
@@ -38,14 +38,4 @@ class CreateMovieTable extends Migration
             $table->timestamps();
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::dropIfExists('movie');
-    }
 }

--- a/database/migrations/2019_07_30_210850_create_networks_table.php
+++ b/database/migrations/2019_07_30_210850_create_networks_table.php
@@ -23,14 +23,4 @@ class CreateNetworksTable extends Migration
             $table->string('origin_country')->nullable();
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::dropIfExists('networks');
-    }
 }

--- a/database/migrations/2019_07_30_210850_create_person_table.php
+++ b/database/migrations/2019_07_30_210850_create_person_table.php
@@ -31,14 +31,4 @@ class CreatePersonTable extends Migration
             $table->string('homepage')->nullable();
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::dropIfExists('person');
-    }
 }

--- a/database/migrations/2019_07_31_024816_alter_requests_table.php
+++ b/database/migrations/2019_07_31_024816_alter_requests_table.php
@@ -28,16 +28,4 @@ class AlterRequestsTable extends Migration
             $table->string('igdb')->default(0)->index()->after('mal');
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::table('torrents', function (Blueprint $table) {
-            //
-        });
-    }
 }

--- a/database/migrations/2019_07_31_210850_create_cast_episode_table.php
+++ b/database/migrations/2019_07_31_210850_create_cast_episode_table.php
@@ -19,14 +19,4 @@ class CreateCastEpisodeTable extends Migration
             $table->primary(['cast_id', 'episode_id']);
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::dropIfExists('cast_episode');
-    }
 }

--- a/database/migrations/2019_07_31_210850_create_cast_movie_table.php
+++ b/database/migrations/2019_07_31_210850_create_cast_movie_table.php
@@ -19,14 +19,4 @@ class CreateCastMovieTable extends Migration
             $table->primary(['cast_id', 'movie_id']);
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::dropIfExists('cast_movie');
-    }
 }

--- a/database/migrations/2019_07_31_210850_create_cast_season_table.php
+++ b/database/migrations/2019_07_31_210850_create_cast_season_table.php
@@ -19,14 +19,4 @@ class CreateCastSeasonTable extends Migration
             $table->primary(['cast_id', 'season_id']);
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::dropIfExists('cast_season');
-    }
 }

--- a/database/migrations/2019_07_31_210850_create_cast_tv_table.php
+++ b/database/migrations/2019_07_31_210850_create_cast_tv_table.php
@@ -19,14 +19,4 @@ class CreateCastTvTable extends Migration
             $table->primary(['cast_id', 'tv_id']);
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::dropIfExists('cast_tv');
-    }
 }

--- a/database/migrations/2019_07_31_210850_create_company_tv_table.php
+++ b/database/migrations/2019_07_31_210850_create_company_tv_table.php
@@ -19,14 +19,4 @@ class CreateCompanyTvTable extends Migration
             $table->primary(['company_id', 'tv_id']);
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::dropIfExists('company_tv');
-    }
 }

--- a/database/migrations/2019_07_31_210850_create_crew_episode_table.php
+++ b/database/migrations/2019_07_31_210850_create_crew_episode_table.php
@@ -19,14 +19,4 @@ class CreateCrewEpisodeTable extends Migration
             $table->primary(['episode_id', 'person_id']);
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::dropIfExists('crew_episode');
-    }
 }

--- a/database/migrations/2019_07_31_210850_create_crew_movie_table.php
+++ b/database/migrations/2019_07_31_210850_create_crew_movie_table.php
@@ -19,14 +19,4 @@ class CreateCrewMovieTable extends Migration
             $table->primary(['movie_id', 'person_id']);
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::dropIfExists('crew_movie');
-    }
 }

--- a/database/migrations/2019_07_31_210850_create_crew_season_table.php
+++ b/database/migrations/2019_07_31_210850_create_crew_season_table.php
@@ -19,14 +19,4 @@ class CreateCrewSeasonTable extends Migration
             $table->primary(['person_id', 'season_id']);
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::dropIfExists('crew_season');
-    }
 }

--- a/database/migrations/2019_07_31_210850_create_crew_tv_table.php
+++ b/database/migrations/2019_07_31_210850_create_crew_tv_table.php
@@ -19,14 +19,4 @@ class CreateCrewTvTable extends Migration
             $table->primary(['person_id', 'tv_id']);
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::dropIfExists('crew_tv');
-    }
 }

--- a/database/migrations/2019_07_31_210850_create_episode_guest_star_table.php
+++ b/database/migrations/2019_07_31_210850_create_episode_guest_star_table.php
@@ -19,14 +19,4 @@ class CreateEpisodeGuestStarTable extends Migration
             $table->primary(['episode_id', 'person_id']);
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::dropIfExists('episode_guest_star');
-    }
 }

--- a/database/migrations/2019_07_31_210850_create_episode_person_table.php
+++ b/database/migrations/2019_07_31_210850_create_episode_person_table.php
@@ -19,14 +19,4 @@ class CreateEpisodePersonTable extends Migration
             $table->primary(['episode_id', 'person_id']);
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::dropIfExists('episode_person');
-    }
 }

--- a/database/migrations/2019_07_31_210850_create_genre_tv_table.php
+++ b/database/migrations/2019_07_31_210850_create_genre_tv_table.php
@@ -19,14 +19,4 @@ class CreateGenreTvTable extends Migration
             $table->primary(['genre_id', 'tv_id']);
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::dropIfExists('genre_tv');
-    }
 }

--- a/database/migrations/2019_07_31_210850_create_network_tv_table.php
+++ b/database/migrations/2019_07_31_210850_create_network_tv_table.php
@@ -19,14 +19,4 @@ class CreateNetworkTvTable extends Migration
             $table->primary(['network_id', 'tv_id']);
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::dropIfExists('network_tv');
-    }
 }

--- a/database/migrations/2019_07_31_210850_create_person_movie_table.php
+++ b/database/migrations/2019_07_31_210850_create_person_movie_table.php
@@ -19,14 +19,4 @@ class CreatePersonMovieTable extends Migration
             $table->primary(['person_id', 'movie_id']);
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::dropIfExists('person_movie');
-    }
 }

--- a/database/migrations/2019_07_31_210850_create_person_tv_table.php
+++ b/database/migrations/2019_07_31_210850_create_person_tv_table.php
@@ -19,14 +19,4 @@ class CreatePersonTvTable extends Migration
             $table->primary(['person_id', 'tv_id']);
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::dropIfExists('person_tv');
-    }
 }

--- a/database/migrations/2019_07_31_210851_create_collection_movie_table.php
+++ b/database/migrations/2019_07_31_210851_create_collection_movie_table.php
@@ -20,14 +20,4 @@ class CreateCollectionMovieTable extends Migration
             $table->primary(['collection_id', 'movie_id']);
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::dropIfExists('collection_movie');
-    }
 }

--- a/database/migrations/2019_07_31_210851_create_company_movie_table.php
+++ b/database/migrations/2019_07_31_210851_create_company_movie_table.php
@@ -19,14 +19,4 @@ class CreateCompanyMovieTable extends Migration
             $table->primary(['company_id', 'movie_id']);
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::dropIfExists('company_movie');
-    }
 }

--- a/database/migrations/2019_07_31_210851_create_genre_movie_table.php
+++ b/database/migrations/2019_07_31_210851_create_genre_movie_table.php
@@ -19,14 +19,4 @@ class CreateGenreMovieTable extends Migration
             $table->primary(['genre_id', 'movie_id']);
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::dropIfExists('genre_movie');
-    }
 }

--- a/database/migrations/2019_07_31_210851_create_person_season_table.php
+++ b/database/migrations/2019_07_31_210851_create_person_season_table.php
@@ -19,14 +19,4 @@ class CreatePersonSeasonTable extends Migration
             $table->primary(['person_id', 'season_id']);
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::dropIfExists('person_season');
-    }
 }

--- a/database/migrations/2019_09_22_204439_create_playlists_table.php
+++ b/database/migrations/2019_09_22_204439_create_playlists_table.php
@@ -37,14 +37,4 @@ class CreatePlaylistsTable extends Migration
             $table->timestamps();
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::dropIfExists('playlists');
-    }
 }

--- a/database/migrations/2019_09_22_204613_create_playlist_torrents_table.php
+++ b/database/migrations/2019_09_22_204613_create_playlist_torrents_table.php
@@ -34,14 +34,4 @@ class CreatePlaylistTorrentsTable extends Migration
             $table->unique(['playlist_id', 'torrent_id', 'tmdb_id']);
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::dropIfExists('playlist_torrents');
-    }
 }

--- a/database/migrations/2019_09_24_160123_alter_comments_table.php
+++ b/database/migrations/2019_09_24_160123_alter_comments_table.php
@@ -28,16 +28,4 @@ class AlterCommentsTable extends Migration
             $table->integer('playlist_id')->nullable()->index()->after('requests_id');
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::table('comments', function (Blueprint $table) {
-            $table->dropColumn('playlist_id');
-        });
-    }
 }

--- a/database/migrations/2019_11_05_233558_create_audits_table.php
+++ b/database/migrations/2019_11_05_233558_create_audits_table.php
@@ -36,24 +36,4 @@ class CreateAuditsTable extends Migration
             $table->timestamps();
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::dropIfExists('audits');
-        Schema::create('log_activities', function (Blueprint $table) {
-            $table->increments('id');
-            $table->string('subject');
-            $table->string('url');
-            $table->string('method');
-            $table->string('ip');
-            $table->string('agent')->nullable();
-            $table->integer('user_id')->nullable();
-            $table->timestamps();
-        });
-    }
 }

--- a/database/migrations/2019_11_27_025048_add_api_token_field_users.php
+++ b/database/migrations/2019_11_27_025048_add_api_token_field_users.php
@@ -31,16 +31,4 @@ class AddApiTokenFieldUsers extends Migration
                 ->default(null);
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::table('users', function (Blueprint $table) {
-            $table->dropColumn('api_token');
-        });
-    }
 }

--- a/database/migrations/2019_12_17_030908_create_keywords_table.php
+++ b/database/migrations/2019_12_17_030908_create_keywords_table.php
@@ -21,14 +21,4 @@ class CreateKeywordsTable extends Migration
             $table->timestamps();
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::dropIfExists('keywords');
-    }
 }

--- a/database/migrations/2020_01_02_203432_bdinfo_to_torrents_table.php
+++ b/database/migrations/2020_01_02_203432_bdinfo_to_torrents_table.php
@@ -17,16 +17,4 @@ class BdinfoToTorrentsTable extends Migration
             $table->longText('bdinfo')->nullable()->after('mediainfo');
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::table('torrents', function (Blueprint $table) {
-            //
-        });
-    }
 }

--- a/database/migrations/2020_02_14_185120_add_foreign_key_to_options_table.php
+++ b/database/migrations/2020_02_14_185120_add_foreign_key_to_options_table.php
@@ -17,16 +17,4 @@ class AddForeignKeyToOptionsTable extends Migration
             $table->foreign('poll_id', 'fk_options_poll')->references('id')->on('polls')->onUpdate('RESTRICT')->onDelete('CASCADE');
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::table('options', function (Blueprint $table) {
-            $table->dropForeign('fk_options_poll');
-        });
-    }
 }

--- a/database/migrations/2020_02_14_202935_drop_ip_checking_in_polls_table.php
+++ b/database/migrations/2020_02_14_202935_drop_ip_checking_in_polls_table.php
@@ -17,16 +17,4 @@ class DropIpCheckingInPollsTable extends Migration
             $table->dropColumn('ip_checking');
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::table('polls', function (Blueprint $table) {
-            $table->boolean('ip_checking')->default(0);
-        });
-    }
 }

--- a/database/migrations/2020_03_02_031656_update_comments_table.php
+++ b/database/migrations/2020_03_02_031656_update_comments_table.php
@@ -17,16 +17,4 @@ class UpdateCommentsTable extends Migration
             $table->integer('collection_id')->nullable()->index()->after('requests_id');
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::table('comments', function (Blueprint $table) {
-            $table->dropColumn('collection_id');
-        });
-    }
 }

--- a/database/migrations/2020_03_26_030235_create_subtitles_table.php
+++ b/database/migrations/2020_03_26_030235_create_subtitles_table.php
@@ -43,14 +43,4 @@ class CreateSubtitlesTable extends Migration
             $table->timestamps();
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::dropIfExists('subtitles');
-    }
 }

--- a/database/migrations/2020_03_26_034620_create_media_languages_table.php
+++ b/database/migrations/2020_03_26_034620_create_media_languages_table.php
@@ -31,14 +31,4 @@ class CreateMediaLanguagesTable extends Migration
             $table->timestamps();
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::dropIfExists('media_languages');
-    }
 }

--- a/database/migrations/2020_03_31_201107_add_is_double_upload_to_groups_table.php
+++ b/database/migrations/2020_03_31_201107_add_is_double_upload_to_groups_table.php
@@ -17,16 +17,4 @@ class AddIsDoubleUploadToGroupsTable extends Migration
             $table->boolean('is_double_upload')->after('is_freeleech')->default(0);
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::table('groups', function (Blueprint $table) {
-            //
-        });
-    }
 }

--- a/database/migrations/2020_05_19_023939_add_type_id_to_torrents_table.php
+++ b/database/migrations/2020_05_19_023939_add_type_id_to_torrents_table.php
@@ -40,16 +40,4 @@ class AddTypeIdToTorrentsTable extends Migration
             $table->dropColumn('type');
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::table('torrents', function (Blueprint $table) {
-            //
-        });
-    }
 }

--- a/database/migrations/2020_05_26_053632_add_type_id_to_requests_table.php
+++ b/database/migrations/2020_05_26_053632_add_type_id_to_requests_table.php
@@ -40,16 +40,4 @@ class AddTypeIdToRequestsTable extends Migration
             $table->dropColumn('type');
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::table('requests', function (Blueprint $table) {
-            //
-        });
-    }
 }

--- a/database/migrations/2020_06_06_185230_create_resolutions_table.php
+++ b/database/migrations/2020_06_06_185230_create_resolutions_table.php
@@ -31,14 +31,4 @@ class CreateResolutionsTable extends Migration
             $table->integer('position');
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::dropIfExists('resolutions');
-    }
 }

--- a/database/migrations/2020_06_07_023938_add_resolution_id_to_torrents_table.php
+++ b/database/migrations/2020_06_07_023938_add_resolution_id_to_torrents_table.php
@@ -42,16 +42,4 @@ class AddResolutionIdToTorrentsTable extends Migration
             });
         }
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::table('torrents', function (Blueprint $table) {
-            //
-        });
-    }
 }

--- a/database/migrations/2020_06_07_054632_add_resolution_id_to_requests_table.php
+++ b/database/migrations/2020_06_07_054632_add_resolution_id_to_requests_table.php
@@ -28,16 +28,4 @@ class AddResolutionIdToRequestsTable extends Migration
             $table->integer('resolution_id')->nullable()->index();
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::table('requests', function (Blueprint $table) {
-            //
-        });
-    }
 }

--- a/database/migrations/2020_06_10_014256_unique_groups.php
+++ b/database/migrations/2020_06_10_014256_unique_groups.php
@@ -17,16 +17,4 @@ class UniqueGroups extends Migration
             $table->unique('slug');
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::table('groups', function (Blueprint $table) {
-            $table->dropUnique('groups_slug_unique');
-        });
-    }
 }

--- a/database/migrations/2020_06_18_115296_add_bumped_at_to_torrents_table.php
+++ b/database/migrations/2020_06_18_115296_add_bumped_at_to_torrents_table.php
@@ -17,16 +17,4 @@ class AddBumpedAtToTorrentsTable extends Migration
             $table->dateTime('bumped_at')->nullable()->after('updated_at');
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::table('torrents', function (Blueprint $table) {
-            $table->dateTime('bumped_at')->nullable();
-        });
-    }
 }

--- a/database/migrations/2020_07_07_202935_drop_tags_tables.php
+++ b/database/migrations/2020_07_07_202935_drop_tags_tables.php
@@ -15,14 +15,4 @@ class DropTagsTables extends Migration
         Schema::dropIfExists('tags');
         Schema::dropIfExists('tag_torrent');
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        //
-    }
 }

--- a/database/migrations/2020_10_06_143759_add_uuid_to_failed_jobs_table.php
+++ b/database/migrations/2020_10_06_143759_add_uuid_to_failed_jobs_table.php
@@ -17,16 +17,4 @@ class AddUuidToFailedJobsTable extends Migration
             $table->string('uuid')->after('id')->nullable()->unique();
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::table('failed_jobs', function (Blueprint $table) {
-            //
-        });
-    }
 }

--- a/database/migrations/2020_10_07_012129_create_job_batches_table.php
+++ b/database/migrations/2020_10_07_012129_create_job_batches_table.php
@@ -26,14 +26,4 @@ class CreateJobBatchesTable extends Migration
             $table->integer('finished_at')->nullable();
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::dropIfExists('job_batches');
-    }
 }

--- a/database/migrations/2020_10_18_235628_create_genre_torrent_table.php
+++ b/database/migrations/2020_10_18_235628_create_genre_torrent_table.php
@@ -19,14 +19,4 @@ class CreateGenreTorrentTable extends Migration
             $table->primary(['genre_id', 'torrent_id']);
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::dropIfExists('genre_torrent');
-    }
 }

--- a/database/migrations/2020_11_01_165838_update_wishes_table.php
+++ b/database/migrations/2020_11_01_165838_update_wishes_table.php
@@ -17,16 +17,4 @@ class UpdateWishesTable extends Migration
             $table->renameColumn('imdb', 'tmdb');
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::table('wishes', function (Blueprint $table) {
-            $table->renameColumn('tmdb', 'imdb');
-        });
-    }
 }

--- a/database/migrations/2021_01_02_230512_update_users_table.php
+++ b/database/migrations/2021_01_02_230512_update_users_table.php
@@ -19,18 +19,4 @@ class UpdateUsersTable extends Migration
             $table->unique('rsskey');
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::table('users', function (Blueprint $table) {
-            $table->dropUnique('users_username_unique');
-            $table->dropUnique('users_passkey_unique');
-            $table->dropUnique('users_rsskey_unique');
-        });
-    }
 }

--- a/database/migrations/2021_01_06_360572_update_nfo_column_on_torrents_table.php
+++ b/database/migrations/2021_01_06_360572_update_nfo_column_on_torrents_table.php
@@ -17,14 +17,4 @@ class UpdateNfoColumnOnTorrentsTable extends Migration
             $table->binary('nfo')->change();
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        //
-    }
 }

--- a/database/migrations/2021_01_18_191121_create_tickets_table.php
+++ b/database/migrations/2021_01_18_191121_create_tickets_table.php
@@ -27,14 +27,4 @@ class CreateTicketsTable extends Migration
             $table->softDeletes();
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::dropIfExists('tickets');
-    }
 }

--- a/database/migrations/2021_01_18_191321_create_ticket_categories_table.php
+++ b/database/migrations/2021_01_18_191321_create_ticket_categories_table.php
@@ -20,14 +20,4 @@ class CreateTicketCategoriesTable extends Migration
             $table->timestamps();
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::dropIfExists('ticket_categories');
-    }
 }

--- a/database/migrations/2021_01_18_191336_create_ticket_priorities_table.php
+++ b/database/migrations/2021_01_18_191336_create_ticket_priorities_table.php
@@ -20,14 +20,4 @@ class CreateTicketPrioritiesTable extends Migration
             $table->timestamps();
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::dropIfExists('ticket_priorities');
-    }
 }

--- a/database/migrations/2021_01_18_191357_create_ticket_attachments_table.php
+++ b/database/migrations/2021_01_18_191357_create_ticket_attachments_table.php
@@ -24,14 +24,4 @@ class CreateTicketAttachmentsTable extends Migration
             $table->softDeletes();
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::dropIfExists('ticket_attachments');
-    }
 }

--- a/database/migrations/2021_01_18_191596_add_ticket_id_to_comments_table.php
+++ b/database/migrations/2021_01_18_191596_add_ticket_id_to_comments_table.php
@@ -17,16 +17,4 @@ class AddTicketIdToCommentsTable extends Migration
             $table->integer('ticket_id')->nullable()->index()->after('playlist_id');
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::table('comments', function (Blueprint $table) {
-            $table->dropColumn('ticket_id');
-        });
-    }
 }

--- a/database/migrations/2021_03_04_042851_create_watchlists_table.php
+++ b/database/migrations/2021_03_04_042851_create_watchlists_table.php
@@ -21,14 +21,4 @@ class CreateWatchlistsTable extends Migration
             $table->timestamps();
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::dropIfExists('watchlists');
-    }
 }

--- a/database/migrations/2021_03_11_024605_add_personal_release_to_torrents_table.php
+++ b/database/migrations/2021_03_11_024605_add_personal_release_to_torrents_table.php
@@ -17,16 +17,4 @@ class AddPersonalReleaseToTorrentsTable extends Migration
             $table->integer('personal_release')->index();
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::table('torrents', function (Blueprint $table) {
-            $table->dropColumn('personal_release');
-        });
-    }
 }

--- a/database/migrations/2021_03_14_093812_add_read_column_tickets_table.php
+++ b/database/migrations/2021_03_14_093812_add_read_column_tickets_table.php
@@ -18,17 +18,4 @@ class AddReadColumnTicketsTable extends Migration
             $table->tinyInteger('staff_read')->nullable()->after('user_read');
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::table('comments', function (Blueprint $table) {
-            $table->dropColumn('user_read');
-            $table->dropColumn('staff_read');
-        });
-    }
 }

--- a/database/migrations/2021_04_13_200421_update_about_column_on_users_table.php
+++ b/database/migrations/2021_04_13_200421_update_about_column_on_users_table.php
@@ -17,14 +17,4 @@ class UpdateAboutColumnOnUsersTable extends Migration
             $table->mediumText('about')->nullable()->change();
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        //
-    }
 }

--- a/database/migrations/2021_05_26_215430_create_recommendations_table.php
+++ b/database/migrations/2021_05_26_215430_create_recommendations_table.php
@@ -37,14 +37,4 @@ class CreateRecommendationsTable extends Migration
             $table->unique(['tv_id', 'recommendation_tv_id']);
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::dropIfExists('recommendations');
-    }
 }

--- a/database/migrations/2021_06_28_123452_add_standalone_css_to_users_table.php
+++ b/database/migrations/2021_06_28_123452_add_standalone_css_to_users_table.php
@@ -28,16 +28,4 @@ class AddStandaloneCssToUsersTable extends Migration
             $table->string('standalone_css')->after('custom_css')->nullable();
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::table('users', function (Blueprint $table) {
-            //
-        });
-    }
 }

--- a/database/migrations/2021_07_08_135537_add_flush_own_peers_to_users_table.php
+++ b/database/migrations/2021_07_08_135537_add_flush_own_peers_to_users_table.php
@@ -17,16 +17,4 @@ class AddFlushOwnPeersToUsersTable extends Migration
             $table->tinyInteger('own_flushes')->default('2');
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::table('users', function (Blueprint $table) {
-            $table->dropColumn('own_flushes');
-        });
-    }
 }

--- a/stubs/migration.create.stub
+++ b/stubs/migration.create.stub
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class DropIpAddressInVotersTable extends Migration
+class {{ class }} extends Migration
 {
     /**
      * Run the migrations.
@@ -13,8 +13,9 @@ class DropIpAddressInVotersTable extends Migration
      */
     public function up()
     {
-        Schema::table('voters', function (Blueprint $table) {
-            $table->dropColumn('ip_address');
+        Schema::create('{{ table }}', function (Blueprint $table) {
+            $table->id();
+            $table->timestamps();
         });
     }
 }

--- a/stubs/migration.stub
+++ b/stubs/migration.stub
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class DropIpAddressInVotersTable extends Migration
+class {{ class }} extends Migration
 {
     /**
      * Run the migrations.
@@ -13,8 +13,6 @@ class DropIpAddressInVotersTable extends Migration
      */
     public function up()
     {
-        Schema::table('voters', function (Blueprint $table) {
-            $table->dropColumn('ip_address');
-        });
+        //
     }
 }

--- a/stubs/migration.update.stub
+++ b/stubs/migration.update.stub
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class DropIpAddressInVotersTable extends Migration
+class {{ class }} extends Migration
 {
     /**
      * Run the migrations.
@@ -13,8 +13,8 @@ class DropIpAddressInVotersTable extends Migration
      */
     public function up()
     {
-        Schema::table('voters', function (Blueprint $table) {
-            $table->dropColumn('ip_address');
+        Schema::table('{{ table }}', function (Blueprint $table) {
+            //
         });
     }
 }


### PR DESCRIPTION
- streamline database migrations by removing the down method for UNIT3D as we never rollback migrations.
- generated the migrations stubs used by artisan make:migration so newly made migrations will not contain the down method as well.