### PR TITLE
(Add) Config to Disable / Enable Client Connectable Check

### DIFF
--- a/app/Jobs/ProcessBasicAnnounceRequest.php
+++ b/app/Jobs/ProcessBasicAnnounceRequest.php
@@ -125,7 +125,7 @@ class ProcessBasicAnnounceRequest implements ShouldQueue
         $peer->left = $this->queries['left'];
         $peer->torrent_id = $this->torrent->id;
         $peer->user_id = $this->user->id;
-        //$peer->updateConnectableStateIfNeeded();
+        $peer->updateConnectableStateIfNeeded();
         $peer->save();
         // End Peer Update
 

--- a/app/Jobs/ProcessCompletedAnnounceRequest.php
+++ b/app/Jobs/ProcessCompletedAnnounceRequest.php
@@ -127,7 +127,7 @@ class ProcessCompletedAnnounceRequest implements ShouldQueue
         $peer->left = 0;
         $peer->torrent_id = $this->torrent->id;
         $peer->user_id = $this->user->id;
-        //$peer->updateConnectableStateIfNeeded();
+        $peer->updateConnectableStateIfNeeded();
         $peer->save();
         // End Peer Update
 

--- a/app/Jobs/ProcessStartedAnnounceRequest.php
+++ b/app/Jobs/ProcessStartedAnnounceRequest.php
@@ -86,7 +86,7 @@ class ProcessStartedAnnounceRequest implements ShouldQueue
         $peer->left = $this->queries['left'];
         $peer->torrent_id = $this->torrent->id;
         $peer->user_id = $this->user->id;
-        //$peer->updateConnectableStateIfNeeded();
+        $peer->updateConnectableStateIfNeeded();
         $peer->save();
         // End Peer Update
 

--- a/app/Jobs/ProcessStoppedAnnounceRequest.php
+++ b/app/Jobs/ProcessStoppedAnnounceRequest.php
@@ -127,7 +127,7 @@ class ProcessStoppedAnnounceRequest implements ShouldQueue
         $peer->left = $this->queries['left'];
         $peer->torrent_id = $this->torrent->id;
         $peer->user_id = $this->user->id;
-        //$peer->updateConnectableStateIfNeeded();
+        $peer->updateConnectableStateIfNeeded();
         $peer->save();
         // End Peer Update
 

--- a/app/Models/Peer.php
+++ b/app/Models/Peer.php
@@ -15,6 +15,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\DB;
 use Kyslik\ColumnSortable\Sortable;
 
 /**
@@ -124,14 +125,28 @@ class Peer extends Model
      */
     public function updateConnectableStateIfNeeded(): void
     {
-        if (! \cache()->has('peers:connectable:'.$this->ip.'-'.$this->port.'-'.$this->agent)) {
-            $con = @fsockopen($this->ip, $this->port, $_, $_, 1);
+        if (\config('announce.connectable_check') == true) {
 
-            $this->connectable = \is_resource($con);
-            \cache()->put('peers:connectable:'.$this->ip.'-'.$this->port.'-'.$this->agent, $this->connectable, now()->addDay());
+            $tmp_ip = $this->ip;
 
-            if (\is_resource($con)) {
-                \fclose($con);
+            // IPv6 Check
+            if (filter_var($tmp_ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6)){
+                $tmp_ip = "[".$tmp_ip."]";
+            }
+
+            if (! \cache()->has('peers:connectable:'.$tmp_ip.'-'.$this->port.'-'.$this->agent)) {
+
+                $con = @fsockopen($tmp_ip, $this->port, $_, $_, 1);
+
+                $this->connectable = \is_resource($con);
+                \cache()->put('peers:connectable:'.$tmp_ip.'-'.$this->port.'-'.$this->agent, $this->connectable, now()->addSeconds(config('announce.connectable_check_interval')));
+
+                if (\is_resource($con)) {
+                    \fclose($con);
+                }
+
+                // See https://laracasts.com/discuss/channels/eloquent/use-update-without-updating-timestamps?page=1&replyId=680133
+                Peer::where('ip', '=', $tmp_ip)->where('port', '=', $this->port)->where('agent', '=', $this->agent)->update(['connectable' => $this->connectable, 'updated_at' => DB::raw('updated_at')]);
             }
         }
     }

--- a/app/Models/Peer.php
+++ b/app/Models/Peer.php
@@ -131,7 +131,7 @@ class Peer extends Model
 
             // IPv6 Check
             if (filter_var($tmp_ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6)) {
-                $tmp_ip = "[".$tmp_ip."]";
+                $tmp_ip = '['.$tmp_ip.']';
             }
 
             if (! \cache()->has('peers:connectable:'.$tmp_ip.'-'.$this->port.'-'.$this->agent)) {

--- a/app/Models/Peer.php
+++ b/app/Models/Peer.php
@@ -130,7 +130,7 @@ class Peer extends Model
             $tmp_ip = $this->ip;
 
             // IPv6 Check
-            if (filter_var($tmp_ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6)){
+            if (filter_var($tmp_ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6)) {
                 $tmp_ip = "[".$tmp_ip."]";
             }
 

--- a/config/announce.php
+++ b/config/announce.php
@@ -48,13 +48,26 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Connectable check interval
+    | Client Connectable Check
     |--------------------------------------------------------------------------
     |
-    | Amount Of Time until the next connectable check
+    | This option enables/disables Client connectivity check
+    | !!! Attention: Will result in leaking the server IP! !!!
+    | It will result in higher disc / DB IO
     |
     */
 
-    'connectable_check_interval' => 60 * 20,
+    'connectable_check' => false,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Connectable Check Interval
+    |--------------------------------------------------------------------------
+    |
+    | Amount Of Time until the next connectable check in seconds
+    |
+    */
+
+    'connectable_check_interval' => 60 * 30,
 
 ];

--- a/resources/views/user/profile.blade.php
+++ b/resources/views/user/profile.blade.php
@@ -547,7 +547,9 @@
                             <th>@lang('torrent.started')</th>
                             <th>@lang('torrent.last-update')</th>
                             <th>@lang('torrent.torrents')</th>
-                            {{--<th>Connectable</th>--}}
+                            @if (\config('announce.connectable_check') == true)
+                            <th>Connectable</th>
+                            @endif
                         </tr>
                     </thead>
                     <tbody>
@@ -568,7 +570,9 @@
                                         <span itemprop="title" class="l-breadcrumb-item-link-title">{{ $count }}</span>
                                     </a>
                                 </td>
-                                {{--<td>@choice('user.client-connectable-state', $p->connectable)</td>--}}
+                                @if (\config('announce.connectable_check') == true)
+                                <td>@choice('user.client-connectable-state', $p->connectable)</td>
+                                @endif
                             </tr>
 			                @php array_push($peer_array, [$p->ip, $p->port]); @endphp
 			            @endif


### PR DESCRIPTION
- Fix Eloquent updating "updated_at" in Connectable Check resulting in incorrect seed time. 
-> Reference: https://laracasts.com/discuss/channels/eloquent/use-update-without-updating-timestamps?page=1&replyId=680133

- Fix Connectable Check for IPv6