### PR TITLE
Update similar-torrent.blade.php

### DIFF
--- a/resources/views/livewire/similar-torrent.blade.php
+++ b/resources/views/livewire/similar-torrent.blade.php
@@ -71,7 +71,7 @@
 				@if($torrents->where('type_id', '=', $type->id)->count() > 0)
 					<thead>
 					<tr>
-						<th class="text-center dark-th" colspan="12">
+						<th class="text-left dark-th" colspan="12">
 							<span style="font-size: 16px;">{{ $type->name }}</span>
 						</th>
 					</tr>


### PR DESCRIPTION
Moves "Livewire Similar" heading text from center to left aligned for consistency and readability

https://gyazo.com/4c2fbc4c7f72292a351ad82345199f89.png