### PR TITLE
Move Admin Panel to User CP

### DIFF
--- a/resources/views/partials/side_nav.blade.php
+++ b/resources/views/partials/side_nav.blade.php
@@ -146,14 +146,5 @@
                 <span class="selected"></span>
             </a>
         </li>
-        @if (auth()->user()->group->is_modo)
-            <li>
-                <a href="{{ route('staff.dashboard.index') }}">
-                    <i class="{{ config('other.font-awesome') }} fa-cogs" style=" font-size: 18px; color: #ffffff;"></i>
-                    <span class="menu-text">@lang('staff.staff-dashboard')</span>
-                    <span class="selected"></span>
-                </a>
-            </li>
-        @endif
     </ul>
 </aside>

--- a/resources/views/partials/top_nav.blade.php
+++ b/resources/views/partials/top_nav.blade.php
@@ -141,6 +141,13 @@
                             @lang('user.my-wishlist')
                         </a>
                     </li>
+                    @if (auth()->user()->group->is_modo)
+                        <li>
+                            <a href="{{ route('staff.dashboard.index') }}">
+                                <i class="{{ config('other.font-awesome') }} fa-cogs"></i>@lang('staff.staff-dashboard')
+                            </a>
+                        </li>
+                    @endif
                     <li>
                         <form role="form" method="POST" action="{{ route('logout') }}" style="background-color: #272634; clear: both; display: block; font-family: lato,sans-serif; font-weight: 400; line-height: 1.42857; padding: 6px 10px; white-space: nowrap; ">
                             @csrf

--- a/resources/views/partials/top_nav.blade.php
+++ b/resources/views/partials/top_nav.blade.php
@@ -102,7 +102,7 @@
                     </li>
                     <li>
                         <a href="{{ route('user_settings', ['username' => auth()->user()->username]) }}">
-                            <i class="{{ config('other.font-awesome') }} fa-cogs"></i> @lang('user.my-settings')
+                            <i class="{{ config('other.font-awesome') }} fa-user-cog"></i> @lang('user.my-settings')
                         </a>
                     </li>
                     <li>

--- a/resources/views/partials/top_nav.blade.php
+++ b/resources/views/partials/top_nav.blade.php
@@ -144,7 +144,7 @@
                     @if (auth()->user()->group->is_modo)
                         <li>
                             <a href="{{ route('staff.dashboard.index') }}">
-                                <i class="{{ config('other.font-awesome') }} fa-cogs"></i>@lang('staff.staff-dashboard')
+                                <i class="{{ config('other.font-awesome') }} fa-cog"></i>@lang('staff.staff-dashboard')
                             </a>
                         </li>
                     @endif


### PR DESCRIPTION
This PR removes the Admin Panel from side_nav and moves it to the User Control Panel in top_nav. Also changes User Settings and Admin Panel icons.