### PR TITLE
[Improvement] Set default value for personal_release

### DIFF
--- a/database/migrations/2021_03_11_024605_add_personal_release_to_torrents_table.php
+++ b/database/migrations/2021_03_11_024605_add_personal_release_to_torrents_table.php
@@ -14,7 +14,7 @@ class AddPersonalReleaseToTorrentsTable extends Migration
     public function up()
     {
         Schema::table('torrents', function (Blueprint $table) {
-            $table->integer('personal_release')->index();
+            $table->integer('personal_release')->default('0')->index();
         });
     }
 }


### PR DESCRIPTION
The Column "torrents.personal_release" is set to be "notNull" and should IMHO have a default value of "0" to prevent errors.
Eg. it does have an impact when running artisan tests.
