### PR TITLE
(Fix) German Translations

### DIFF
--- a/resources/lang/de/torrent.php
+++ b/resources/lang/de/torrent.php
@@ -34,7 +34,7 @@ return [
     'categories'               => 'Kategorien',
     'category'                 => 'Kategorie',
     'client'                   => 'Client',
-    'commited'                 => 'Begangen',
+    'commited'                 => 'Engagierter',
     'completed'                => 'Abgeschlossen',
     'completed_at'             => 'Abgeschlossen am',
     'completed-not-seeding'    => 'Du hast diesen Download abgeschlossen, seedest aber nicht mehr',


### PR DESCRIPTION
sounds more natural.

you commited a federal offence ~ du hast eine Straftat begangen
you are commited in a club ~ du bist engagiert in einem verein

normally it would be in lower case, but it's only occurrence is in index.blade.php where it starts a line -> First letter in upper case because it looks better in german

someone with write access should think about changing 'commited' to 'committed' everywhere