### PR TITLE
(Fix) free leech amount when featured using the API

### DIFF
--- a/app/Http/Controllers/API/TorrentController.php
+++ b/app/Http/Controllers/API/TorrentController.php
@@ -150,7 +150,7 @@ class TorrentController extends BaseController
 
         // Set freeleech and doubleup if featured
         if ($torrent->featured == 1) {
-            $torrent->free = '1';
+            $torrent->free = '100';
             $torrent->doubleup = '1';
         }
 


### PR DESCRIPTION
Set free to be 100 if the torrent is featured using the API.
Was previously set to 1 which will only act as a 1% free buff.
