### PR TITLE
(Fix) user torrents page credited upload

### DIFF
--- a/app/Http/Livewire/UserTorrents.php
+++ b/app/Http/Livewire/UserTorrents.php
@@ -111,7 +111,7 @@ class UserTorrents extends Component
                 'torrents.size',
                 'torrents.status',
             )
-            ->selectRaw('IF(torrents.user_id = ?, 1, 0) AS uploaded', [$this->user->id])
+            ->selectRaw('IF(torrents.user_id = ?, 1, 0) AS uploader', [$this->user->id])
             ->selectRaw('history.active AND history.seeder AS seeding')
             ->selectRaw('history.active AND NOT history.seeder AS leeching')
             ->selectRaw('TIMESTAMPDIFF(SECOND, history.created_at, history.completed_at) AS leechtime')

--- a/resources/sass/components/_user-torrents.scss
+++ b/resources/sass/components/_user-torrents.scss
@@ -17,7 +17,7 @@
 .user-torrents__prewarned-header,
 .user-torrents__warned-header,
 .user-torrents__immune-header,
-.user-torrents__uploaded-header,
+.user-torrents__uploader-header,
 .user-torrents__status-header {
     cursor: pointer;
     white-space: nowrap;
@@ -46,7 +46,7 @@
 .user-torrents__prewarned,
 .user-torrents__warned,
 .user-torrents__immune,
-.user-torrents__uploaded,
+.user-torrents__uploader,
 .user-torrents__status {
     font-size: 11px;
 }
@@ -77,14 +77,14 @@
 .user-torrents__prewarned-header,
 .user-torrents__warned-header,
 .user-torrents__immune-header,
-.user-torrents__uploaded-header,
+.user-torrents__uploader-header,
 .user-torrents__status-header,
 .user-torrents__seeding,
 .user-torrents__leeching,
 .user-torrents__prewarned,
 .user-torrents__warned,
 .user-torrents__immune,
-.user-torrents__uploaded,
+.user-torrents__uploader,
 .user-torrents__status {
     text-align: center;
 }

--- a/resources/views/livewire/user-torrents.blade.php
+++ b/resources/views/livewire/user-torrents.blade.php
@@ -371,8 +371,8 @@
                                 <i class="{{ config('other.font-awesome') }} fa-times text-red" title="Not immune"></i>
                             @endif
                         </td>
-                        <td class="user-torrents__uploaded">
-                            @if ($history->uploaded == 1)
+                        <td class="user-torrents__uploader">
+                            @if ($history->uploader == 1)
                                 <i class="{{ config('other.font-awesome') }} text-green fa-check" title="{{ __('torrent.uploaded') }}"></i>
                             @else
                                 <i class="{{ config('other.font-awesome') }} text-red fa-times" title="Not {{ __('torrent.uploaded') }}"></i>


### PR DESCRIPTION
Credited upload column was being overwritten by the custom selectRaw. With this PR, the second instance of `uploaded` is renamed to `uploader`.