### PR TITLE
(Feature) Allow custom seedtime for requested torrents

### DIFF
--- a/app/Console/Commands/AutoPreWarning.php
+++ b/app/Console/Commands/AutoPreWarning.php
@@ -58,13 +58,25 @@ class AutoPreWarning extends Command
                 ->where('seedtime', '<=', \config('hitrun.seedtime'))
                 ->where('updated_at', '<', $carbon->copy()->subDays(\config('hitrun.prewarn'))->toDateTimeString())
                 ->get();
+            $prewarnRequests = History::with(['user', 'torrent'])
+                ->where('prewarn', '=', 0)
+                ->where('hitrun', '=', 0)
+                ->where('immune', '=', 0)
+                ->where('actual_downloaded', '>', 0)
+                ->where('active', '=', 0)
+                ->where('seedtime', '<=', \config('hitrun.seedtime')+604800)
+                ->where('seedtime', '>=', \config('hitrun.seedtime'))
+                ->where('updated_at', '<', $carbon->copy()->subDays(\config('hitrun.prewarn'))->toDateTimeString())
+                ->get();
+            $merge = $prewarnRequests->merge($prewarn);
 
-            foreach ($prewarn as $pre) {
+            foreach ($merge as $pre) {
                 // Skip Prewarning if Torrent is NULL
                 // e.g. Torrent has been Rejected by a Moderator after it has been downloaded and not deleted
                 if (is_null($pre->torrent)) {
                     continue;
                 }
+
 
                 if (! $pre->user->group->is_immune && $pre->actual_downloaded > ($pre->torrent->size * (\config('hitrun.buffer') / 100))) {
                     $exsist = Warning::withTrashed()
@@ -76,14 +88,39 @@ class AutoPreWarning extends Command
                         $timeleft = \config('hitrun.grace') - \config('hitrun.prewarn');
 
                         // Send Private Message
-                        $pm = new PrivateMessage();
-                        $pm->sender_id = 1;
-                        $pm->receiver_id = $pre->user->id;
-                        $pm->subject = 'Hit and Run Warning Incoming';
-                        $pm->message = 'You have received a automated [b]PRE-WARNING PM[/b] from the system because [b]you have been disconnected for '.\config('hitrun.prewarn').\sprintf(' days on Torrent %s
-                                            and have not yet met the required seedtime rules set by ', $pre->torrent->name).\config('other.title').\sprintf('. If you fail to seed it within %s day(s) you will receive a automated WARNING which will last ', $timeleft).\config('hitrun.expire').' days![/b]
-                                            [color=red][b] THIS IS AN AUTOMATED SYSTEM MESSAGE, PLEASE DO NOT REPLY![/b][/color]';
-                        $pm->save();
+                        if ($prewarnRequests->contains('info_hash', $pre->torrent->info_hash)) {
+                            // When seedtime requirements for requested torrent
+                            $pm = new PrivateMessage();
+                            $pm->sender_id = 1;
+                            $pm->receiver_id = $pre->user->id;
+                            $pm->subject = \sprintf('Hit and Run Warning Incoming');
+                            $pm->message = \sprintf('You have received an automated [b]PRE-WARNING PM[/b] from the system, because [b]you have been disconnected[/b] for
+                                ').\config('hitrun.prewarn').\sprintf(' days on Torrent [u][url=/torrents/%s]%s[/url][/u].
+
+                                If you fail to seed it within %s day(s) you will receive an automated WARNING!
+
+                                You have requested this torrent, this means it is subject to the extended seedtime 
+                                requirements defined in our [u][url="/pages/1#RequestRules"]Request Rules[/url][/u].
+                                
+                                [color=red][b] THIS IS AN AUTOMATED SYSTEM MESSAGE, PLEASE DO NOT REPLY![/b][/color]',
+                                $pre->torrent->id, $pre->torrent->name, $timeleft);
+                            $pm->save();
+                        }
+                        else {
+                            // When seedtime requirements for default torrent
+                            $pm = new PrivateMessage();
+                            $pm->sender_id = 1;
+                            $pm->receiver_id = $pre->user->id;
+                            $pm->subject = 'Hit and Run Warning Incoming';
+                            $pm->message = \sprintf('You have received an automated [b]PRE-WARNING PM[/b] from the system, because [b]you have been disconnected[/b] for
+                                ').\config('hitrun.prewarn').\sprintf(' days on Torrent [u][url=/torrents/%s]%s[/url][/u].
+
+                                If you fail to seed it within %s day(s) you will receive an automated WARNING!
+                                
+                                [color=red][b] THIS IS AN AUTOMATED SYSTEM MESSAGE, PLEASE DO NOT REPLY![/b][/color]',
+                                $pre->torrent->id, $pre->torrent->name, $timeleft);
+                            $pm->save();
+                        }
 
                         // Set History Prewarn
                         $pre->prewarn = 1;

--- a/app/Console/Commands/AutoWarning.php
+++ b/app/Console/Commands/AutoWarning.php
@@ -15,6 +15,7 @@ namespace App\Console\Commands;
 
 use App\Models\History;
 use App\Models\PrivateMessage;
+use App\Models\TorrentRequest;
 use App\Models\Warning;
 use Carbon\Carbon;
 use Illuminate\Console\Command;
@@ -58,8 +59,19 @@ class AutoWarning extends Command
                 ->where('seedtime', '<', \config('hitrun.seedtime'))
                 ->where('updated_at', '<', $carbon->copy()->subDays(\config('hitrun.grace'))->toDateTimeString())
                 ->get();
+            $hitrunRequests = History::with(['user', 'torrent'])
+                ->where('actual_downloaded', '>', 0)
+                ->where('prewarn', '=', 1)
+                ->where('hitrun', '=', 0)
+                ->where('immune', '=', 0)
+                ->where('active', '=', 0)
+                ->where('seedtime', '<', \config('hitrun.seedtime')+604800)
+                ->where('seedtime', '>=', \config('hitrun.seedtime'))
+                ->where('updated_at', '<', $carbon->copy()->subDays(\config('hitrun.grace'))->toDateTimeString())
+                ->get();
+            $merge = $hitrunRequests->merge($hitrun);
 
-            foreach ($hitrun as $hr) {
+            foreach ($merge as $hr) {
                 if (! $hr->user->group->is_immune && $hr->actual_downloaded > ($hr->torrent->size * (\config('hitrun.buffer') / 100))) {
                     $exsist = Warning::withTrashed()
                         ->where('torrent', '=', $hr->torrent->id)
@@ -82,13 +94,34 @@ class AutoWarning extends Command
                         $hr->user->save();
 
                         // Send Private Message
-                        $pm = new PrivateMessage();
-                        $pm->sender_id = 1;
-                        $pm->receiver_id = $hr->user->id;
-                        $pm->subject = 'Hit and Run Warning Received';
-                        $pm->message = 'You have received a automated [b]WARNING[/b] from the system because [b]you failed to follow the Hit and Run rules in relation to Torrent '.$hr->torrent->name.'[/b]
-                            [color=red][b]THIS IS AN AUTOMATED SYSTEM MESSAGE, PLEASE DO NOT REPLY![/b][/color]';
-                        $pm->save();
+                        if ($hitrunRequests->contains('info_hash', $hr->torrent->info_hash)) {
+                            // When seedtime requirements for requested torrent
+                            $pm = new PrivateMessage();
+                            $pm->sender_id = 1;
+                            $pm->receiver_id = $hr->user->id;
+                            $pm->subject = \sprintf('Hit and Run Warning Received');
+                            $pm->message = \sprintf('You have received an automated [b]WARNING[/b] from the system, because you failed to follow the Hit and Run rules in relation to the Torrent:
+                                [u][url=/torrents/%s]%s[/url][/u].
+                                
+                                You have requested this torrent, this means it is subject to the extended seedtime requirements defined in our [u][url=/pages/1#RequestRules]Request Rules[/url][/u].
+                                
+                                [color=red][b]THIS IS AN AUTOMATED SYSTEM MESSAGE, PLEASE DO NOT REPLY![/b][/color]',
+                                $hr->torrent->id, $hr->torrent->name);
+                            $pm->save();
+                        }
+                        else {
+                            // When seedtime requirements for default torrent
+                            $pm = new PrivateMessage();
+                            $pm->sender_id = 1;
+                            $pm->receiver_id = $hr->user->id;
+                            $pm->subject = \sprintf('Hit and Run Warning Received');
+                            $pm->message = \sprintf('You have received an automated [b]WARNING[/b] from the system, because you failed to follow the Hit and Run rules in relation to Torrent:
+                                [u][url=/torrents/%s]%s[/url][/u].
+
+                                [color=red][b]THIS IS AN AUTOMATED SYSTEM MESSAGE, PLEASE DO NOT REPLY![/b][/color]',
+                                $hr->torrent->id, $hr->torrent->name);
+                            $pm->save();
+                        }
 
                         $hr->save();
                     }

--- a/app/Helpers/StringHelper.php
+++ b/app/Helpers/StringHelper.php
@@ -87,7 +87,7 @@ class StringHelper
      *
      * @return string
      */
-    public static function timeRemaining($seconds)
+    public static function timeRemaining($seconds, $fromRequest)
     {
         $minutes = 0;
         $hours = 0;
@@ -96,7 +96,12 @@ class StringHelper
         $months = 0;
         $years = 0;
 
-        $seconds = \config('hitrun.seedtime') - $seconds;
+        if ($fromRequest) {
+            $seconds = \config('hitrun.seedtime')+604800 - $seconds;
+        }
+        else {
+            $seconds = \config('hitrun.seedtime') - $seconds;
+        }
 
         if ($seconds == 0) {
             return 'N/A';

--- a/app/Http/Controllers/TorrentController.php
+++ b/app/Http/Controllers/TorrentController.php
@@ -460,8 +460,14 @@ class TorrentController extends Controller
     {
         $torrent = Torrent::withAnyStatus()->findOrFail($id);
         $history = History::with(['user'])->where('info_hash', '=', $torrent->info_hash)->latest()->get();
+        $userRequests = TorrentRequest::where('filled_hash', '=', $torrent->info_hash)->get()->toArray();
 
-        return \view('torrent.history', ['torrent' => $torrent, 'history' => $history]);
+        return \view('torrent.history', [
+            'torrent' => $torrent,
+            'history' => $history,
+            'userRequests' => $userRequests,
+        ]);
+
     }
 
     /**

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -1812,6 +1812,7 @@ class UserController extends Controller
         $hisUplCre = History::where('user_id', '=', $user->id)->sum('uploaded');
         $hisDownl = History::where('user_id', '=', $user->id)->sum('actual_downloaded');
         $hisDownlCre = History::where('user_id', '=', $user->id)->sum('downloaded');
+        $userRequests = TorrentRequest::where('user_id', '=', $user->id)->get()->toArray();
 
         if (\config('hitrun.enabled') == true) {
             $downloads = History::selectRaw('distinct(history.info_hash), max(torrents.name) as name, max(torrents.id), max(history.completed_at) as completed_at, max(history.created_at) as created_at, max(history.id) as id, max(history.user_id) as user_id, max(history.seedtime) as seedtime, max(history.seedtime) as satisfied_at, max(history.seeder) as seeder, max(torrents.size) as size,max(torrents.leechers) as leechers,max(torrents.seeders) as seeders,max(torrents.times_completed) as times_completed')->with(['torrent' => function ($query) {
@@ -1819,7 +1820,7 @@ class UserController extends Controller
             }])->leftJoin('torrents', 'torrents.info_hash', '=', 'history.info_hash')
                 ->whereRaw('history.actual_downloaded > (torrents.size * ('.(\config('hitrun.buffer') / 100).'))')
                 ->where('history.user_id', '=', $user->id)->groupBy('history.info_hash')->orderBy('satisfied_at', 'desc')
-                ->whereRaw('(history.seedtime < ? and history.immune != 1)', [\config('hitrun.seedtime')])
+                ->whereRaw('(history.immune != 1)')
                 ->paginate(50);
         } else {
             $downloads = History::selectRaw('distinct(history.info_hash), max(torrents.name) as name, max(torrents.id), max(history.completed_at) as completed_at, max(history.created_at) as created_at, max(history.id) as id, max(history.user_id) as user_id, max(history.seedtime) as seedtime, max(history.seedtime) as satisfied_at, max(history.seeder) as seeder, max(torrents.size) as size,max(torrents.leechers) as leechers,max(torrents.seeders) as seeders,max(torrents.times_completed) as times_completed')->with(['torrent' => function ($query) {
@@ -1839,6 +1840,7 @@ class UserController extends Controller
             'his_upl_cre'   => $hisUplCre,
             'his_downl'     => $hisDownl,
             'his_downl_cre' => $hisDownlCre,
+            'userRequests'  => $userRequests,
         ]);
     }
 

--- a/resources/views/torrent/history.blade.php
+++ b/resources/views/torrent/history.blade.php
@@ -95,16 +95,38 @@
                                 </td>
                                 <td>{{ $hpeers->created_at ? $hpeers->created_at->diffForHumans() : 'N/A' }}</td>
                                 <td>{{ $hpeers->updated_at ? $hpeers->updated_at->diffForHumans() : 'N/A' }}</td>
-                                @if ($hpeers->seedtime < config('hitrun.seedtime')) <td>
-                                        <span
-                                            class="badge-extra text-red">{{ App\Helpers\StringHelper::timeElapsed($hpeers->seedtime) }}</span>
-                                        </td>
+                                @foreach ($userRequests as $userRequest)
+                                    @if (in_array($hpeers->user_id, $userRequest))
+                                        @if ($hpeers->seedtime < config('hitrun.seedtime')+604800)
+                                            <td>
+                                                <span class="badge-extra text-red">
+                                                    {{ App\Helpers\StringHelper::timeElapsed($hpeers->seedtime) }}
+                                                </span>
+                                            </td>
+                                        @else
+                                            <td>
+                                                <span class="badge-extra text-green">
+                                                    {{ App\Helpers\StringHelper::timeElapsed($hpeers->seedtime) }}
+                                                </span>
+                                            </td>
+                                        @endif
                                     @else
-                                        <td>
-                                            <span
-                                                class="badge-extra text-green">{{ App\Helpers\StringHelper::timeElapsed($hpeers->seedtime) }}</span>
-                                        </td>
+                                        @if ($hpeers->seedtime < config('hitrun.seedtime'))
+                                            <td>
+                                                <span class="badge-extra text-red">
+                                                    {{ App\Helpers\StringHelper::timeElapsed($hpeers->seedtime) }}
+                                                </span>
+                                            </td>
+                                        @else
+                                            <td>
+                                                <span class="badge-extra text-green">
+                                                    {{ App\Helpers\StringHelper::timeElapsed($hpeers->seedtime) }}
+                                                </span>
+                                            </td>
+                                        @endif
                                     @endif
+                                @endforeach
+                                
                             </tr>
                         @endforeach
                     </tbody>

--- a/resources/views/user/private/unsatisfieds.blade.php
+++ b/resources/views/user/private/unsatisfieds.blade.php
@@ -122,44 +122,130 @@
                         </thead>
                         <tbody>
                             @foreach ($downloads as $download)
-                                <tr class="userFiltered" active="{{ $download->active ? '1' : '0' }}"
-                                    seeding="{{ $download->seeder == 1 ? '1' : '0' }}"
-                                    prewarned="{{ $download->prewarn ? '1' : '0' }}" hr="{{ $download->hitrun ? '1' : '0' }}"
-                                    immune="{{ $download->immune ? '1' : '0' }}">
-                                    <td>
-                                        <a class="view-torrent" href="{{ route('torrent', ['id' => $download->torrent->id]) }}">
-                                            {{ $download->torrent->name }}
-                                        </a>
-                                        <div class="pull-right">
-                                            <a href="{{ route('download', ['id' => $download->torrent->id]) }}">
-                                                <button class="btn btn-primary btn-circle" type="button"><i
-                                                        class="{{ config('other.font-awesome') }} fa-download"></i></button>
+                                @foreach ($userRequests as $userRequest)
+                                    @if (in_array($download->torrent->info_hash, $userRequest))
+                                        @if ($download->seedtime < config('hitrun.seedtime')+604800)
+                                            
+                                        
+                                            <tr class="userFiltered" active="{{ $download->active ? '1' : '0' }}"
+                                                seeding="{{ $download->seeder == 1 ? '1' : '0' }}"
+                                                prewarned="{{ $download->prewarn ? '1' : '0' }}" hr="{{ $download->hitrun ? '1' : '0' }}"
+                                                immune="{{ $download->immune ? '1' : '0' }}">
+                                                <td>
+                                                    <a class="view-torrent" href="{{ route('torrent', ['id' => $download->torrent->id]) }}">
+                                                        {{ $download->torrent->name }}
+                                                        <i class="fas fa-exclamation-circle text-orange" aria-hidden="true" data-toggle="tooltip" title="" data-original-title="
+                                                                You have requested this torrent, this means it is subject to the extended seedtime 
+                                                                requirements defined in our Request Rules.
+                                                            ">
+                                                        </i>
+                                                    </a>
+                                                    <div class="pull-right">
+                                                        <a href="{{ route('download', ['id' => $download->torrent->id]) }}">
+                                                            <button class="btn btn-primary btn-circle" type="button"><i
+                                                                    class="{{ config('other.font-awesome') }} fa-download"></i></button>
+                                                        </a>
+                                                    </div>
+                                                </td>
+                                                <td>
+                                                    <a
+                                                        href="{{ route('categories.show', ['id' => $download->torrent->category->id]) }}">{{ $download->torrent->category->name }}</a>
+                                                </td>
+                                                <td>
+                                                    <span class="badge-extra text-blue text-bold">
+                                                        {{ $download->torrent->getSize() }}</span>
+                                                </td>
+                                                <td>
+                                                    <span class="badge-extra text-green text-bold"> {{ $download->torrent->seeders }}</span>
+                                                </td>
+                                                <td>
+                                                    <span class="badge-extra text-red text-bold"> {{ $download->torrent->leechers }}</span>
+                                                </td>
+                                                <td>
+                                                    <span class="badge-extra text-orange text-bold">
+                                                        {{ $download->torrent->times_completed }} @lang('common.times')</span>
+                                                </td>
+                                                <td>
+                                                    {{ $download->completed_at && $download->completed_at != null ? $download->completed_at->diffForHumans() : 'N/A' }}
+                                                </td>
+                                                @if ($download->seedtime < config('hitrun.seedtime')+604800) <td>
+                                                    <span
+                                                        class="badge-extra text-red">{{ App\Helpers\StringHelper::timeRemaining($download->seedtime, $fromRequest = true) }}</span>
+                                                    </td>
+                                                @else
+                                                    <td>
+                                                        <span
+                                                            class="badge-extra text-green">{{ App\Helpers\StringHelper::timeElapsed($download->seedtime) }}</span>
+                                                    </td>
+                                                @endif
+                                                @if ($download->seedtime < config('hitrun.seedtime')+604800) <td>
+                                                    <span
+                                                        class="badge-extra text-red">{{ App\Helpers\StringHelper::timeElapsed($download->seedtime) }}</span>
+                                                    </td>
+                                                @else
+                                                    <td>
+                                                        <span
+                                                            class="badge-extra text-green">{{ App\Helpers\StringHelper::timeElapsed($download->seedtime) }}</span>
+                                                    </td>
+                                                @endif
+                                                <td>
+                                                    @if ($download->seeder == 1)
+                                                        <span
+                                                            class='label label-success'>{{ strtoupper(trans('torrent.downloaded')) }}</span>
+                                                    @else
+                                                        <span
+                                                            class='label label-danger'>{{ strtoupper(trans('torrent.not-downloaded')) }}</span>
+                                                    @endif
+                                                </td>
+                                            </tr>
+
+
+
+                                        @endif
+                                    @endif
+                                @endforeach
+                                @if (!in_array($download->torrent->info_hash, $userRequest) && $download->seedtime < config('hitrun.seedtime'))
+                                    
+                                
+                                    <tr class="userFiltered" active="{{ $download->active ? '1' : '0' }}"
+                                        seeding="{{ $download->seeder == 1 ? '1' : '0' }}"
+                                        prewarned="{{ $download->prewarn ? '1' : '0' }}" hr="{{ $download->hitrun ? '1' : '0' }}"
+                                        immune="{{ $download->immune ? '1' : '0' }}">
+                                        <td>
+                                            <a class="view-torrent" href="{{ route('torrent', ['id' => $download->torrent->id]) }}">
+                                                {{ $download->torrent->name }}
                                             </a>
-                                        </div>
-                                    </td>
-                                    <td>
-                                        <a
-                                            href="{{ route('categories.show', ['id' => $download->torrent->category->id]) }}">{{ $download->torrent->category->name }}</a>
-                                    </td>
-                                    <td>
-                                        <span class="badge-extra text-blue text-bold">
-                                            {{ $download->torrent->getSize() }}</span>
-                                    </td>
-                                    <td>
-                                        <span class="badge-extra text-green text-bold"> {{ $download->torrent->seeders }}</span>
-                                    </td>
-                                    <td>
-                                        <span class="badge-extra text-red text-bold"> {{ $download->torrent->leechers }}</span>
-                                    </td>
-                                    <td>
-                                        <span class="badge-extra text-orange text-bold">
-                                            {{ $download->torrent->times_completed }} @lang('common.times')</span>
-                                    </td>
-                                    <td>{{ $download->completed_at && $download->completed_at != null ? $download->completed_at->diffForHumans() : 'N/A' }}
-                                    </td>
-                                    @if ($download->seedtime < config('hitrun.seedtime')) <td>
+                                            <div class="pull-right">
+                                                <a href="{{ route('download', ['id' => $download->torrent->id]) }}">
+                                                    <button class="btn btn-primary btn-circle" type="button"><i
+                                                            class="{{ config('other.font-awesome') }} fa-download"></i></button>
+                                                </a>
+                                            </div>
+                                        </td>
+                                        <td>
+                                            <a
+                                                href="{{ route('categories.show', ['id' => $download->torrent->category->id]) }}">{{ $download->torrent->category->name }}</a>
+                                        </td>
+                                        <td>
+                                            <span class="badge-extra text-blue text-bold">
+                                                {{ $download->torrent->getSize() }}</span>
+                                        </td>
+                                        <td>
+                                            <span class="badge-extra text-green text-bold"> {{ $download->torrent->seeders }}</span>
+                                        </td>
+                                        <td>
+                                            <span class="badge-extra text-red text-bold"> {{ $download->torrent->leechers }}</span>
+                                        </td>
+                                        <td>
+                                            <span class="badge-extra text-orange text-bold">
+                                                {{ $download->torrent->times_completed }} @lang('common.times')</span>
+                                        </td>
+                                        <td>
+                                            {{ $download->completed_at && $download->completed_at != null ? $download->completed_at->diffForHumans() : 'N/A' }}
+                                        </td>
+                                        @if ($download->seedtime < config('hitrun.seedtime')) <td>
                                             <span
-                                                class="badge-extra text-red">{{ App\Helpers\StringHelper::timeRemaining($download->seedtime) }}</span>
+                                                class="badge-extra text-red">{{ App\Helpers\StringHelper::timeRemaining($download->seedtime, $fromRequest = false) }}</span>
                                             </td>
                                         @else
                                             <td>
@@ -168,25 +254,33 @@
                                             </td>
                                         @endif
                                         @if ($download->seedtime < config('hitrun.seedtime')) <td>
-                                                <span
-                                                    class="badge-extra text-red">{{ App\Helpers\StringHelper::timeElapsed($download->seedtime) }}</span>
-                                                </td>
-                                            @else
-                                                <td>
-                                                    <span
-                                                        class="badge-extra text-green">{{ App\Helpers\StringHelper::timeElapsed($download->seedtime) }}</span>
-                                                </td>
-                                            @endif
-                                            <td>
-                                                @if ($download->seeder == 1)
-                                                    <span
-                                                        class='label label-success'>{{ strtoupper(trans('torrent.downloaded')) }}</span>
-                                                @else
-                                                    <span
-                                                        class='label label-danger'>{{ strtoupper(trans('torrent.not-downloaded')) }}</span>
-                                                @endif
+                                            <span
+                                                class="badge-extra text-red">{{ App\Helpers\StringHelper::timeElapsed($download->seedtime) }}</span>
                                             </td>
-                                </tr>
+                                        @else
+                                            <td>
+                                                <span
+                                                    class="badge-extra text-green">{{ App\Helpers\StringHelper::timeElapsed($download->seedtime) }}</span>
+                                            </td>
+                                        @endif
+                                        <td>
+                                            @if ($download->seeder == 1)
+                                                <span
+                                                    class='label label-success'>{{ strtoupper(trans('torrent.downloaded')) }}</span>
+                                            @else
+                                                <span
+                                                    class='label label-danger'>{{ strtoupper(trans('torrent.not-downloaded')) }}</span>
+                                            @endif
+                                        </td>
+                                    </tr>
+
+
+                                @endif
+                                
+                                
+
+                                
+                                
                             @endforeach
                         </tbody>
                     </table>


### PR DESCRIPTION
Adds the ability to add a custom seedtime for torrents which have been requested by a user.

If a User creates a request (Movie XY), and this request gets filled & approved by the requester, he usually downloads the movie.
In this case this one user who has requested the movie, will have to seed for X seconds (configurable in config/hitrun.php).

Adjustment has been made to PreWarning & Warning command. As well as for the user's unsatisfied tab and for the Torrent's history tab.

ToDo:
- Add option to set seedtime in config file
- Testing for Pre- & Warning