### PR TITLE
Remove duplication of borders in CSS to get back user status circle in chat

### DIFF
--- a/resources/sass/main/_custom.scss
+++ b/resources/sass/main/_custom.scss
@@ -10812,7 +10812,6 @@ div.single_column {
 #frame .content .messages ul li.sent img.chat-user-image {
     height: 40px;
     width: 40px;
-    border: 2px !important;
 }
 /* Message header */
 .sent > h4 {

--- a/resources/sass/themes/galactic.scss
+++ b/resources/sass/themes/galactic.scss
@@ -994,7 +994,6 @@ pre {
 #frame .content .messages ul li.sent img.chat-user-image {
     height: 40px;
     width: 40px;
-    border: 2px !important;
 }
 /* Message header */
 .sent > h4 {


### PR DESCRIPTION
Borders have been defined multiple times and have been overwritten by other borders.
Removing them in the new "chat bubble" CSS part, will bring back the colored circles border for user profiles representing their online status.

[https://ibb.co/NtqV0B0](https://ibb.co/NtqV0B0)