### PR TITLE
(Update) quicksearch improvements

### DIFF
--- a/app/Http/Livewire/QuickSearchDropdown.php
+++ b/app/Http/Livewire/QuickSearchDropdown.php
@@ -15,23 +15,26 @@ class QuickSearchDropdown extends Component
 
     public function render(): \Illuminate\Contracts\View\Factory|\Illuminate\Contracts\View\View
     {
+        $search = '%'.str_replace(' ', '%', $this->quicksearchText).'%';
         $search_results = match ($this->quicksearchRadio) {
             'movies' => Movie::query()
                 ->select(['id', 'poster', 'title', 'release_date'])
-                ->where('title', 'LIKE', '%'.$this->quicksearchText.'%')
+                ->selectRaw("concat(title, ' ', release_date) as title_and_year")
+                ->having('title_and_year', 'LIKE', $search)
                 ->oldest('title')
                 ->take(10)
                 ->get(),
             'series' => Tv::query()
                 ->select(['id', 'poster', 'name', 'first_air_date'])
-                ->where('name', 'LIKE', '%'.$this->quicksearchText.'%')
+                ->selectRaw("concat(name, ' ', first_air_date) as title_and_year")
+                ->having('title_and_year', 'LIKE', $search)
                 ->oldest('name')
                 ->take(10)
                 ->get(),
             'persons' => Person::query()
                 ->select(['id', 'still', 'name'])
                 ->whereNotNull('still')
-                ->where('name', 'LIKE', '%'.$this->quicksearchText.'%')
+                ->where('name', 'LIKE', $search)
                 ->oldest('name')
                 ->take(10)
                 ->get(),

--- a/app/Http/Livewire/QuickSearchDropdown.php
+++ b/app/Http/Livewire/QuickSearchDropdown.php
@@ -9,43 +9,34 @@ use Livewire\Component;
 
 class QuickSearchDropdown extends Component
 {
-    public string $movie = '';
+    public string $quicksearchRadio = 'movies';
 
-    public string $series = '';
-
-    public string $person = '';
+    public string $quicksearchText = '';
 
     public function render(): \Illuminate\Contracts\View\Factory|\Illuminate\Contracts\View\View
     {
-        $search_results = [];
-
-        if (strlen($this->movie) >= 3) {
-            $search_results = Movie::query()
+        $search_results = match ($this->quicksearchRadio) {
+            'movies' => Movie::query()
                 ->select(['id', 'poster', 'title', 'release_date'])
-                ->where('title', 'LIKE', '%'.$this->movie.'%')
+                ->where('title', 'LIKE', '%'.$this->quicksearchText.'%')
                 ->oldest('title')
                 ->take(10)
-                ->get();
-        }
-
-        if (strlen($this->series) >= 3) {
-            $search_results = Tv::query()
+                ->get(),
+            'series' => Tv::query()
                 ->select(['id', 'poster', 'name', 'first_air_date'])
-                ->where('name', 'LIKE', '%'.$this->series.'%')
+                ->where('name', 'LIKE', '%'.$this->quicksearchText.'%')
                 ->oldest('name')
                 ->take(10)
-                ->get();
-        }
-
-        if (strlen($this->person) >= 3) {
-            $search_results = Person::query()
+                ->get(),
+            'persons' => Person::query()
                 ->select(['id', 'still', 'name'])
                 ->whereNotNull('still')
-                ->where('name', 'LIKE', '%'.$this->person.'%')
+                ->where('name', 'LIKE', '%'.$this->quicksearchText.'%')
                 ->oldest('name')
                 ->take(10)
-                ->get();
-        }
+                ->get(),
+            default  => [],
+        };
 
         return \view('livewire.quick-search-dropdown', [
             'search_results' => $search_results,

--- a/resources/sass/components/_quick_search.scss
+++ b/resources/sass/components/_quick_search.scss
@@ -25,6 +25,7 @@
     border-radius: 16px;
     overflow: hidden;
     border: 1px solid transparent;
+    height: 100%;
 }
 
 .quick-search:active .quick-search__inputs,

--- a/resources/views/livewire/quick-search-dropdown.blade.php
+++ b/resources/views/livewire/quick-search-dropdown.blade.php
@@ -1,6 +1,6 @@
 <div
     class="quick-search"
-    x-data="{ search: 'movie', ...quickSearchKeyboardNavigation() }"
+    x-data="{ ...quickSearchKeyboardNavigation() }"
     x-on:keydown.escape.window="$refs.movieSearch.blur(); $refs.seriesSearch.blur(); $refs.personSearch.blur()"
 >
     <div class="quick-search__inputs">
@@ -9,13 +9,10 @@
                 <input
                     type="radio"
                     class="quick-search__radio"
-                    name="quick-search"
-                    x-on:click="
-                        search = 'movie';
-                        $wire.set('series', '');
-                        $wire.set('person', '');
-                        $nextTick(() => $refs.movieSearch.focus());
-                    "
+                    name="quicksearchRadio"
+                    value="movies"
+                    wire:model="quicksearchRadio"
+                    x-on:click="$nextTick(() => $refs.quickSearch.focus());"
                 />
                 <i
                     class="quick-search__radio-icon {{ \config('other.font-awesome') }} fa-camera-movie"
@@ -26,13 +23,10 @@
                 <input
                     type="radio"
                     class="quick-search__radio"
-                    name="quick-search"
-                    x-on:click="
-                        search = 'series';
-                        $wire.set('movie', '');
-                        $wire.set('person', '');
-                        $nextTick(() => $refs.seriesSearch.focus());
-                    "
+                    name="quicksearchRadio"
+                    value="series"
+                    wire:model="quicksearchRadio"
+                    x-on:click="$nextTick(() => $refs.quickSearch.focus());"
                 />
                 <i
                     class="quick-search__radio-icon {{ \config('other.font-awesome') }} fa-tv-retro"
@@ -43,13 +37,10 @@
                 <input
                     type="radio"
                     class="quick-search__radio"
-                    name="quick-search"
-                    x-on:click="
-                        search = 'person';
-                        $wire.set('movie', '');
-                        $wire.set('series', '');
-                        $nextTick(() => $refs.personSearch.focus());
-                    "
+                    name="quicksearchRadio"
+                    value="persons"
+                    wire:model="quicksearchRadio"
+                    x-on:click="$nextTick(() => $refs.quickSearch.focus());"
                 />
                 <i
                     class="quick-search__radio-icon {{ \config('other.font-awesome') }} fa-user"
@@ -59,37 +50,14 @@
         </div>
         <input
             class="quick-search__input"
-            wire:model.debounce.250ms="movie"
+            wire:model.debounce.250ms="quicksearchText"
             type="text"
-            placeholder="Movie"
-            x-show="search == 'movie'"
-            x-ref="movieSearch"
+            placeholder="{{ $quicksearchRadio }}"
+            x-ref="quickSearch"
             x-on:keydown.down.prevent="$refs.searchResults.firstElementChild?.firstElementChild?.focus()"
             x-on:keydown.up.prevent="$refs.searchResults.lastElementChild?.firstElementChild?.focus()"
         />
-        <input
-            wire:model.debounce.250ms="series"
-            class="quick-search__input"
-            type="text"
-            placeholder="Series"
-            x-show="search == 'series'"
-            x-ref="seriesSearch"
-            x-cloak
-            x-on:keydown.down.prevent="$refs.searchResults.firstElementChild?.firstElementChild?.focus()"
-            x-on:keydown.up.prevent="$refs.searchResults.lastElementChild?.firstElementChild?.focus()"
-        />
-        <input
-            wire:model.debounce.250ms="person"
-            class="quick-search__input"
-            type="text"
-            placeholder="Person"
-            x-show="search == 'person'"
-            x-ref="personSearch"
-            x-cloak
-            x-on:keydown.down.prevent="$refs.searchResults.firstElementChild?.lastElementChild?.focus()"
-            x-on:keydown.up.prevent="$refs.searchResults.lastElementChild?.firstElementChild?.focus()"
-        />
-        @if (strlen($movie) >= 3  || strlen($series) >= 3  || strlen($person) >= 3)
+        @if (strlen($quicksearchText) > 0)
             <div class="quick-search__results" x-ref="searchResults">
                 @forelse ($search_results as $search_result)
                     <article
@@ -97,61 +65,65 @@
                         x-on:keydown.down.prevent="quickSearchArrowDown($el)"
                         x-on:keydown.up.prevent="quickSearchArrowUp($el)"
                     >
-                        @if (strlen($movie) >= 3 )
-                            <a
-                                class="quick-search__result-link"
-                                href="{{ route('torrents.similar', ['category_id' => '1', 'tmdb' => $search_result->id]) }}"
-                            >
-                                <img
-                                    class="quick-search__image"
-                                    src="{{ $search_result->poster }}"
-                                    alt="{{ __('torrent.poster') }}"
-                                />
-                                <h2 class="quick-search__result-text">
-                                    {{ $search_result->title }}
-                                    <time
-                                        class="quick-search__result-year"
-                                        datetime="{{ $search_result->release_date }}"
-                                    >
-                                        {{ substr($search_result->release_date, 0, 4) }}
-                                    </time>
-                                </h2>
-                            </a>
-                        @elseif (strlen($series) >= 3 )
-                            <a
-                                class="quick-search__result-link"
-                                href="{{ route('torrents.similar', ['category_id' => '2', 'tmdb' => $search_result->id]) }}"
-                            >
-                                <img
-                                    class="quick-search__image"
-                                    src="{{ $search_result->poster }}"
-                                    alt="{{ __('torrent.poster') }}"
-                                />
-                                <h2 class="quick-search__result-text">
-                                    {{ $search_result->name }}
-                                    <time
-                                        class="quick-search__result-year"
-                                        datetime="{{ $search_result->first_air_date }}"
-                                    >
-                                        {{ substr($search_result->first_air_date, 0, 4) }}
-                                    </time>
-                                </h2>
-                            </a>
-                        @elseif (strlen($person) >= 3 )
-                            <a
-                                class="quick-search__result-link"
-                                href="{{ route('mediahub.persons.show', ['id' => $search_result->id]) }}"
-                            >
-                                <img
-                                    class="quick-search__image"
-                                    src="{{ $search_result->still }}"
-                                    alt="{{ __('torrent.poster') }}"
-                                />
-                                <h2 class="quick-search__result-text">
-                                    {{ $search_result->name }}
-                                </h2>
-                            </a>
-                        @endif
+                        @switch ($quicksearchRadio)
+                            @case ("movies")
+                                <a
+                                    class="quick-search__result-link"
+                                    href="{{ route('torrents.similar', ['category_id' => '1', 'tmdb' => $search_result->id]) }}"
+                                >
+                                    <img
+                                        class="quick-search__image"
+                                        src="{{ $search_result->poster }}"
+                                        alt="{{ __('torrent.poster') }}"
+                                    />
+                                    <h2 class="quick-search__result-text">
+                                        {{ $search_result->title }}
+                                        <time
+                                            class="quick-search__result-year"
+                                            datetime="{{ $search_result->release_date }}"
+                                        >
+                                            {{ substr($search_result->release_date, 0, 4) }}
+                                        </time>
+                                    </h2>
+                                </a>
+                            @break
+                            @case ("series")
+                                <a
+                                    class="quick-search__result-link"
+                                    href="{{ route('torrents.similar', ['category_id' => '2', 'tmdb' => $search_result->id]) }}"
+                                >
+                                    <img
+                                        class="quick-search__image"
+                                        src="{{ $search_result->poster }}"
+                                        alt="{{ __('torrent.poster') }}"
+                                    />
+                                    <h2 class="quick-search__result-text">
+                                        {{ $search_result->name }}
+                                        <time
+                                            class="quick-search__result-year"
+                                            datetime="{{ $search_result->first_air_date }}"
+                                        >
+                                            {{ substr($search_result->first_air_date, 0, 4) }}
+                                        </time>
+                                    </h2>
+                                </a>
+                            @break
+                            @case ("persons")
+                                <a
+                                    class="quick-search__result-link"
+                                    href="{{ route('mediahub.persons.show', ['id' => $search_result->id]) }}"
+                                >
+                                    <img
+                                        class="quick-search__image"
+                                        src="{{ $search_result->still }}"
+                                        alt="{{ __('torrent.poster') }}"
+                                    />
+                                    <h2 class="quick-search__result-text">
+                                        {{ $search_result->name }}
+                                    </h2>
+                                </a>
+                            @break
+                        @endswitch
                     </article>
                 @empty
                     <article class="quick-search__result--empty">


### PR DESCRIPTION
The current iteration of the quick search uses 3 separate text inputs, each tied to their own livewire variable. The other 2 are hidden until selected by the user. When a different text input is selected, the other 2 are reset and hidden to prevent erroneous results.

This new update to quick search uses only a single variable for the searched text, and another to hold the value of the radio button, allowing the user to switch between different searches without the text resetting.

The search string length limitation was also removed, as it was deemed to not be a cause for performance issues, and was more useful for the user to receive unwanted results, than none at all.

Also whitespace is now replaces as a wildcard, for improved search usability.

Also fixed the CSS issue where there was a gap between the search entry and results.