### PR TITLE
(Update) stats cards into table

### DIFF
--- a/resources/views/stats/clients/clients.blade.php
+++ b/resources/views/stats/clients/clients.blade.php
@@ -22,16 +22,31 @@
         <div class="block">
             <h2>Clients</h2>
             <hr>
-            <div class="row col-md-offset-1">
-                @foreach ($clients as $key => $value)
-                    @php if (\strlen($key) > 26) { $key = substr($key, 0, 23).'...'; } @endphp
-                    <div class="well col-md-3" style="margin: 10px;">
-                        <div class="text-center">
-                            <h3 class="text-success">{{ $key }}</h3>
-                            <span class="badge-extra text-blue">Used by {{ $value }} User(s)</span>
-                        </div>
-                    </div>
-                @endforeach
+            <div class="row">
+                <div class="col-md-12">
+                    <table class="table table-condensed table-striped table-bordered">
+                        <thead>
+                        <tr>
+                            <th>Client</th>
+                            <th class="text-right">{{ __('common.users') }}</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        @foreach ($clients as $client => $count)
+                            <tr>
+                                <td class="text-success">
+                                    {{ $client }}
+                                </td>
+                                <td>
+                                    <p class="text-blue text-right">
+                                        Used by {{ $count }} users(s)
+                                    </p>
+                                </td>
+                            </tr>
+                        @endforeach
+                        </tbody>
+                    </table>
+                </div>
             </div>
         </div>
     </div>

--- a/resources/views/stats/groups/groups.blade.php
+++ b/resources/views/stats/groups/groups.blade.php
@@ -26,21 +26,36 @@
             <p class="text-red"><strong><i class="{{ config('other.font-awesome') }} fa-users"></i>
                     {{ __('stat.groups') }}</strong>
                 ({{ __('stat.users-per-group') }})</p>
-            <div class="row col-md-offset-2">
-                @foreach ($groups as $group)
-                    <div class="well col-md-3" style="margin: 10px;">
-                        <div class="text-center">
-                            <a href="{{ route('group', ['id' => $group->id]) }}">
-                                <h2 style="color:{{ $group->color }};">
-                                    <i class="{{ $group->icon }}" aria-hidden="true"></i>&nbsp;{{ $group->name }}</h2>
-                            </a>
-                            <p class="lead text-blue">{{ $group
-                                        ->users()
-                                        ->withTrashed()
-                                        ->count() }} Users</p>
-                        </div>
-                    </div>
-                @endforeach
+            <div class="row">
+                <div class="col-md-12">
+                    <table class="table table-condensed table-striped table-bordered">
+                        <thead>
+                        <tr>
+                            <th>{{ __('common.group') }}</th>
+                            <th class="text-right">{{ __('common.users') }}</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        @foreach ($groups as $group)
+                            <tr>
+                                <td>
+                                    <a href="{{ route('group', ['id' => $group->id]) }}">
+                                        <span style="color:{{ $group->color }};">
+                                            <i class="{{ $group->icon }}" aria-hidden="true"></i>
+                                            {{ $group->name }}
+                                        </span>
+                                    </a>
+                                </td>
+                                <td>
+                                    <p class="text-blue text-right">
+                                        {{ $group->users()->withTrashed()->count() }}
+                                    </p>
+                                </td>
+                            </tr>
+                        @endforeach
+                        </tbody>
+                    </table>
+                </div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Fixes the issue where long group names wrap to 2+ lines and cause the card to be too big to fit into the grid.
Also allows you to view the full client name, since many client names are longer than 26 characters (the current length limit).

The current card design is too small for this data. Tables work better, even though there is extra whitespace.

The table design is copied from the other stats pages so there is no lack of continuity.