### PR TITLE
(Add) Client List in User Profile with Connectable Check

### DIFF
--- a/app/Jobs/ProcessBasicAnnounceRequest.php
+++ b/app/Jobs/ProcessBasicAnnounceRequest.php
@@ -126,6 +126,7 @@ class ProcessBasicAnnounceRequest implements ShouldQueue
         $peer->left = $this->queries['left'];
         $peer->torrent_id = $this->torrent->id;
         $peer->user_id = $this->user->id;
+        $peer->updateConnectableStateIfNeeded();
         $peer->save();
         // End Peer Update
 

--- a/app/Jobs/ProcessCompletedAnnounceRequest.php
+++ b/app/Jobs/ProcessCompletedAnnounceRequest.php
@@ -127,6 +127,7 @@ class ProcessCompletedAnnounceRequest implements ShouldQueue
         $peer->left = 0;
         $peer->torrent_id = $this->torrent->id;
         $peer->user_id = $this->user->id;
+        $peer->updateConnectableStateIfNeeded();
         $peer->save();
         // End Peer Update
 

--- a/app/Jobs/ProcessStartedAnnounceRequest.php
+++ b/app/Jobs/ProcessStartedAnnounceRequest.php
@@ -86,6 +86,7 @@ class ProcessStartedAnnounceRequest implements ShouldQueue
         $peer->left = $this->queries['left'];
         $peer->torrent_id = $this->torrent->id;
         $peer->user_id = $this->user->id;
+        $peer->updateConnectableStateIfNeeded();
         $peer->save();
         // End Peer Update
 

--- a/app/Jobs/ProcessStoppedAnnounceRequest.php
+++ b/app/Jobs/ProcessStoppedAnnounceRequest.php
@@ -127,6 +127,7 @@ class ProcessStoppedAnnounceRequest implements ShouldQueue
         $peer->left = $this->queries['left'];
         $peer->torrent_id = $this->torrent->id;
         $peer->user_id = $this->user->id;
+        $peer->updateConnectableStateIfNeeded();
         $peer->save();
         // End Peer Update
 

--- a/app/Models/Peer.php
+++ b/app/Models/Peer.php
@@ -15,8 +15,8 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
-use Predis\Client as RedisClient;
 use Kyslik\ColumnSortable\Sortable;
+use Predis\Client as RedisClient;
 
 /**
  * App\Models\Peer.
@@ -117,17 +117,17 @@ class Peer extends Model
 
     /**
      * Updates Connectable State If Needed.
-     * 
+     *
      * @var resource
      */
     public function updateConnectableStateIfNeeded()
     {
         $redis = new RedisClient();
-        if (!$redis->get('peers:connectable:' . $this->id)) {
+        if (! $redis->get('peers:connectable:'.$this->id)) {
             $con = @fsockopen($this->ip, $this->port, $_, $_, 1);
 
             $this->connectable = is_resource($con);
-            $redis->setex('peers:connectable:' . $this->id, config('announce.connectable_check_interval'), $this->connectable ? 'yes' : 'no');
+            $redis->setex('peers:connectable:'.$this->id, config('announce.connectable_check_interval'), $this->connectable ? 'yes' : 'no');
 
             if (is_resource($con)) {
                 fclose($con);

--- a/config/announce.php
+++ b/config/announce.php
@@ -55,6 +55,6 @@ return [
     |
     */
 
-    'connectable_check_interval' => 60*20,
+    'connectable_check_interval' => 60 * 20,
 
 ];

--- a/config/announce.php
+++ b/config/announce.php
@@ -46,4 +46,15 @@ return [
 
     'rate_limit' => 3,
 
+    /*
+    |--------------------------------------------------------------------------
+    | Connectable check interval
+    |--------------------------------------------------------------------------
+    |
+    | Amount Of Time until the next connectable check
+    |
+    */
+
+    'connectable_check_interval' => 60*20,
+
 ];

--- a/database/migrations/2021_07_31_172708_add_connectable_state_to_peers_table.php
+++ b/database/migrations/2021_07_31_172708_add_connectable_state_to_peers_table.php
@@ -1,0 +1,20 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddConnectableStateToPeersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('peers', function (Blueprint $table) {
+            $table->boolean('connectable')->default(0);
+        });
+    }
+}

--- a/resources/lang/de/user.php
+++ b/resources/lang/de/user.php
@@ -63,6 +63,8 @@ return [
     'change-email-help'                    => 'Du musst dein Konto erneut bestätigen, nachdem du deine E-Mail-Adresse geändert hast',
     'change-password'                      => 'Ändere das Passwort',
     'change-password-help'                 => 'Du musst dich erneut anmelden, nachdem du dein Passwort geändert hast',
+    'client-connectable-state'             => '{0}Nein|{1}Ja',
+    'client-list'                          => 'Clients und IP-Adressen',
     'client-ip-address'                    => 'Client-IP-Adresse',
     'code'                                 => 'Code',
     'comments'                             => 'Kommentare',

--- a/resources/lang/en/user.php
+++ b/resources/lang/en/user.php
@@ -67,6 +67,8 @@ return [
     'change-email-help'            => 'You will have to re-confirm your account, after you change your email',
     'change-password'              => 'Change Password',
     'change-password-help'         => 'You will have to login again, after you change your password',
+    'client-connectable-state'     => '{0}No|{1}Yes',
+    'client-list'                  => 'Clients and IP-Addresses',
     'client-ip-address'            => 'Client IP Address',
     'code'                         => 'Code',
     'comments'                     => 'Comments',

--- a/resources/views/user/profile.blade.php
+++ b/resources/views/user/profile.blade.php
@@ -536,6 +536,57 @@
             </div>
     @if (auth()->user()->id == $user->id || auth()->user()->group->is_modo)
         <div class="block">
+            <h3><i class="{{ config('other.font-awesome') }} fa-broadcast-tower"></i> @lang('user.client-list')</h3>
+            <div style="word-wrap: break-word; display: table; width: 100%;">
+                <table class="table table-condensed table-striped table-bordered">
+                    <thead>
+                        <tr>
+                            <th>@lang('torrent.client')</th>
+                            <th>@lang('common.ip')</th>
+                            <th>@lang('common.port')</th>
+                            <th>@lang('torrent.started')</th>
+                            <th>@lang('torrent.last-update')</th>
+                            <th>@lang('torrent.torrents')</th>
+                            <th>Connectable</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                    @php $peer_array = []; @endphp
+                    @foreach ($peers as $p)
+			            @if (!in_array([$p->ip, $p->port], $peer_array))
+                            @php $count = App\Models\Peer::with(['user'])->where('user_id', '=', $user->id)->latest('seeder')->where('ip', '=', $p->ip)->where('port', '=', $p->port)->count(); @endphp
+                            <tr>
+                                <td>
+                                    <span class="badge-extra text-purple text-bold">{{ $p->agent }}</span>
+                                </td>
+                                @if (auth()->user()->group->is_modo || auth()->user()->id == $p->user_id)
+                                    <td><span class="badge-extra text-bold">{{ $p->ip }}</span></td>
+                                    <td><span class="badge-extra text-bold">{{ $p->port }}</span></td>
+                                @else
+                                    <td> ---</td>
+                                    <td> ---</td>
+                                @endif
+                                <td>{{ $p->created_at ? $p->created_at->diffForHumans() : 'N/A' }}</td>
+                                <td>{{ $p->updated_at ? $p->updated_at->diffForHumans() : 'N/A' }}</td>
+                                @if (auth()->user()->group->is_modo || auth()->user()->id == $p->user_id)
+			                        <td>
+				                        <a href="{{ route('user_active_by_client', ['username' => $user->username, 'ip' => $p->ip, 'port' => $p->port]) }}" itemprop="url" class="l-breadcrumb-item-link">
+            				                        <span itemprop="title" class="l-breadcrumb-item-link-title">{{ $count }}</span>
+        			                    </a>
+			                        </td>
+                                @else
+                                    <td> ---</td>
+                                @endif
+                                <td>@choice('user.client-connectable-state', $p->connectable)</td>
+                            </tr>
+			                @php array_push($peer_array, [$p->ip, $p->port]); @endphp
+			            @endif
+                    @endforeach
+                    </tbody>
+                </table>
+            </div>
+        </div>
+        <div class="block">
             <h3><i class="{{ config('other.font-awesome') }} fa-lock"></i> @lang('user.private-info')</h3>
             <div style="word-wrap: break-word; display: table; width: 100%;">
                 <table class="table user-info table-condensed table-striped table-bordered">

--- a/routes/web.php
+++ b/routes/web.php
@@ -303,6 +303,7 @@ Route::group(['middleware' => 'language'], function () {
             Route::get('/{username}/resurrections', [App\Http\Controllers\UserController::class, 'resurrections'])->name('user_resurrections');
             Route::get('/{username}/requested', [App\Http\Controllers\UserController::class, 'requested'])->name('user_requested');
             Route::get('/{username}/active', [App\Http\Controllers\UserController::class, 'active'])->name('user_active');
+            Route::get('/{username}/activeByClient/{ip}/{port}', [App\Http\Controllers\UserController::class, 'activeByClient'])->name('user_active_by_client');
             Route::get('/{username}/torrents', [App\Http\Controllers\UserController::class, 'torrents'])->name('user_torrents');
             Route::get('/{username}/uploads', [App\Http\Controllers\UserController::class, 'uploads'])->name('user_uploads');
             Route::get('/{username}/downloads', [App\Http\Controllers\UserController::class, 'downloads'])->name('user_downloads');


### PR DESCRIPTION
**As always: Test before merging!** (Hopefully I did not forget to add some of our changes)

This PR adds the following tab in the user profile:
![grafik](https://user-images.githubusercontent.com/34812414/127784508-da7b0c23-11f0-4cd0-ab24-d63c47a76980.png)

IP and Port are only visible by moderator or the user itself.

**Database Change:** Add Connectable State to Peers Table.

It uses Redis for updating the state in a set interval in the new added config line under `config/announce.php`



