### PR TITLE
Fix ShoutBox PM not working when clicking on Username

### DIFF
--- a/resources/js/components/chat/mixins/pmMethods.js
+++ b/resources/js/components/chat/mixins/pmMethods.js
@@ -21,11 +21,11 @@ export default {
         showCancelButton: true,
         confirmButtonText: 'Send',
         showLoaderOnConfirm: true,
-        onOpen: () => {
+        willOpen: () => {
           this.editor = $('#chat-message-pm').wysibb()
           this.target = $('#receiver-id').val();
         },
-        onClose: () => {
+        willClose: () => {
           this.editor = null;
           this.target = null;
         },


### PR DESCRIPTION
Reason: sweetalert2 "onOpen" and "onClose" is deprecated.

`willOpen`: https://sweetalert2.github.io/#willOpen
`willClose`: https://sweetalert2.github.io/#willClose

