### PR TITLE
(Update) Redirect to intended page upon login

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -124,7 +124,7 @@ class LoginController extends Controller
                 ->withWarning(\trans('auth.require-rules'));
         }
 
-        return \redirect()->route('home.index')
+        return \redirect()->intended()
             ->withSuccess(\trans('auth.welcome'));
     }
 }


### PR DESCRIPTION
Makes it easier to view the intended page (after login) if you were sent a link to the site while being logged out. Redirects to the home page for logins through other means (e.g. being disabled) were kept to maintain emphasis on the notification message.