### PR TITLE
(Update) Peerlist generation

### DIFF
--- a/app/Http/Controllers/AnnounceController.php
+++ b/app/Http/Controllers/AnnounceController.php
@@ -451,7 +451,12 @@ class AnnounceController extends Controller
             $limit = ($queries['numwant'] <= 50 ? $queries['numwant'] : 50);
 
             // Get Torrents Peers
-            $peers = Peer::where('torrent_id', '=', $torrent->id)->where('user_id', '!=', $user->id)->take($limit)->get()->toArray();
+            if ($queries['left'] == 0) {
+                // Only include leechers in a seeder's peerlist
+                $peers = Peer::where('torrent_id', '=', $torrent->id)->where('seeder', '=', 0)->where('user_id', '!=', $user->id)->take($limit)->get()->toArray();
+            } else {
+                $peers = Peer::where('torrent_id', '=', $torrent->id)->where('user_id', '!=', $user->id)->take($limit)->get()->toArray();
+            }
 
             $repDict['peers'] = $this->givePeers($peers, $queries['compact'], $queries['no_peer_id']);
             $repDict['peers6'] = $this->givePeers($peers, $queries['compact'], $queries['no_peer_id'], FILTER_FLAG_IPV6);


### PR DESCRIPTION
This optimizes the peerlist generated for seeders. Since there is never a situation where a seeder needs to connect to another seeder, we can prevent the situation entirely by not providing those IPs to the client. This is helpful for seeders with thousands of torrents (with many seeds, but few leeches) and subpar networking equipment.