### PR TITLE
(Update) top navigation bar

### DIFF
--- a/config/unit3d.php
+++ b/config/unit3d.php
@@ -77,5 +77,5 @@ return [
 
     'chat-link-name' => 'Discord',
     'chat-link-icon' => 'fab fa-discord',
-    'chat-link-url'  => ''
+    'chat-link-url'  => '',
 ];

--- a/config/unit3d.php
+++ b/config/unit3d.php
@@ -65,4 +65,17 @@ return [
 
     // Global Rate Limit for Comments - X Per Minute
     'comment-rate-limit' => env('COMMENTS_PER_MINUTE', 3),
+
+    /*
+    |--------------------------------------------------------------------------
+    | External Chat Platform
+    |--------------------------------------------------------------------------
+    |
+    | Settings to configure an external chat platform
+    |
+    */
+
+    'chat-link-name' => 'Discord',
+    'chat-link-icon' => 'fab fa-discord',
+    'chat-link-url'  => ''
 ];

--- a/resources/views/partials/top_nav.blade.php
+++ b/resources/views/partials/top_nav.blade.php
@@ -319,7 +319,14 @@
                 </a>
             </li>
             <li class="top-nav__dropdown">
-                <a>
+                <a class="top-nav__dropdown--nontouch" href="{{ route('users.show', ['username' => auth()->user()->username]) }}">
+                    <img
+                        src="{{ url(auth()->user()->image ? 'files/img/'.auth()->user()->image : 'img/profile.png')}}"
+                        alt="{{ auth()->user()->username }}"
+                        class="top-nav__profile-image"
+                    >
+                </a>
+                <a class="top-nav__dropdown--touch" tabindex="0">
                     <img
                         src="{{ url(auth()->user()->image ? 'files/img/'.auth()->user()->image : 'img/profile.png')}}"
                         alt="{{ auth()->user()->username }}"
@@ -328,7 +335,7 @@
                 </a>
                 <ul>
                     <li>
-                        <a href="{{ route('users.show', ['username' => auth()->user()->username]) }}">
+                        <a class="top-nav__username" href="{{ route('users.show', ['username' => auth()->user()->username]) }}">
                             <span class="text-bold" style="color:{{ auth()->user()->group->color }}; background-image:{{ auth()->user()->group->effect }};">
                                 <i class="{{ auth()->user()->group->icon }}"></i>
                                 {{ auth()->user()->username }}

--- a/resources/views/partials/top_nav.blade.php
+++ b/resources/views/partials/top_nav.blade.php
@@ -87,6 +87,14 @@
                         {{ __('common.news') }}
                     </a>
                 </li>
+                @if (!empty(config('unit3d.chat-link-url')))
+                    <li>
+                        <a  href="{{ config('unit3d.chat-link-url') }}">
+                            <i class="{{ config('unit3d.chat-link-icon') }}"></i>
+                            {{ config('unit3d.chat-link-name') ?: __('common.chat') }}
+                        </a>
+                    </li>
+                @endif
             </ul>
         </li>
         <li class="top-nav__dropdown">

--- a/resources/views/partials/top_nav.blade.php
+++ b/resources/views/partials/top_nav.blade.php
@@ -168,12 +168,6 @@
             </a>
             <ul>
                 <li>
-                    <a href="{{ route('bonus') }}">
-                        <i class="{{ config('other.font-awesome') }} fa-shopping-cart"></i>
-                        {{ __('bon.bon') }} {{ __('bon.store') }}
-                    </a>
-                </li>
-                <li>
                     <a href="{{ route('subtitles.index') }}">
                         <i class="{{ config('other.font-awesome') }} fa-closed-captioning"></i>
                         {{ __('common.subtitles') }}

--- a/resources/views/partials/top_nav.blade.php
+++ b/resources/views/partials/top_nav.blade.php
@@ -217,12 +217,16 @@
         </ul> 
         <ul class="top-nav__ratio-bar" x-bind:class="expanded && 'mobile'">
             <li class="ratio-bar__uploaded" title="{{ __('common.upload') }}">
-                <i class="{{ config('other.font-awesome') }} fa-arrow-up"></i>
-                {{ auth()->user()->getUploaded() }}
+                <a href="{{ route('user_uploads', ['username' => auth()->user()->username]) }}">
+                    <i class="{{ config('other.font-awesome') }} fa-arrow-up"></i>
+                    {{ auth()->user()->getUploaded() }}
+                </a>
             </li>
             <li class="ratio-bar__downloaded" title="{{ __('common.download') }}">
-                <i class="{{ config('other.font-awesome') }} fa-arrow-down"></i>
-                {{ auth()->user()->getDownloaded() }}
+                <a href="{{ route('user_downloads', ['username' => auth()->user()->username]) }}">
+                    <i class="{{ config('other.font-awesome') }} fa-arrow-down"></i>
+                    {{ auth()->user()->getDownloaded() }}
+                </a>
             </li>
             <li class="ratio-bar__seeding" title="{{ __('torrent.seeding') }}">
                 <a href="{{ route('user_active', ['username' => auth()->user()->username]) }}">
@@ -231,14 +235,16 @@
                 </a>
             </li>
             <li class="ratio-bar__leeching" title="{{ __('torrent.leeching') }}">
-                <a href="{{ route('user_active', ['username' => auth()->user()->username]) }}">
+                <a href="{{ route('user_unsatisfieds', ['username' => auth()->user()->username]) }}">
                     <i class="{{ config('other.font-awesome') }} fa-download"></i>
                     {{ auth()->user()->getLeeching() }}
                 </a>
             </li>
             <li class="ratio-bar__buffer" title="{{ __('common.buffer') }}">
-                <i class="{{ config('other.font-awesome') }} fa-exchange"></i>
-                {{ auth()->user()->untilRatio(config('other.ratio')) }}
+                <a href="{{ route('user_torrents', ['username' => auth()->user()->username]) }}">
+                    <i class="{{ config('other.font-awesome') }} fa-exchange"></i>
+                    {{ auth()->user()->untilRatio(config('other.ratio')) }}
+                </a>
             </li>
             <li class="ratio-bar__points" title="{{ __('user.my-bonus-points') }}">
                 <a href="{{ route('bonus') }}">
@@ -247,8 +253,10 @@
                 </a>
             </li>
             <li class="ratio-bar__ratio" title="{{ __('common.ratio') }}">
-                <i class="{{ config('other.font-awesome') }} fa-sync-alt"></i>
-                {{ auth()->user()->getRatioString() }}
+                <a href="{{ route('user_torrents', ['username' => auth()->user()->username]) }}">
+                    <i class="{{ config('other.font-awesome') }} fa-sync-alt"></i>
+                    {{ auth()->user()->getRatioString() }}
+                </a>
             </li>
             <li class="ratio-bar__tokens" title="{{ __('user.my-fl-tokens') }}">
                 <a href="{{ route('users.show', ['username' => auth()->user()->username]) }}">

--- a/resources/views/partials/top_nav.blade.php
+++ b/resources/views/partials/top_nav.blade.php
@@ -270,14 +270,14 @@
         <ul class="top-nav__icon-bar" x-bind:class="expanded && 'mobile'">
             @if (auth()->user()->group->is_modo)
                 <li>
-                    <a class="top-nav--right__icon-link" href="{{ route('staff.dashboard.index') }}">
+                    <a class="top-nav--right__icon-link" href="{{ route('staff.dashboard.index') }}" title="{{ __('staff.staff-dashboard') }}">
                         <i class="{{ config('other.font-awesome') }} fa-cogs"></i>
                     </a>
                 </li>
             @endif
             @if (auth()->user()->group->is_modo)
                 <li>
-                    <a class="top-nav--right__icon-link" href="{{ route('staff.moderation.index') }}">
+                    <a class="top-nav--right__icon-link" href="{{ route('staff.moderation.index') }}" title="{{ __('staff.torrent-moderation') }}">
                         <i class="{{ config('other.font-awesome') }} fa-tasks"></i>
                         @php
                             $torrents_unmoderated = DB::table('torrents')->where('status', '=', '0')->count()
@@ -295,7 +295,7 @@
                         ->where('read', '=', '0')
                         ->count()
                 @endphp
-                <a class="top-nav--right__icon-link" href="{{ route('inbox') }}">
+                <a class="top-nav--right__icon-link" href="{{ route('inbox') }}" title="{{ __('pm.inbox') }}">
                     <i class="{{ config('other.font-awesome') }} fa-envelope"></i>
                     @if ($pm > 0)
                         <x-animation.notification />
@@ -303,7 +303,7 @@
                 </a>
             </li>
             <li>
-                <a class="top-nav--right__icon-link" href="{{ route('notifications.index') }}">
+                <a class="top-nav--right__icon-link" href="{{ route('notifications.index') }}" title="{{ __('user.notifications') }}">
                     <i class="{{ config('other.font-awesome') }} fa-bell"></i>
                     @if (auth()->user()->unreadNotifications->count() > 0)
                         <x-animation.notification />


### PR DESCRIPTION
A series of small commits:

- Removes the bon store link in the menus since it can easily be accessed through clicking the bon statistic.
- Title attributes added to the icon buttons in the navbar to know what they are when they are hovered over.
- The statistics in the navbar for upload, download, etc. now all link with relevant user pages.
- You can now click the avatar to access the profile when not using a touch device.
- A new chat item is added to the top nav for sites that use an external chat platform.