### PR TITLE
(Refactor) custom routes into using helper parameters

### DIFF
--- a/resources/views/mediahub/collection/show.blade.php
+++ b/resources/views/mediahub/collection/show.blade.php
@@ -55,7 +55,7 @@
                     </div>
                 </div>
                 <div class="movie-bottom">
-                    <a href="{{ route('torrents') }}?perPage=25&collectionId={{ $collection->id }}" role="button"
+                    <a href="{{ route('torrents', ['collectionId' => $collection->id]) }}" role="button"
                        class="btn btn-sm btn-labeled btn-success">
                     <span class='btn-label'>
                         <i class='{{ config('other.font-awesome') }} fa-eye'></i> Collection Torrents List

--- a/resources/views/partials/top_nav.blade.php
+++ b/resources/views/partials/top_nav.blade.php
@@ -397,7 +397,7 @@
                         </a>
                     </li>
                     <li>
-                        <a href="{{ route('torrents') }}?bookmarked=1">
+                        <a href="{{ route('torrents', ['bookmarked' => 1]) }}">
                             <i class="{{ config('other.font-awesome') }} fa-bookmark"></i>
                             {{ __('user.my-bookmarks') }}
                         </a>

--- a/resources/views/playlist/show.blade.php
+++ b/resources/views/playlist/show.blade.php
@@ -76,7 +76,7 @@
                         <i class='{{ config('other.font-awesome') }} fa-download'></i> {{ __('playlist.download-all') }}
                     </span>
                     </a>
-                    <a href="{{ route('torrents') }}?perPage=25&playlistId={{ $playlist->id }}" role="button"
+                    <a href="{{ route('torrents', ['playlistId' => $playlist->id]) }}" role="button"
                        class="btn btn-sm btn-labeled btn-success">
                     <span class='btn-label'>
                         <i class='{{ config('other.font-awesome') }} fa-eye'></i> Playlist Torrents List

--- a/resources/views/torrent/partials/game_meta.blade.php
+++ b/resources/views/torrent/partials/game_meta.blade.php
@@ -70,7 +70,7 @@
                 @if ($torrent->keywords)
                     @foreach ($torrent->keywords as $keyword)
                         <span class="badge-user text-bold text-green">
-                            <a href="{{ route('torrents') }}?keywords={{ $keyword->name }}">
+                            <a href="{{ route('torrents', ['keywords' => $keyword->name]) }}">
                                 <i class="{{ config('other.font-awesome') }} fa-tag"></i> {{ $keyword->name }}
                             </a>
                         </span>

--- a/resources/views/torrent/partials/movie_meta.blade.php
+++ b/resources/views/torrent/partials/movie_meta.blade.php
@@ -112,7 +112,7 @@
                 @if ($torrent->keywords)
                     @foreach ($torrent->keywords as $keyword)
                         <span class="badge-user text-bold text-green">
-                            <a href="{{ route('torrents') }}?keywords={{ $keyword->name }}">
+                            <a href="{{ route('torrents', ['keywords' => $keyword->name]) }}">
                                 <i class="{{ config('other.font-awesome') }} fa-tag"></i> {{ $keyword->name }}
                             </a>
                         </span>

--- a/resources/views/torrent/partials/tv_meta.blade.php
+++ b/resources/views/torrent/partials/tv_meta.blade.php
@@ -133,7 +133,7 @@
                 @if ($torrent->keywords)
                     @foreach ($torrent->keywords as $keyword)
                         <span class="badge-user text-bold text-green">
-                            <a href="{{ route('torrents') }}?keywords={{ $keyword->name }}">
+                            <a href="{{ route('torrents', ['keywords' => $keyword->name]) }}">
                                 <i class="{{ config('other.font-awesome') }} fa-tag"></i> {{ $keyword->name }}
                             </a>
                         </span>

--- a/resources/views/user/buttons/other.blade.php
+++ b/resources/views/user/buttons/other.blade.php
@@ -9,7 +9,7 @@
         <a href="{{ route('user_requested', ['username' => $user->username]) }}" class="btn btn-sm btn-primary">
             {{ __('user.requested') }}
         </a>
-        <a href="{{ route('torrents') }}?bookmarked=1" class="btn btn-sm btn-primary">
+        <a href="{{ route('torrents', ['bookmarked' => 1]) }}" class="btn btn-sm btn-primary">
             {{ __('user.bookmarks') }}
         </a>
         <a href="{{ route('wishes.index', ['username' => $user->username]) }}" class="btn btn-sm btn-primary">

--- a/resources/views/user/buttons/staff.blade.php
+++ b/resources/views/user/buttons/staff.blade.php
@@ -2,7 +2,7 @@
     <a href="{{ route('user_resurrections', ['username' => $user->username]) }}" class="btn btn-sm btn-primary">
         {{ __('user.resurrections') }}
     </a>
-    <a href="{{ route('torrents') }}?bookmarked=1" class="btn btn-sm btn-primary">
+    <a href="{{ route('torrents', ['bookmarked' => 1]) }}" class="btn btn-sm btn-primary">
         {{ __('user.bookmarks') }}
     </a>
     <a href="{{ route('wishes.index', ['username' => $user->username]) }}" class="btn btn-sm btn-primary">

--- a/resources/views/user/buttons/user.blade.php
+++ b/resources/views/user/buttons/user.blade.php
@@ -2,7 +2,7 @@
     <a href="{{ route('user_resurrections', ['username' => $user->username]) }}" class="btn btn-sm btn-primary">
         {{ __('user.resurrections') }}
     </a>
-    <a href="{{ route('torrents') }}?bookmarked=1" class="btn btn-sm btn-primary">
+    <a href="{{ route('torrents', ['bookmarked' => 1]) }}" class="btn btn-sm btn-primary">
         {{ __('user.bookmarks') }}
     </a>
     <a href="{{ route('wishes.index', ['username' => $user->username]) }}" class="btn btn-sm btn-primary">


### PR DESCRIPTION
The route helper is probably a better way to do this rather than customizing the routes manually.

Some routes weren't able to use this format, namely the `forum_topic` route that linked to a specific page and post. It seems that the route currently accepts `page` as a parameter, so it appends the page number onto the end of the route instead of after the `?`.