### PR TITLE
Fix: Cache Key Prefix

### DIFF
--- a/app/Models/Peer.php
+++ b/app/Models/Peer.php
@@ -65,7 +65,7 @@ class Peer extends Model
                 $tmp_ip = '['.$tmp_ip.']';
             }
 
-            $key = strtolower(config('app.name')).'_cache:peers:connectable:'.$tmp_ip.'-'.$this->port.'-'.$this->agent;
+            $key = config('cache.prefix').':peers:connectable:'.$tmp_ip.'-'.$this->port.'-'.$this->agent;
             $cache = Redis::connection('cache')->get($key);
             $ttl = 0;
             if (isset($cache)) {

--- a/config/cache.php
+++ b/config/cache.php
@@ -105,6 +105,6 @@ return [
     |
     */
 
-    'prefix' => env('CACHE_PREFIX', Str::slug(env('APP_NAME', 'laravel'), '_').'_cache'),
+    'prefix' => env('CACHE_PREFIX', Str::slug(config('app.name'), '_').'_cache'),
 
 ];


### PR DESCRIPTION
I was building the cache key like this

`$key = strtolower(config('app.name')).'_cache:peers:connectable:'.$tmp_ip.'-'.$this->port.'-'.$this->agent;`

I should have been building it like this

`$key = config('cache.prefix').':peers:connectable:'.$tmp_ip.'-'.$this->port.'-'.$this->agent;`

UNIT3D was building the prefix like this

`'prefix' => env('CACHE_PREFIX', Str::slug(env('APP_NAME', 'laravel'), '_').'_cache'),`

But built using an ENV which is not used by default so this has also be fixed. This would be an issue in a multi-tenant environment
