### PR TITLE
(Update) top navigation bar

### DIFF
--- a/resources/sass/components/_quick_search.scss
+++ b/resources/sass/components/_quick_search.scss
@@ -1,10 +1,10 @@
 .quick-search {
     position: relative;
-    max-width: 280px;
+    max-width: 360px;
     flex-grow: 1;
     z-index: 5;
 
-    @media screen and (max-width: 1280px) {
+    @media screen and (max-width: 1150px) {
         display: none;
     }
 }

--- a/resources/sass/layout/_top_nav.scss
+++ b/resources/sass/layout/_top_nav.scss
@@ -130,6 +130,18 @@
     text-decoration: none;
 }
 
+@media (hover: none) {
+    .top-nav__dropdown--nontouch {
+        display: none !important;
+    }
+}
+
+@media (hover: hover) {
+    .top-nav__dropdown--touch {
+        display: none !important;
+    }
+}
+
 .top-nav__dropdown > a > .top-nav--left__container {
     display: grid;
     align-items: center;

--- a/resources/sass/layout/_top_nav.scss
+++ b/resources/sass/layout/_top_nav.scss
@@ -5,6 +5,9 @@
     grid-template: 'left menus right toggle' 48px / 1fr auto 1fr auto;
     align-items: center;
     padding: 0 14px;
+    position: fixed;
+    width: 100vw;
+    z-index: 6;
 
     &.mobile {
         grid-template: 'left toggle' 'menus menus' 'right right' auto / 1fr auto;

--- a/resources/sass/layout/_top_nav.scss
+++ b/resources/sass/layout/_top_nav.scss
@@ -24,7 +24,7 @@
         gap: 16px;
     }
 
-    @media screen and (max-width: 1023px) {
+    @media screen and (max-width: 767px) {
         & .top-nav__site-logo,
         & .top-nav__branding i {
             font-size: 22px;
@@ -38,6 +38,11 @@
     display: flex;
     gap: 36px;
     justify-content: end;
+
+    &.mobile {
+        display: flex;
+        flex-direction: column;
+    }
 
     @media screen and (max-width: 1280px) {
         gap: 16px;
@@ -264,7 +269,7 @@
     grid-template-rows: repeat(2, auto);
     grid-template-columns: repeat(4, auto);
     grid-auto-flow: column;
-    font-size: 10px;
+    font-size: 11px;
     list-style-type: none;
     color: #ddd;
     align-content: center;
@@ -272,8 +277,24 @@
     padding: 0;
     margin: 0;
 
-    @media screen and (max-width: 767px) {
+    @media screen and (min-width: 767px) and (max-width: 1280px) {
         display: none;
+    }
+
+    @media screen and (min-width: 1800px) {
+        grid-template-rows: auto;
+        grid-template-columns: repeat(8, auto);
+        font-size: 12px;
+        margin: 0 48px;
+    }
+
+    @media screen and (max-width: 767px) {
+        font-size: 12px;
+        display: none;
+
+        &.mobile {
+            display: grid;
+        }
     }
 }
 
@@ -400,7 +421,7 @@
 ******************************************************************************/
 
 .top-nav__stats {
-    display: grid;
+    display: none;
     grid-template: 'up down ratio' auto 'up down ratio' auto / auto auto auto;
     column-gap: 18px;
     align-items: center;
@@ -413,25 +434,24 @@
     margin: 0;
     padding: 0;
 
-    @media screen and (max-width: 1280px) {
-        display: none;
+    @media screen and (min-width: 1023px) and (max-width: 1280px) {
+        display: grid;
     }
 }
 
 .top-nav__stats-up {
     grid-area: up;
+    white-space: nowrap;
 }
 
 .top-nav__stats-down {
     grid-area: down;
+    white-space: nowrap;
 }
 
 .top-nav__stats-ratio {
     grid-area: ratio;
-}
-
-.top-nav__stats-user {
-    grid-area: user;
+    white-space: nowrap;
 }
 
 /* Menu toggle
@@ -444,10 +464,10 @@
     border: none;
     color: #999;
 
-    @media screen and (min-width: 768px) {
+    @media screen and (min-width: 767px) {
         display: none;
 
-        &.expanded {
+        &.mobile {
             display: inline-block;
         }
     }

--- a/resources/sass/layout/_top_nav.scss
+++ b/resources/sass/layout/_top_nav.scss
@@ -285,7 +285,7 @@
         grid-template-rows: auto;
         grid-template-columns: repeat(8, auto);
         font-size: 12px;
-        margin: 0 48px;
+        margin: 0 40px;
     }
 
     @media screen and (max-width: 767px) {
@@ -470,5 +470,28 @@
         &.mobile {
             display: inline-block;
         }
+    }
+}
+
+/* Username and rank
+******************************************************************************/
+
+.top-nav__username.top-nav__username {
+    text-align: center;
+    padding: 12px 0 2px 0;
+    grid-template-columns: auto;
+}
+
+.top-nav__username--highresolution {
+    display: none;
+    align-items: center;
+    font-size: 14px;
+    
+    > span {
+        white-space: nowrap;
+    }
+
+    @media screen and (min-width: 1900px) {
+        display: flex;
     }
 }

--- a/resources/views/partials/top_nav.blade.php
+++ b/resources/views/partials/top_nav.blade.php
@@ -8,7 +8,12 @@
     </div>
     <ul class="top-nav__main-menus" x-bind:class="expanded && 'mobile'">
         <li class="top-nav--left__list-item top-nav__dropdown">
-            <a tabindex="0">
+            <a class="top-nav__dropdown--nontouch"  href="{{ route('torrents') }}">
+                <div class="top-nav--left__container">
+                    {{ __('torrent.torrents') }}
+                </div>
+            </a>
+            <a class="top-nav__dropdown--touch" tabindex="0">
                 <div class="top-nav--left__container">
                     {{ __('torrent.torrents') }}
                 </div>
@@ -41,7 +46,12 @@
             </ul>
         </li>
         <li class="top-nav--left__list-item top-nav__dropdown">
-            <a tabindex="0">
+            <a class="top-nav__dropdown--nontouch"  href="{{ route('forums.index') }}">
+                <div class="top-nav--left__container">
+                    {{ __('common.community') }}
+                </div>
+            </a>
+            <a class="top-nav__dropdown--touch" tabindex="0">
                 <div class="top-nav--left__container">
                     {{ __('common.community') }}
                 </div>

--- a/resources/views/partials/top_nav.blade.php
+++ b/resources/views/partials/top_nav.blade.php
@@ -221,6 +221,48 @@
                 {{ auth()->user()->getRatioString() }}
             </li>
         </ul> 
+        <ul class="top-nav__ratio-bar" x-bind:class="expanded && 'mobile'">
+            <li class="ratio-bar__uploaded" title="{{ __('common.upload') }}">
+                <i class="{{ config('other.font-awesome') }} fa-arrow-up"></i>
+                {{ auth()->user()->getUploaded() }}
+            </li>
+            <li class="ratio-bar__downloaded" title="{{ __('common.download') }}">
+                <i class="{{ config('other.font-awesome') }} fa-arrow-down"></i>
+                {{ auth()->user()->getDownloaded() }}
+            </li>
+            <li class="ratio-bar__seeding" title="{{ __('torrent.seeding') }}">
+                <a href="{{ route('user_active', ['username' => auth()->user()->username]) }}">
+                    <i class="{{ config('other.font-awesome') }} fa-upload"></i>
+                    {{ auth()->user()->getSeeding() }}
+                </a>
+            </li>
+            <li class="ratio-bar__leeching" title="{{ __('torrent.leeching') }}">
+                <a href="{{ route('user_active', ['username' => auth()->user()->username]) }}">
+                    <i class="{{ config('other.font-awesome') }} fa-download"></i>
+                    {{ auth()->user()->getLeeching() }}
+                </a>
+            </li>
+            <li class="ratio-bar__buffer" title="{{ __('common.buffer') }}">
+                <i class="{{ config('other.font-awesome') }} fa-exchange"></i>
+                {{ auth()->user()->untilRatio(config('other.ratio')) }}
+            </li>
+            <li class="ratio-bar__points" title="{{ __('user.my-bonus-points') }}">
+                <a href="{{ route('bonus') }}">
+                    <i class="{{ config('other.font-awesome') }} fa-coins" ></i>
+                    {{ auth()->user()->getSeedbonus() }}
+                </a>
+            </li>
+            <li class="ratio-bar__ratio" title="{{ __('common.ratio') }}">
+                <i class="{{ config('other.font-awesome') }} fa-sync-alt"></i>
+                {{ auth()->user()->getRatioString() }}
+            </li>
+            <li class="ratio-bar__tokens" title="{{ __('user.my-fl-tokens') }}">
+                <a href="{{ route('users.show', ['username' => auth()->user()->username]) }}">
+                    <i class="{{ config('other.font-awesome') }} fa-star"></i>
+                    {{ auth()->user()->fl_tokens }}
+                </a>
+            </li>
+        </ul> 
         <ul class="top-nav__icon-bar" x-bind:class="expanded && 'mobile'">
             @if (auth()->user()->group->is_modo)
                 <li>
@@ -273,50 +315,6 @@
                     >
                 </a>
                 <ul>
-                    <li>
-                        <ul class="top-nav__ratio-bar">
-                            <li class="ratio-bar__uploaded" title="{{ __('common.upload') }}">
-                                <i class="{{ config('other.font-awesome') }} fa-arrow-up text-green"></i>
-                                {{ auth()->user()->getUploaded() }}
-                            </li>
-                            <li class="ratio-bar__downloaded" title="{{ __('common.download') }}">
-                                <i class="{{ config('other.font-awesome') }} fa-arrow-down text-red"></i>
-                                {{ auth()->user()->getDownloaded() }}
-                            </li>
-                            <li class="ratio-bar__seeding" title="{{ __('torrent.seeding') }}">
-                                <a href="{{ route('user_active', ['username' => auth()->user()->username]) }}">
-                                    <i class="{{ config('other.font-awesome') }} fa-upload text-green"></i>
-                                    {{ auth()->user()->getSeeding() }}
-                                </a>
-                            </li>
-                            <li class="ratio-bar__leeching" title="{{ __('torrent.leeching') }}">
-                                <a href="{{ route('user_active', ['username' => auth()->user()->username]) }}">
-                                    <i class="{{ config('other.font-awesome') }} fa-download text-red"></i>
-                                    {{ auth()->user()->getLeeching() }}
-                                </a>
-                            </li>
-                            <li class="ratio-bar__buffer" title="{{ __('common.buffer') }}">
-                                <i class="{{ config('other.font-awesome') }} fa-exchange text-orange"></i>
-                                {{ auth()->user()->untilRatio(config('other.ratio')) }}
-                            </li>
-                            <li class="ratio-bar__points" title="{{ __('user.my-bonus-points') }}">
-                                <a href="{{ route('bonus') }}">
-                                    <i class="{{ config('other.font-awesome') }} fa-coins text-gold" ></i>
-                                    {{ auth()->user()->getSeedbonus() }}
-                                </a>
-                            </li>
-                            <li class="ratio-bar__ratio" title="{{ __('common.ratio') }}">
-                                <i class="{{ config('other.font-awesome') }} fa-sync-alt text-blue"></i>
-                                {{ auth()->user()->getRatioString() }}
-                            </li>
-                            <li class="ratio-bar__tokens" title="{{ __('user.my-fl-tokens') }}">
-                                <a href="{{ route('users.show', ['username' => auth()->user()->username]) }}">
-                                    <i class="{{ config('other.font-awesome') }} fa-star text-gold"></i>
-                                    {{ auth()->user()->fl_tokens }}
-                                </a>
-                            </li>
-                        </ul>
-                    </li>
                     <li>
                         <a href="{{ route('users.show', ['username' => auth()->user()->username]) }}">
                             <i class="{{ config('other.font-awesome') }} fa-user"></i>
@@ -386,7 +384,7 @@
     </div>
     <button
         class="top-nav__toggle {{ \config('other.font-awesome') }}"
-        x-bind:class="expanded ? 'fa-times' : 'fa-bars'"
+        x-bind:class="expanded ? 'fa-times mobile' : 'fa-bars'"
         x-on:click="expanded = !expanded"
     ></button>
 </nav>

--- a/resources/views/partials/top_nav.blade.php
+++ b/resources/views/partials/top_nav.blade.php
@@ -28,7 +28,7 @@
                 <li>
                     <a href="{{ route('upload_form', ['category_id' => 1]) }}">
                         <i class="{{ config('other.font-awesome') }} fa-upload"></i>
-                        {{ __('common.publish') }}
+                        {{ __('common.upload') }}
                     </a>
                 </li>
                 <li>
@@ -200,7 +200,7 @@
                 <li>
                     <a href="{{ route('internal') }}">
                         <i class="{{ config('other.font-awesome') }} fa-star-shooting"></i>
-                        {{ __('common.staff') }}
+                        {{ __('common.internal') }}
                     </a>
                 </li>
             </ul>

--- a/resources/views/partials/top_nav.blade.php
+++ b/resources/views/partials/top_nav.blade.php
@@ -263,6 +263,16 @@
                 </a>
             </li>
         </ul> 
+        <a class="top-nav__username--highresolution" href="{{ route('users.show', ['username' => auth()->user()->username]) }}">
+            <span class="text-bold" style="color:{{ auth()->user()->group->color }}; background-image:{{ auth()->user()->group->effect }};">
+                <i class="{{ auth()->user()->group->icon }}"></i>
+                {{ auth()->user()->username }}
+                @if (auth()->user()->getWarning() > 0)
+                    <i class="{{ config('other.font-awesome') }} fa-exclamation-circle text-orange"
+                        title="{{ __('common.active-warning') }}"></i>
+                @endif
+            </span>
+        </a>
         <ul class="top-nav__icon-bar" x-bind:class="expanded && 'mobile'">
             @if (auth()->user()->group->is_modo)
                 <li>
@@ -315,6 +325,18 @@
                     >
                 </a>
                 <ul>
+                    <li>
+                        <a href="{{ route('users.show', ['username' => auth()->user()->username]) }}">
+                            <span class="text-bold" style="color:{{ auth()->user()->group->color }}; background-image:{{ auth()->user()->group->effect }};">
+                                <i class="{{ auth()->user()->group->icon }}"></i>
+                                {{ auth()->user()->username }}
+                                @if (auth()->user()->getWarning() > 0)
+                                    <i class="{{ config('other.font-awesome') }} fa-exclamation-circle text-orange"
+                                       title="{{ __('common.active-warning') }}"></i>
+                                @endif
+                            </span>
+                        </a>
+                    </li>
                     <li>
                         <a href="{{ route('users.show', ['username' => auth()->user()->username]) }}">
                             <i class="{{ config('other.font-awesome') }} fa-user"></i>


### PR DESCRIPTION
Best reviewed commit by commit.

- Create shortcuts with the "Torrents" and "Community" dropdown buttons so that they link to the torrents list and forums respectively, but only when not using a touch device.
- Have stats fill out to a single row (instead of 2 rows) on large displays
- Fix the navbar so it's constantly visible when scrolled down
- Show the username and rank

![image](https://user-images.githubusercontent.com/78790963/165738136-7642d2c9-3baa-4c10-bff1-1087724b3936.png)