### PR TITLE
(Add) Limit BBCode Font size in Shoutbox

### DIFF
--- a/resources/js/components/chat/Chatbox.vue
+++ b/resources/js/components/chat/Chatbox.vue
@@ -1006,6 +1006,9 @@ export default {
         },
         /* User defaults to System user */
         createMessage(message, save = true, user_id = 1, receiver_id = null, bot_id = null) {
+            // Prevent Users abusing BBCode size
+            const regex = new RegExp(/\[size=[0-9]{3,}\]/);
+            if (regex.test(message) == true) return;
             if (this.tab == 'userlist') return;
             axios
                 .post('/api/chat/messages', {


### PR DESCRIPTION
This limits the maximum BBCode font size in the shoutbox to 99 with simple regex.

Maybe something to add in the future, is to notify the user that it's not allowed.

Messages which are matching the regex are simply not send.

