### PR TITLE
(Update) user torrents page

### DIFF
--- a/app/Http/Livewire/UserTorrents.php
+++ b/app/Http/Livewire/UserTorrents.php
@@ -42,6 +42,8 @@ class UserTorrents extends Component
 
     public string $immune = 'any';
 
+    public string $downloaded = 'any';
+
     public string $hasHistory = 'any';
 
     public array $status = [];
@@ -163,6 +165,8 @@ class UserTorrents extends Component
             ->when($this->hasHistory === 'exclude', fn ($query) => $query->whereNull('history.updated_at'))
             ->when($this->uploaded === 'include', fn ($query) => $query->where('torrents.user_id', '=', $this->user->id))
             ->when($this->uploaded === 'exclude', fn ($query) => $query->where('torrents.user_id', '<>', $this->user->id))
+            ->when($this->downloaded === 'include', fn ($query) => $query->where('history.actual_downloaded', '>', 0))
+            ->when($this->downloaded === 'exclude', fn ($query) => $query->where('history.actual_downloaded', '=', 0))
             ->when(! empty($this->status), fn ($query) => $query->whereIntegerInRaw('status', $this->status))
             ->when($this->unapprovedOnTop, fn ($query) => $query->orderByRaw('IF(status = 1, 1, 0)'))
             ->orderBy($this->sortField, $this->sortDirection)

--- a/app/Http/Livewire/UserTorrents.php
+++ b/app/Http/Livewire/UserTorrents.php
@@ -59,7 +59,7 @@ class UserTorrents extends Component
     protected $queryString = [
         'perPage'           => ['except' => ''],
         'name'              => ['except' => ''],
-        'sortField'         => ['except' => 'initial_sort'],
+        'sortField'         => ['except' => 'created_at'],
         'sortDirection'     => ['except' => 'desc'],
         'unsatisfied'       => ['except' => 'any'],
         'active'            => ['except' => 'any'],
@@ -69,7 +69,9 @@ class UserTorrents extends Component
         'immune'            => ['except' => 'any'],
         'uploaded'          => ['except' => 'any'],
         'downloaded'        => ['except' => 'any'],
+        'hasHistory'        => ['except' => 'any'],
         'status'            => ['except' => []],
+        'unapprovedOnTop'   => ['except' => true],
         'showMorePrecision' => ['except' => false],
     ];
 

--- a/app/Http/Livewire/UserTorrents.php
+++ b/app/Http/Livewire/UserTorrents.php
@@ -142,13 +142,13 @@ class UserTorrents extends Component
                     ->where(fn ($query) => $query
                         ->where('seedtime', '>', \config('hitrun.seedtime'))
                         ->orWhere('immune', '=', 1)
-                        ->orWhereRaw('actual_downloaded < torrents.size * ?', [\config('hitrun.buffer')])
+                        ->orWhereRaw('actual_downloaded < (torrents.size * ? / 100)', [\config('hitrun.buffer')])
                     )
                 )
                 ->when($this->unsatisfied === 'include', fn ($query) => $query
                     ->where('seedtime', '<', \config('hitrun.seedtime'))
                     ->where('immune', '=', 0)
-                    ->whereRaw('actual_downloaded > torrents.size * ?', [\config('hitrun.buffer')])
+                    ->whereRaw('actual_downloaded > (torrents.size * ? / 100)', [\config('hitrun.buffer')])
                 )
             )
             ->when($this->active === 'include', fn ($query) => $query->where('active', '=', 1))

--- a/resources/views/livewire/user-torrents.blade.php
+++ b/resources/views/livewire/user-torrents.blade.php
@@ -349,8 +349,10 @@
                                     {{ App\Helpers\StringHelper::timeElapsed($history->leechtime) }}
                                 @endif
                             </td>
-                            <td class="user-torrents__seedtime {{ $history->seedtime < config('hitrun.seedtime') ? 'text-red' : 'text-green' }}">
-                                {{ App\Helpers\StringHelper::timeElapsed($history->seedtime) }}
+                            <td class="user-torrents__seedtime">
+                                <span class="{{ $history->seedtime < config('hitrun.seedtime') ? 'text-red' : 'text-green' }}">
+                                    {{ App\Helpers\StringHelper::timeElapsed($history->seedtime) }}
+                                </span>
                             </td>
                             <td class="user-torrents__created-at">
                                 @if ($history->updated_at === null)
@@ -369,11 +371,13 @@
                                     {{ \implode(" ", \array_slice(\explode(" ", App\Helpers\StringHelper::timeElapsed($history->leechtime)), 0, 2)) }}
                                 @endif
                             </td>
-                            <td class="user-torrents__seedtime {{ $history->seedtime < config('hitrun.seedtime') ? 'text-red' : 'text-green' }}">
+                            <td class="user-torrents__seedtime">
                                 @if ($history->seedtime === null)
                                     N/A
                                 @else
-                                    {{ \implode(" ", \array_slice(\explode(" ", App\Helpers\StringHelper::timeElapsed($history->seedtime)), 0, 2)) }}
+                                    <span class="{{ $history->seedtime < config('hitrun.seedtime') ? 'text-red' : 'text-green' }}">
+                                        {{ \implode(" ", \array_slice(\explode(" ", App\Helpers\StringHelper::timeElapsed($history->seedtime)), 0, 2)) }}
+                                    </span>
                                 @endif
                             </td>
                             <td class="user-torrents__created-at">

--- a/resources/views/livewire/user-torrents.blade.php
+++ b/resources/views/livewire/user-torrents.blade.php
@@ -97,6 +97,18 @@
                         </label>
                     </span>
                     <span class="badge-user">
+                        <label style="user-select: none" class="inline" x-data="{ state: @entangle('downloaded'), ...ternaryCheckbox() }">
+                            <input
+                                type="checkbox"
+                                class="user-torrents__checkbox"
+                                x-init="updateTernaryCheckboxProperties($el, state)"
+                                x-on:click="state = getNextTernaryCheckboxState(state); updateTernaryCheckboxProperties($el, state)"
+                                x-bind:checked="state === 'include'"
+                            >
+                            {{ __('torrent.downloaded') }}
+                        </label>
+                    </span>
+                    <span class="badge-user">
                         <label style="user-select: none" class="inline" x-data="{ state: @entangle('hasHistory'), ...ternaryCheckbox() }">
                             <input
                                 type="checkbox"

--- a/resources/views/livewire/user-torrents.blade.php
+++ b/resources/views/livewire/user-torrents.blade.php
@@ -96,6 +96,18 @@
                             {{ __('torrent.uploaded') }}
                         </label>
                     </span>
+                    <span class="badge-user">
+                        <label style="user-select: none" class="inline" x-data="{ state: @entangle('hasHistory'), ...ternaryCheckbox() }">
+                            <input
+                                type="checkbox"
+                                class="user-torrents__checkbox"
+                                x-init="updateTernaryCheckboxProperties($el, state)"
+                                x-on:click="state = getNextTernaryCheckboxState(state); updateTernaryCheckboxProperties($el, state)"
+                                x-bind:checked="state === 'include'"
+                            >
+                            Has history
+                        </label>
+                    </span>
                 </div>
             </div>
             <div class="mx-0 mt-5 form-group fatten-me">
@@ -130,12 +142,18 @@
                 </div>
             </div>
             <div class="mx-0 mt-5 form-group fatten-me">
-                <div class="mt-5 col-sm-1 label label-default fatten-me">Precision</div>
+                <div class="mt-5 col-sm-1 label label-default fatten-me">Options</div>
                 <div class="col-sm-10">
                     <span class="badge-user">
                         <label class="inline">
                             <input type="checkbox" class="user-torrents__checkbox" wire:model="showMorePrecision">
                             Show more precision
+                        </label>
+                    </span>
+                    <span class="badge-user">
+                        <label class="inline">
+                            <input type="checkbox" class="user-torrents__checkbox" wire:model="unapprovedOnTop">
+                            Unapproved on top
                         </label>
                     </span>
                 </div>
@@ -229,26 +247,26 @@
                 @foreach ($histories as $history)
                     <tr>
                         <td>
-                            <a class="user-torrents__name" href="{{ route('torrent', ['id' => $history->torrent_id]) }}">
+                            <a class="user-torrents__name" href="{{ route('torrent', ['id' => $history->id]) }}">
                                 {{ $history->name }}
                             </a>
                         </td>
                         <td class="user-torrents__seeders">
-                            <a href="{{ route('peers', ['id' => $history->torrent_id]) }}">
+                            <a href="{{ route('peers', ['id' => $history->id]) }}">
                                 <span class='text-green'>
                                     {{ $history->seeders }}
                                 </span>
                             </a>
                         </td>
                         <td class="user-torrents__leechers">
-                            <a href="{{ route('peers', ['id' => $history->torrent_id]) }}">
+                            <a href="{{ route('peers', ['id' => $history->id]) }}">
                                 <span class='text-red'>
                                     {{ $history->leechers }}
                                 </span>
                             </a>
                         </td>
                         <td class="user-torrents__times">
-                            <a href="{{ route('history', ['id' => $history->torrent_id]) }}">
+                            <a href="{{ route('history', ['id' => $history->id]) }}">
                                 <span class='text-orange'>
                                     {{ $history->times_completed }}
                                 </span>
@@ -312,28 +330,54 @@
                             </span>
                         </td>
                         @if ($showMorePrecision)
-                            <td class="user-torrents__leechtime">{{ App\Helpers\StringHelper::timeElapsed($history->leechtime) }}</td>
+                            <td class="user-torrents__leechtime">
+                                @if ($history->actual_uploaded === null)
+                                    N/A
+                                @else
+                                    {{ App\Helpers\StringHelper::timeElapsed($history->leechtime) }}
+                                @endif
+                            </td>
                             <td class="user-torrents__seedtime {{ $history->seedtime < config('hitrun.seedtime') ? 'text-red' : 'text-green' }}">
                                 {{ App\Helpers\StringHelper::timeElapsed($history->seedtime) }}
                             </td>
-                            <td class="user-torrents__created-at">{{ $history->created_at ?? 'N/A' }}</td>
+                            <td class="user-torrents__created-at">
+                                @if ($history->updated_at === null)
+                                    <em title="Uploaded date">{{ $history->created_at ?? 'N/A' }}</em>
+                                @else
+                                    {{ $history->created_at ?? 'N/A' }}
+                                @endif
+                            </td>
                             <td class="user-torrents__updated-at">{{ $history->updated_at ?? 'N/A' }}</td>
                             <td class="user-torrents__complated-at">{{ $history->completed_at ?? 'N/A' }}</td>
                         @else
                             <td class="user-torrents__leechtime">
-                                {{ \implode(" ", \array_slice(\explode(" ", App\Helpers\StringHelper::timeElapsed($history->leechtime)), 0, 2)) }}
+                                @if ($history->leechtime === null)
+                                    N/A
+                                @else
+                                    {{ \implode(" ", \array_slice(\explode(" ", App\Helpers\StringHelper::timeElapsed($history->leechtime)), 0, 2)) }}
+                                @endif
                             </td>
                             <td class="user-torrents__seedtime {{ $history->seedtime < config('hitrun.seedtime') ? 'text-red' : 'text-green' }}">
-                                {{ \implode(" ", \array_slice(\explode(" ", App\Helpers\StringHelper::timeElapsed($history->seedtime)), 0, 2)) }}
+                                @if ($history->seedtime === null)
+                                    N/A
+                                @else
+                                    {{ \implode(" ", \array_slice(\explode(" ", App\Helpers\StringHelper::timeElapsed($history->seedtime)), 0, 2)) }}
+                                @endif
                             </td>
                             <td class="user-torrents__created-at">
-                                {{ isset($history->created_at) ? \explode(" ", $history->created_at)[0] : 'N/A' }}
+                                @if ($history->updated_at === null)
+                                    <em title="Uploaded date">
+                                        {{ $history->created_at === null ? 'N/A' : \explode(" ", $history->created_at)[0] }}
+                                    </em>
+                                @else
+                                    {{ $history->created_at === null ? 'N/A' : \explode(" ", $history->created_at)[0] }}
+                                @endif
                             </td>
                             <td class="user-torrents__updated-at">
-                                {{ isset($history->updated_at) ? \explode(" ", $history->updated_at)[0] : 'N/A' }}
+                                {{ $history->updated_at === null ? 'N/A' : \explode(" ", $history->updated_at)[0] }}
                             </td>
                             <td class="user-torrents__completed-at">
-                                {{ isset($history->completed_at) ? \explode(" ", $history->completed_at)[0] : 'N/A' }}
+                                {{ $history->completed_at === null ? 'N/A' : \explode(" ", $history->completed_at)[0] }}
                             </td>
                         @endif
                         <td class="user-torrents__seeding">


### PR DESCRIPTION
- Fixed unannounced uploaded torrents from not appearing on a user's torrents page (Before it only showed history records, now it shows the torrent information if that user had uploaded it, but not announced).
- Added a `Has History` ternary filter to the user's torrents page to find torrents that were uploaded by the user, but never announced.
- Added a `Downloaded` filter to filter user torrents with an actual_download field greater than 0.
- Updated the query string to reflect the new parameters
- Fixed the seedtime colors (red for below the configured minimum seedtime limit, green for above)
- Fixed a bug in the unsatisfieds filter where it was filtering the wrong torrents