### PR TITLE
(Add) Hide Closed Tickets by default

### DIFF
--- a/app/Http/Livewire/TicketSearch.php
+++ b/app/Http/Livewire/TicketSearch.php
@@ -22,6 +22,7 @@ class TicketSearch extends Component
     use WithPagination;
 
     public $user;
+    public $show = false;
     public $perPage = 25;
     public $search = '';
     public $sortField = 'updated_at';

--- a/resources/views/livewire/ticket-search.blade.php
+++ b/resources/views/livewire/ticket-search.blade.php
@@ -2,6 +2,12 @@
 	<div class="mb-10 form-inline pull-left">
 		<a href="{{ route('tickets.create') }}" class="btn btn-success"><i class="fas fa-plus"></i> @lang('ticket.create-ticket')</a>
 	</div>
+	<div class="mb-10 form-inline pull-left">
+		<div class="form-group" style="padding-top: 8px; padding-left: 15px;">
+			<input type="checkbox" wire:model="show">
+			Show Closed Tickets
+		</div>
+	</div>
 	<div class="mb-10 form-inline pull-right">
 		<div class="form-group">
 			@lang('common.quantity')
@@ -68,6 +74,7 @@
 				<th>@lang('common.action')</th>
 			</tr>
 			@foreach ($tickets as $ticket)
+			@if($show || !$show && !$ticket->closed_at)
 				<tr>
 					<td>
 						<span class="badge-user">
@@ -170,6 +177,7 @@
 						</div>
 					</td>
 				</tr>
+			@endif
 			@endforeach
 			</tbody>
 		</table>


### PR DESCRIPTION
This PR adds a toggle button in the ticket system to toggle the visibility of closed tickets.
By default, it will hide them.

Hidden:
![grafik](https://user-images.githubusercontent.com/34812414/128526933-a70ac059-bc0d-4dd2-a578-4acc5d99c82b.png)

Visible:
![grafik](https://user-images.githubusercontent.com/34812414/128527201-a0f75d60-d9fb-4768-9629-2ab52b5d4b6e.png)
