### PR TITLE
(Update) Select current forum type as default when updating forums

### DIFF
--- a/resources/views/Staff/forum/edit.blade.php
+++ b/resources/views/Staff/forum/edit.blade.php
@@ -45,8 +45,13 @@
                 <label for="forum_type">Forum Type</label>
                 <label>
                     <select name="forum_type" class="form-control">
-                        <option value="category">Category</option>
-                        <option value="forum">Forum</option>
+                        @if ($forum->getCategory() == null)
+                            <option value="category" selected>Category (Current)</option>
+                            <option value="forum">Forum</option>
+                        @else
+                            <option value="category">Category</option>
+                            <option value="forum" selected>Forum (Current)</option>
+                        @endif
                     </select>
                 </label>
             </div>
@@ -56,7 +61,7 @@
                 <label>
                     <select name="parent_id" class="form-control">
                         @if ($forum->getCategory() != null)
-                            <option value="{{ $forum->parent_id }}" selected>{{ $forum->getCategory()->name }}(Current)</option>
+                            <option value="{{ $forum->parent_id }}" selected>{{ $forum->getCategory()->name }} (Current)</option>
                         @endif
                         @foreach ($categories as $c)
                             <option value="{{ $c->id }}">{{ $c->name }}</option>


### PR DESCRIPTION
When editing forum properties, it will automatically change the forum type to "Category". This PR prevents you from needing to remember to always correct it after changing other unrelated properties.