### PR TITLE
(Fix) Missing " in torrent-list-search.blade.php

### DIFF
--- a/resources/views/livewire/torrent-list-search.blade.php
+++ b/resources/views/livewire/torrent-list-search.blade.php
@@ -280,8 +280,8 @@
 			<table class="table table-condensed table-striped table-bordered" id="torrent-list-table">
 				<thead>
 				<tr>
-					<th class="torrent-listings-poster></th>
-					<th class="torrent-listings-format></th>
+					<th class="torrent-listings-poster"></th>
+					<th class="torrent-listings-format"></th>
 					<th class="torrents-filename torrent-listings-overview">
 						<div sortable wire:click="sortBy('name')" :direction="$sortField === 'name' ? $sortDirection : null" role="button">
 							@lang('common.name')


### PR DESCRIPTION
Fixes the torrent list not being displayed correctly.
Issue is from PR https://github.com/HDInnovations/UNIT3D-Community-Edition/pull/1858