### PR TITLE
(Refactor) quick search - unify, keyboard navigation

### DIFF
--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -8,6 +8,7 @@
 @import '~sweetalert2/src/sweetalert2';
 @import '../js/wysibb/theme/default/wbbtheme.css';
 @import 'vendor/virtual-select';
+@import 'vendor/alpinejs';
 
 // UNIT3D components
 @import 'variables';
@@ -16,3 +17,4 @@
 @import 'main/aboutus';
 @import 'chat/chatbox';
 @import 'main/tooltips';
+@import 'components/quick_search';

--- a/resources/sass/components/_quick_search.scss
+++ b/resources/sass/components/_quick_search.scss
@@ -1,0 +1,158 @@
+.quick-search {
+    position: relative;
+    max-width: 280px;
+    margin-top: 8px;
+}
+
+.quick-search:active,
+.quick-search:focus-within {
+    box-shadow: 0 4px 6px rgba(32, 33, 36, 0.28);
+    border-radius: 16px;
+}
+
+.quick-search__inputs {
+    display: flex;
+    /* Ordered backwards for better keyboard navigation */
+    flex-direction: row-reverse;
+    align-items: stretch;
+    gap: 2px;
+    background-color: #444;
+    border-radius: 16px;
+    overflow: hidden;
+    border: 1px solid transparent;
+    height: 32px;
+}
+
+.quick-search:active .quick-search__inputs,
+.quick-search:focus-within .quick-search__inputs {
+    border-radius: 16px 16px 0 0;
+}
+
+.quick-search__input {
+    width: 100%;
+    background-color: inherit;
+    border: none;
+    font-size: 13px;
+    padding: 1px 0 1px 8px;
+    color: #b6b6b6;
+}
+
+.quick-search__input::placeholder {
+    text-transform: capitalize;
+}
+
+.quick-search__input:focus {
+    outline: none;
+}
+
+.quick-search:not(:focus-within) .quick-search__results {
+    display: none;
+}
+
+.quick-search__radios {
+    display: flex;
+    align-items: stretch;
+    background-color: inherit;
+    cursor: pointer;
+    width: min-content;
+}
+
+.quick-search__radio-label {
+    cursor: pointer;
+    color: #b6b6b6;
+    display: flex;
+}
+
+.quick-search__radio-label:hover,
+.quick-search__radio-label:focus-within {
+    color: #ddd;
+}
+
+.quick-search__radio-icon {
+    height: 100%;
+}
+
+.quick-search__radio-icon:before {
+    display: block;
+    height: 100%;
+    width: 32px;
+    padding: 8px 0;
+    text-align: center;
+    font-size: 14px;
+}
+
+.quick-search__radio-icon:hover,
+.quick-search__radio-label:focus-within .quick-search__radio-icon {
+    background-color: #4b4b4b;
+}
+
+.quick-search__radio:checked ~ .quick-search__radio-icon:before {
+    background-color: #555;
+    color: #ddd;
+}
+
+.quick-search__radio {
+    position: absolute !important;
+    opacity: 0;
+    width: 0 !important;
+    height: 0 !important;
+
+    &::after {
+        width: 0 !important;
+        height: 0 !important;
+    }
+}
+
+.quick-search__results {
+    position: absolute;
+    left: 0;
+    top: 100%;
+    width: 100%;
+    border-radius: 0 0 16px 16px;
+    box-shadow: 0 4px 6px rgba(32, 33, 36, 0.28);
+    max-height: 80vh;
+    overflow-y: auto;
+}
+
+.quick-search__result-link,
+.quick-search__result--empty,
+.quick-search__result--keep-typing {
+    display: flex;
+    background-color: #444;
+    text-decoration: none;
+    color: #ccc;
+    font-size: 12px;
+}
+
+.quick-search__result-link {
+    padding: 12px;
+}
+
+.quick-search__result--empty,
+.quick-search__result--keep-typing {
+    padding: 0;
+}
+
+.quick-search__result-link:hover,
+.quick-search__result-link:focus {
+    background-color: #555;
+}
+
+.quick-search__image {
+    width: 40px;
+    border-radius: 5px;
+    height: min-content;
+}
+
+.quick-search__result-text {
+    margin: 0;
+    padding: 5px 10px;
+    display: grid;
+    align-items: center;
+    font-size: 13px;
+}
+
+.quick-search__result-year {
+    color: #888;
+    font-size: 13px;
+}

--- a/resources/sass/vendor/_alpinejs.scss
+++ b/resources/sass/vendor/_alpinejs.scss
@@ -1,0 +1,3 @@
+[x-cloak] {
+    display: none !important;
+}

--- a/resources/views/livewire/quick-search-dropdown.blade.php
+++ b/resources/views/livewire/quick-search-dropdown.blade.php
@@ -1,106 +1,187 @@
-<div style="width: 460px; min-height: 50px; display: block;" x-data="{ lock: false }">
-    <div class="text-center form-inline"
-         @focusout="if (!lock) { $wire.set('movie', ''); $wire.set('series', ''); $wire.set('person', ''); }">
-        <div class="form-group" style="position: relative; vertical-align: top;">
-            <input wire:model.debounce.250ms="movie" type="text" class="form-control" placeholder="Movie"
-                   autocomplete="off" style="width: 150px;"
-                   @focusin="$wire.set('series', ''); $wire.set('person', '');">
+<div
+    class="quick-search"
+    x-data="{ search: 'movie', ...quickSearchKeyboardNavigation() }"
+    x-on:keydown.escape.window="$refs.movieSearch.blur(); $refs.seriesSearch.blur(); $refs.personSearch.blur()"
+>
+    <div class="quick-search__inputs">
+        <div class="quick-search__radios">
+            <label class="quick-search__radio-label">
+                <input
+                    type="radio"
+                    class="quick-search__radio"
+                    x-on:click="
+                        search = 'movie';
+                        $wire.set('series', '');
+                        $wire.set('person', '');
+                        $nextTick(() => $refs.movieSearch.focus());
+                    "
+                />
+                <i
+                    class="quick-search__radio-icon {{ \config('other.font-awesome') }} fa-camera-movie"
+                    title="{{ __('mediahub.movies') }}"
+                ></i>
+            </label>
+            <label class="quick-search__radio-label">
+                <input
+                    type="radio"
+                    class="quick-search__radio"
+                    x-on:click="
+                        search = 'series';
+                        $wire.set('movie', '');
+                        $wire.set('person', '');
+                        $nextTick(() => $refs.seriesSearch.focus());
+                    "
+                />
+                <i
+                    class="quick-search__radio-icon {{ \config('other.font-awesome') }} fa-tv-retro"
+                    title="{{ __('mediahub.shows') }}"
+                ></i>
+            </label>
+            <label class="quick-search__radio-label">
+                <input
+                    type="radio"
+                    class="quick-search__radio"
+                    x-on:click="
+                        search = 'person';
+                        $wire.set('movie', '');
+                        $wire.set('series', '');
+                        $nextTick(() => $refs.personSearch.focus());
+                    "
+                />
+                <i
+                    class="quick-search__radio-icon {{ \config('other.font-awesome') }} fa-user"
+                    title="{{ __('mediahub.persons') }}"
+                ></i>
+            </label>
         </div>
-        <div class="form-group" style="position: relative; vertical-align: top;">
-            <input wire:model.debounce.250ms="series" type="text" class="form-control" placeholder="Series"
-                   autocomplete="off" style="width: 150px;" @focusin="$wire.set('movie', ''); $wire.set('person', '');">
-        </div>
-        <div class="form-group" style="position: relative; vertical-align: top;">
-            <input wire:model.debounce.250ms="person" type="text" class="form-control" placeholder="Person"
-                   autocomplete="off" style="width: 150px;" @focusin="$wire.set('movie', ''); $wire.set('series', '');">
-        </div>
-    </div>
-    @if( strlen($movie) > 2  || strlen($series) > 2  || strlen($person) > 2)
-        <div style="width: 100%; min-height: 60px; margin: 0; padding: 3px; display: block; background-color: #2b2b2b;"
-             @mouseenter="lock = true;" @mouseleave="lock = false">
-            @forelse ($search_results as $search_result)
-                @if (strlen($movie) > 2 )
-                    <div id="movie.{{$search_result->id}}" class="row" style="cursor: pointer; margin-bottom: 5px;"
-                         @click="window.location.href = '{{ route('torrents.similar', ['category_id' => '1', 'tmdb' => $search_result->id]) }}'"
-                         @contextmenu.prevent="window.open('{{ route('torrents.similar', ['category_id' => '1', 'tmdb' => $search_result->id]) }}', '_blank').focus()"
-
-
+        <input
+            class="quick-search__input"
+            wire:model.debounce.250ms="movie"
+            type="text"
+            placeholder="Movie"
+            x-show="search == 'movie'"
+            x-ref="movieSearch"
+            x-on:keydown.down.prevent="$refs.searchResults.firstElementChild?.firstElementChild?.focus()"
+            x-on:keydown.up.prevent="$refs.searchResults.lastElementChild?.firstElementChild?.focus()"
+        />
+        <input
+            wire:model.debounce.250ms="series"
+            class="quick-search__input"
+            type="text"
+            placeholder="Series"
+            x-show="search == 'series'"
+            x-ref="seriesSearch"
+            x-cloak
+            x-on:keydown.down.prevent="$refs.searchResults.firstElementChild?.firstElementChild?.focus()"
+            x-on:keydown.up.prevent="$refs.searchResults.lastElementChild?.firstElementChild?.focus()"
+        />
+        <input
+            wire:model.debounce.250ms="person"
+            class="quick-search__input"
+            type="text"
+            placeholder="Person"
+            x-show="search == 'person'"
+            x-ref="personSearch"
+            x-cloak
+            x-on:keydown.down.prevent="$refs.searchResults.firstElementChild?.lastElementChild?.focus()"
+            x-on:keydown.up.prevent="$refs.searchResults.lastElementChild?.firstElementChild?.focus()"
+        />
+        @if (strlen($movie) >= 3  || strlen($series) >= 3  || strlen($person) >= 3)
+            <div class="quick-search__results" x-ref="searchResults">
+                @forelse ($search_results as $search_result)
+                    <article
+                        class="quick-search__result"
+                        x-on:keydown.down.prevent="quickSearchArrowDown($el)"
+                        x-on:keydown.up.prevent="quickSearchArrowUp($el)"
                     >
-                        <div class="col-xs-3 text-center">
-                            <img src="{{ $search_result->poster }}" style="height: 60px; padding: 0; margin: 0">
-                        </div>
-                        <div class="col-xs-9 text-left">
-                            <div style="height: 60px;">
-                                <p style="line-height: initial; height: 60px; display: table-cell; vertical-align: middle;">
-                                    {{ $search_result->title }} ({{ substr($search_result->release_date, 0, 4) }})
-                                </p>
-                            </div>
-                        </div>
-                    </div>
-                @elseif (strlen($series) > 2 )
-                    <div id="series.{{$search_result->id}}" class="row" style="cursor: pointer; margin-bottom: 5px;"
-                         @click="window.location.href = '{{ route('torrents.similar', ['category_id' => '2', 'tmdb' => $search_result->id]) }}'"
-                         @contextmenu.prevent="window.open('{{ route('torrents.similar', ['category_id' => '2', 'tmdb' => $search_result->id]) }}', '_blank').focus()"
-                    >
-                        <div class="col-xs-3 text-center">
-                            <img src="{{ $search_result->poster }}" style="height: 60px; padding: 0; margin: 0">
-                        </div>
-                        <div class="col-xs-9 text-left">
-                            <div style="height: 60px;">
-                                <p style="line-height: initial; height: 60px; display: table-cell; vertical-align: middle;">{{ $search_result->name }}
-                                    ({{ substr($search_result->first_air_date, 0, 4) }})
-                                </p>
-                            </div>
-                        </div>
-                    </div>
-
-                @elseif (strlen($person) > 2 )
-                    <div id="person.{{$search_result->id}}" class="row" style="cursor: pointer; margin-bottom: 5px;"
-                         @click="window.location.href = '{{ route('mediahub.persons.show', ['id' => $search_result->id]) }}'"
-                         @contextmenu.prevent="window.open('{{ route('mediahub.persons.show', ['id' => $search_result->id]) }}', '_blank').focus()"
-                    >
-                        <div class="col-xs-3 text-center">
-                            <img src="{{ $search_result->still }}" style="height: 60px; padding: 0; margin: 0">
-                        </div>
-                        <div class="col-xs-9 text-left">
-                            <div style="height: 60px;">
-                                <p style="line-height: initial; height: 60px; display: table-cell; vertical-align: middle;">
+                        @if (strlen($movie) >= 3 )
+                            <a
+                                class="quick-search__result-link"
+                                href="{{ route('torrents.similar', ['category_id' => '1', 'tmdb' => $search_result->id]) }}"
+                            >
+                                <img
+                                    class="quick-search__image"
+                                    src="{{ $search_result->poster }}"
+                                    alt="{{ __('torrent.poster') }}"
+                                />
+                                <h2 class="quick-search__result-text">
+                                    {{ $search_result->title }}
+                                    <time
+                                        class="quick-search__result-year"
+                                        datetime="{{ $search_result->release_date }}"
+                                    >
+                                        {{ substr($search_result->release_date, 0, 4) }}
+                                    </time>
+                                </h2>
+                            </a>
+                        @elseif (strlen($series) >= 3 )
+                            <a
+                                class="quick-search__result-link"
+                                href="{{ route('torrents.similar', ['category_id' => '2', 'tmdb' => $search_result->id]) }}"
+                            >
+                                <img
+                                    class="quick-search__image"
+                                    src="{{ $search_result->poster }}"
+                                    alt="{{ __('torrent.poster') }}"
+                                />
+                                <h2 class="quick-search__result-text">
                                     {{ $search_result->name }}
-                                </p>
-                            </div>
-                        </div>
-                    </div>
-                @endif
-            @empty
-                <div class="px-3 py-3">No results found</div>
-            @endforelse
-        </div>
-    @elseif( $movie || $series || $person)
-        <div style="width: 100%; min-height: 60px; margin: 0; padding: 3px; display: block; background-color: #2b2b2b;"
-             @mouseenter="lock = true;" @mouseleave="lock = false">
-            <div class="px-3 my-3">Keep typing to get results</div>
-        </div>
-    @endif
+                                    <time
+                                        class="quick-search__result-year"
+                                        datetime="{{ $search_result->first_air_date }}"
+                                    >
+                                        {{ substr($search_result->first_air_date, 0, 4) }}
+                                    </time>
+                                </h2>
+                            </a>
+                        @elseif (strlen($person) >= 3 )
+                            <a
+                                class="quick-search__result-link"
+                                href="{{ route('mediahub.persons.show', ['id' => $search_result->id]) }}"
+                            >
+                                <img
+                                    class="quick-search__image"
+                                    src="{{ $search_result->still }}"
+                                    alt="{{ __('torrent.poster') }}"
+                                />
+                                <h2 class="quick-search__result-text">
+                                    {{ $search_result->name }}
+                                </h2>
+                            </a>
+                        @endif
+                    </article>
+                @empty
+                    <article class="quick-search__result--empty">
+                        <p class="quick-search__result-text">No results found</p>
+                    </article>
+                @endforelse
+            </div>
+        @else
+            <div class="quick-search__results">
+                <article class="quick-search__result--keep-typing">
+                    <p class="quick-search__result-text">Keep typing to get results</p>
+                </article>
+            </div>
+        @endif
+    </div>
 </div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+<script nonce="{{ HDVinnie\SecureHeaders\SecureHeaders::nonce('script') }}">
+    function quickSearchKeyboardNavigation() {
+        return {
+            quickSearchArrowDown(el) {
+                if (el.nextElementSibling == null) {
+                    el.parentNode?.firstElementChild?.firstElementChild?.focus()
+                } else {
+                    el.nextElementSibling?.firstElementChild?.focus()
+                }
+            },
+            quickSearchArrowUp(el) {
+                if (el.previousElementSibling == null) {
+                    document.querySelector(`.quick-search__input:not([style='display: none;'])`)?.focus()
+                } else {
+                    el.previousElementSibling?.firstElementChild?.focus()
+                }        
+            }
+        }
+    }
+</script>


### PR DESCRIPTION
Unifies the 3 quick searches into a single search.
3 radio buttons are used to toggle between the searches.
Keyboard navigation is also added.
Proper theming will come in a future PR.

![image](https://user-images.githubusercontent.com/78790963/165064194-adb5c0b1-7a63-421e-9aac-1016ae0e2427.png)
