### PR TITLE
(Fix) Markdown Helper

### DIFF
--- a/app/Helpers/Markdown.php
+++ b/app/Helpers/Markdown.php
@@ -1337,7 +1337,7 @@ class Markdown
 
     protected function inlineSpecialCharacter($Excerpt)
     {
-        if (\substr($Excerpt['text'], 1, 1) !== ' ' && \str_contains($Excerpt['text'], ';') && \preg_match('#^&(#?+[0-9a-zA-Z]++);#', $Excerpt['text'], $matches)
+        if (\substr($Excerpt['text'], 1, 1) !== ' ' && \str_contains($Excerpt['text'], ';') && \preg_match('/^&(#?+[0-9a-zA-Z]++);/', $Excerpt['text'], $matches)
         ) {
             return [
                 'element' => ['rawHtml' => '&'.$matches[1].';'],


### PR DESCRIPTION
The preg_match was erroring due to an unescaped hash.
Fixed the bug switching it to be slash delimited.
This preg_match needed either a different delimiter or escaped hash.
Opted to use the different delimiter due to a slash being more common.