### PR TITLE
(Add) Limit BBCode Font size in User Profile ("About Me")

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -207,6 +207,15 @@ class UserController extends Controller
             }
         }
 
+        // Prevent User from abusing BBCODE Font Size (max. 99)
+        $aboutTemp = $request->input('about');
+        if(\str_contains($aboutTemp, '[size=')) {
+            if (\preg_match('/\[size=[0-9]{3,}\]/', $aboutTemp)) {
+                return \redirect()->route('users.show', ['username' => $user->username])
+                    ->withErrors('Font size is too big!');
+            }
+        }
+
         // Define data
         $user->title = $request->input('title');
         $user->about = $request->input('about');

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -209,7 +209,7 @@ class UserController extends Controller
 
         // Prevent User from abusing BBCODE Font Size (max. 99)
         $aboutTemp = $request->input('about');
-        if(\str_contains($aboutTemp, '[size=')) {
+        if (\str_contains($aboutTemp, '[size=')) {
             if (\preg_match('/\[size=[0-9]{3,}\]/', $aboutTemp)) {
                 return \redirect()->route('users.show', ['username' => $user->username])
                     ->withErrors('Font size is too big!');


### PR DESCRIPTION
This limits the maximum BBCode font size to 99 with simple regex.

Why this addition? : Because there are very "interesting" users which will set it to ridiculous values.

Maybe this can be done better, but it's enough at first.