### PR TITLE
(Add) Torrent Client Stats

### DIFF
--- a/app/Console/Commands/AutoStatsClients.php
+++ b/app/Console/Commands/AutoStatsClients.php
@@ -49,12 +49,12 @@ class AutoStatsClients extends Command
             if (! \in_array($peer->user_id, $user_id)) {
                 $user_id[] = $peer->user_id;
                 $clients_tmp[] = $peer->agent;
-                $clients[(string)$peer->agent] = 1;
+                $clients[(string) $peer->agent] = 1;
             } elseif (! \in_array($peer->agent, $clients_tmp) && \in_array($peer->user_id, $user_id)) {
                 $clients_tmp[] = $peer->agent;
-                $clients[(string)$peer->agent] = 1;
+                $clients[(string) $peer->agent] = 1;
             } else {
-                ++$clients[(string)$peer->agent];
+                ++$clients[(string) $peer->agent];
             }
         }
 

--- a/app/Console/Commands/AutoStatsClients.php
+++ b/app/Console/Commands/AutoStatsClients.php
@@ -52,7 +52,7 @@ class AutoStatsClients extends Command
                 array_push($user_id, $peer->user_id);
                 array_push($clients_tmp, $peer->agent);
                 $clients[strval($peer->agent)] = 1;
-            } else if(! in_array($peer->agent, $clients_tmp) && in_array($peer->user_id, $user_id)) {
+            } elseif(! in_array($peer->agent, $clients_tmp) && in_array($peer->user_id, $user_id)) {
                 array_push($clients_tmp, $peer->agent);
                 $clients[strval($peer->agent)] = 1;
             } else {
@@ -60,7 +60,7 @@ class AutoStatsClients extends Command
             }
         }
 
-        if(! empty($clients)) {
+        if (! empty($clients)) {
             \cache()->put('stats:clients', $clients, Carbon::now()->addMinutes(1440));
         }
 

--- a/app/Console/Commands/AutoStatsClients.php
+++ b/app/Console/Commands/AutoStatsClients.php
@@ -59,6 +59,9 @@ class AutoStatsClients extends Command
         }
 
         if (! empty($clients)) {
+            // Sort Clients by Array Key Alphabetically
+            \ksort($clients);
+
             \cache()->put('stats:clients', $clients, Carbon::now()->addMinutes(1440));
         }
 

--- a/app/Console/Commands/AutoStatsClients.php
+++ b/app/Console/Commands/AutoStatsClients.php
@@ -54,7 +54,7 @@ class AutoStatsClients extends Command
                 $clients_tmp[] = $peer->agent;
                 $clients[(string) $peer->agent] = 1;
             } else {
-                ++$clients[(string) $peer->agent];
+                $clients[(string) $peer->agent]++;
             }
         }
 

--- a/app/Console/Commands/AutoStatsClients.php
+++ b/app/Console/Commands/AutoStatsClients.php
@@ -52,7 +52,7 @@ class AutoStatsClients extends Command
                 array_push($user_id, $peer->user_id);
                 array_push($clients_tmp, $peer->agent);
                 $clients[strval($peer->agent)] = 1;
-            } elseif(! in_array($peer->agent, $clients_tmp) && in_array($peer->user_id, $user_id)) {
+            } elseif (! in_array($peer->agent, $clients_tmp) && in_array($peer->user_id, $user_id)) {
                 array_push($clients_tmp, $peer->agent);
                 $clients[strval($peer->agent)] = 1;
             } else {

--- a/app/Console/Commands/AutoStatsClients.php
+++ b/app/Console/Commands/AutoStatsClients.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * NOTICE OF LICENSE.
+ *
+ * UNIT3D Community Edition is open-sourced software licensed under the GNU Affero General Public License v3.0
+ * The details is bundled with this project in the file LICENSE.txt.
+ *
+ * @project    UNIT3D Community Edition
+ *
+ * @author     HDVinnie <hdinnovations@protonmail.com>
+ * @license    https://www.gnu.org/licenses/agpl-3.0.en.html/ GNU Affero General Public License v3.0
+ */
+
+namespace App\Console\Commands;
+
+use App\Models\Peer;
+use Carbon\Carbon;
+use Illuminate\Console\Command;
+
+class AutoStatsClients extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'auto:stats_clients';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Updates the Client Stats daily.';
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $peers = Peer::where('seeder', '=', 1)->get();
+
+        $user_id = [];
+        $clients = [];
+        $clients_tmp = [];
+
+        // Goal is to calculate the number of users and not the peer count
+        foreach ($peers as $peer) {
+            if (!in_array($peer->user_id, $user_id)){
+                array_push($user_id, $peer->user_id);
+                array_push($clients_tmp, $peer->agent);
+                $clients[strval($peer->agent)] = 1;
+            }
+            else if(!in_array($peer->agent, $clients_tmp) && in_array($peer->user_id, $user_id))
+            {
+                array_push($clients_tmp, $peer->agent);
+                $clients[strval($peer->agent)] = 1;
+            }
+            else
+            {
+                $clients[strval($peer->agent)] += 1;
+            }
+        }
+
+        if(!empty($clients)) {
+            \cache()->put('stats:clients', $clients, Carbon::now()->addMinutes(1440));
+        }
+
+        $this->comment('Automated Client Stats Completed.');
+    }
+}

--- a/app/Console/Commands/AutoStatsClients.php
+++ b/app/Console/Commands/AutoStatsClients.php
@@ -35,10 +35,8 @@ class AutoStatsClients extends Command
 
     /**
      * Execute the console command.
-     *
-     * @return mixed
      */
-    public function handle()
+    public function handle(): mixed
     {
         $peers = Peer::where('seeder', '=', 1)->get();
 
@@ -48,15 +46,15 @@ class AutoStatsClients extends Command
 
         // Goal is to calculate the number of users and not the peer count
         foreach ($peers as $peer) {
-            if (! in_array($peer->user_id, $user_id)) {
-                array_push($user_id, $peer->user_id);
-                array_push($clients_tmp, $peer->agent);
-                $clients[strval($peer->agent)] = 1;
-            } elseif (! in_array($peer->agent, $clients_tmp) && in_array($peer->user_id, $user_id)) {
-                array_push($clients_tmp, $peer->agent);
-                $clients[strval($peer->agent)] = 1;
+            if (! \in_array($peer->user_id, $user_id)) {
+                $user_id[] = $peer->user_id;
+                $clients_tmp[] = $peer->agent;
+                $clients[(string)$peer->agent] = 1;
+            } elseif (! \in_array($peer->agent, $clients_tmp) && \in_array($peer->user_id, $user_id)) {
+                $clients_tmp[] = $peer->agent;
+                $clients[(string)$peer->agent] = 1;
             } else {
-                $clients[strval($peer->agent)] += 1;
+                ++$clients[(string)$peer->agent];
             }
         }
 

--- a/app/Console/Commands/AutoStatsClients.php
+++ b/app/Console/Commands/AutoStatsClients.php
@@ -48,23 +48,19 @@ class AutoStatsClients extends Command
 
         // Goal is to calculate the number of users and not the peer count
         foreach ($peers as $peer) {
-            if (!in_array($peer->user_id, $user_id)){
+            if (! in_array($peer->user_id, $user_id)) {
                 array_push($user_id, $peer->user_id);
                 array_push($clients_tmp, $peer->agent);
                 $clients[strval($peer->agent)] = 1;
-            }
-            else if(!in_array($peer->agent, $clients_tmp) && in_array($peer->user_id, $user_id))
-            {
+            } else if(! in_array($peer->agent, $clients_tmp) && in_array($peer->user_id, $user_id)) {
                 array_push($clients_tmp, $peer->agent);
                 $clients[strval($peer->agent)] = 1;
-            }
-            else
-            {
+            } else {
                 $clients[strval($peer->agent)] += 1;
             }
         }
 
-        if(!empty($clients)) {
+        if(! empty($clients)) {
             \cache()->put('stats:clients', $clients, Carbon::now()->addMinutes(1440));
         }
 

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -58,6 +58,7 @@ class Kernel extends ConsoleKernel
         $schedule->command('auto:sync_peers')->daily();
         $schedule->command('auto:email-blacklist-update')->weekends();
         $schedule->command('auto:reset_user_flushes')->daily();
+        $schedule->command('auto:stats_clients')->daily();
         //$schedule->command('auto:ban_disposable_users')->weekends();
         //$schedule->command('backup:clean')->daily();
         //$schedule->command('backup:run')->daily();

--- a/app/Http/Controllers/StatsController.php
+++ b/app/Http/Controllers/StatsController.php
@@ -358,4 +358,18 @@ class StatsController extends Controller
 
         return \view('stats.languages.languages', ['languages' => $languages]);
     }
+
+    /**
+     * Show Extra-Stats Clients.
+     */
+    public function clients(): \Illuminate\Contracts\View\Factory | \Illuminate\View\View
+    {
+        $clients = [];
+
+        if (\cache()->has('stats:clients')) {
+            $clients = \cache()->get('stats:clients');
+        }
+
+        return \view('stats.clients.clients', ['clients' => $clients]);
+    }
 }

--- a/app/Http/Controllers/StatsController.php
+++ b/app/Http/Controllers/StatsController.php
@@ -362,7 +362,7 @@ class StatsController extends Controller
     /**
      * Show Extra-Stats Clients.
      */
-    public function clients(): \Illuminate\Contracts\View\Factory | \Illuminate\View\View
+    public function clients(): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
     {
         $clients = [];
 

--- a/resources/views/stats/clients/clients.blade.php
+++ b/resources/views/stats/clients/clients.blade.php
@@ -24,6 +24,7 @@
             <hr>
             <div class="row col-md-offset-1">
                 @foreach ($clients as $key => $value)
+                    @php if (\strlen($key) > 26) { $key = substr($key, 0, 23).'...'; } @endphp
                     <div class="well col-md-3" style="margin: 10px;">
                         <div class="text-center">
                             <h3 class="text-success">{{ $key }}</h3>

--- a/resources/views/stats/clients/clients.blade.php
+++ b/resources/views/stats/clients/clients.blade.php
@@ -1,0 +1,37 @@
+@extends('layout.default')
+
+@section('title')
+    <title>@lang('stat.stats') - {{ config('other.title') }}</title>
+@endsection
+
+@section('breadcrumb')
+    <li class="active">
+        <a href="{{ route('stats') }}" itemprop="url" class="l-breadcrumb-item-link">
+            <span itemprop="title" class="l-breadcrumb-item-link-title">@lang('stat.stats')</span>
+        </a>
+    </li>
+    <li>
+        <a href="{{ route('languages') }}" itemprop="url" class="l-breadcrumb-item-link">
+            <span itemprop="title" class="l-breadcrumb-item-link-title">Clients</span>
+        </a>
+    </li>
+@endsection
+
+@section('content')
+    <div class="container">
+        <div class="block">
+            <h2>Clients</h2>
+            <hr>
+            <div class="row col-md-offset-1">
+                @foreach ($clients as $key => $value)
+                    <div class="well col-md-3" style="margin: 10px;">
+                        <div class="text-center">
+                            <h3 class="text-success">{{ $key }}</h3>
+                            <span class="badge-extra text-blue">Used by {{ $value }} User(s)</span>
+                        </div>
+                    </div>
+                @endforeach
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/stats/index.blade.php
+++ b/resources/views/stats/index.blade.php
@@ -140,6 +140,13 @@
         <div class="row">
             <div class="col-sm-4">
                 <div class="well well-sm">
+                    <a href="{{ route('clients') }}">
+                        <p class="lead text-green text-center">Clients</p>
+                    </a>
+                </div>
+            </div>
+            <div class="col-sm-4">
+                <div class="well well-sm">
                     <a href="{{ route('uploaded') }}">
                         <p class="lead text-green text-center">@lang('common.users')</p>
                     </a>

--- a/routes/web.php
+++ b/routes/web.php
@@ -194,6 +194,7 @@ Route::group(['middleware' => 'language'], function () {
         // Extra-Stats System
         Route::group(['prefix' => 'stats'], function () {
             Route::get('/', [App\Http\Controllers\StatsController::class, 'index'])->name('stats');
+            Route::get('/user/clients', [App\Http\Controllers\StatsController::class, 'clients'])->name('clients');
             Route::get('/user/uploaded', [App\Http\Controllers\StatsController::class, 'uploaded'])->name('uploaded');
             Route::get('/user/downloaded', [App\Http\Controllers\StatsController::class, 'downloaded'])->name('downloaded');
             Route::get('/user/seeders', [App\Http\Controllers\StatsController::class, 'seeders'])->name('seeders');


### PR DESCRIPTION
Would recommend to test it... 

Not gonna lie, the job / command `AutoStatsClients.php` has pretty ugly looking code, but it works on prod.

A job to calculate the clients and users runs every 24h:
```php
$schedule->command('auto:stats_clients')->daily();
```

A new route has been added:
```php
Route::get('/user/clients', [App\Http\Controllers\StatsController::class, 'clients'])->name('clients');
```

Stats read from cache (see `StatsController.php`):
```php
$clients = [];

if (\cache()->has('stats:clients')) {
     $clients = \cache()->get('stats:clients');
}

return \view('stats.clients.clients', ['clients' => $clients]);
```

On stats page:

![grafik](https://user-images.githubusercontent.com/34812414/146073340-2ec469c8-73dd-406c-82c4-ee2582bf9d40.png)

When there is nothing in the cache / not run yet:

![grafik](https://user-images.githubusercontent.com/34812414/146073465-a95a1c70-5b99-42e7-915c-3311d12e018b.png)

Working behavior:

![grafik](https://user-images.githubusercontent.com/34812414/146073697-2acf2be6-e9ad-4639-a00d-d681aae236e1.png)
