### PR TITLE
(Refactor) torrent search filters into trait

### DIFF
--- a/app/Http/Livewire/GraveyardSearch.php
+++ b/app/Http/Livewire/GraveyardSearch.php
@@ -38,19 +38,19 @@ class GraveyardSearch extends Component
 
     public string $malId = '';
 
-    public $free;
+    public array $free = [];
 
-    public $doubleup;
+    public bool $doubleup = false;
 
-    public $featured;
+    public bool $featured = false;
 
-    public $stream;
+    public bool $stream = false;
 
-    public $sd;
+    public bool $sd = false;
 
-    public $highspeed;
+    public bool $highspeed = false;
 
-    public $internal;
+    public bool $internal = false;
 
     public int $perPage = 25;
 
@@ -69,7 +69,7 @@ class GraveyardSearch extends Component
         'imdbId'        => ['except' => ''],
         'tvdbId'        => ['except' => ''],
         'malId'         => ['except' => ''],
-        'free'          => ['except' => false],
+        'free'          => ['except' => []],
         'doubleup'      => ['except' => false],
         'featured'      => ['except' => false],
         'stream'        => ['except' => false],
@@ -105,54 +105,33 @@ class GraveyardSearch extends Component
 
     final public function getTorrentsProperty(): \Illuminate\Contracts\Pagination\LengthAwarePaginator
     {
+        $user = \auth()->user();
+        $isRegexAllowed = $user->group->is_modo;
+        $isRegex = fn ($field) => $isRegexAllowed
+            && \strlen($field) >= 2
+            && $field[0] === '/'
+            && $field[-1] === '/';
+        
         return Torrent::with('category', 'type', 'resolution')
             ->where('created_at', '<', Carbon::now()->copy()->subDays(30)->toDateTimeString())
-            ->where('seeders', '=', 0)
-            ->when($this->name, function ($query) {
-                $query->where('name', 'LIKE', '%'.$this->name.'%');
-            })
-            ->when($this->categories, function ($query) {
-                $query->whereIntegerInRaw('category_id', $this->categories);
-            })
-            ->when($this->types, function ($query) {
-                $query->whereIntegerInRaw('type_id', $this->types);
-            })
-            ->when($this->resolutions, function ($query) {
-                $query->whereIntegerInRaw('resolution_id', $this->resolutions);
-            })
-            ->when($this->tmdbId, function ($query) {
-                $query->where('tmdb', '=', $this->tmdbId);
-            })
-            ->when($this->imdbId, function ($query) {
-                $query->where('imdb', '=', $this->imdbId);
-            })
-            ->when($this->tvdbId, function ($query) {
-                $query->where('tvdb', '=', $this->tvdbId);
-            })
-            ->when($this->malId, function ($query) {
-                $query->where('mal', '=', $this->malId);
-            })
-            ->when($this->free, function ($query) {
-                $query->where('free', '=', 1);
-            })
-            ->when($this->doubleup, function ($query) {
-                $query->where('doubleup', '=', 1);
-            })
-            ->when($this->featured, function ($query) {
-                $query->where('featured', '=', 1);
-            })
-            ->when($this->stream, function ($query) {
-                $query->where('stream', '=', 1);
-            })
-            ->when($this->sd, function ($query) {
-                $query->where('sd', '=', 1);
-            })
-            ->when($this->highspeed, function ($query) {
-                $query->where('highspeed', '=', 1);
-            })
-            ->when($this->internal, function ($query) {
-                $query->where('internal', '=', 1);
-            })
+            ->dead()
+            ->when($this->name            !== ''   , fn ($query) => $query->ofName($this->name, $isRegex($this->name)))
+            ->when($this->categories      !== []   , fn ($query) => $query->ofCategory($this->categories))
+            ->when($this->types           !== []   , fn ($query) => $query->ofType($this->types))
+            ->when($this->resolutions     !== []   , fn ($query) => $query->ofResolution($this->resolutions))
+            ->when($this->tmdbId          !== ''   , fn ($query) => $query->ofTmdb($this->tmdbId))
+            ->when($this->imdbId          !== ''   , fn ($query) => $query->ofImdb(\preg_match('/tt0*(?=(\d{7,}))/', $this->imdbId, $matches) ? $matches[1] : $this->imdbId))
+            ->when($this->tvdbId          !== ''   , fn ($query) => $query->ofTvdb($this->tvdbId))
+            ->when($this->malId           !== ''   , fn ($query) => $query->ofMal($this->malId))
+            ->when($this->free            !== []   , fn ($query) => $query->ofFreeleech($this->free))
+            ->when($this->doubleup        !== false, fn ($query) => $query->doubleup())
+            ->when($this->featured        !== false, fn ($query) => $query->featured())
+            ->when($this->stream          !== false, fn ($query) => $query->streamOptimized())
+            ->when($this->sd              !== false, fn ($query) => $query->sd())
+            ->when($this->highspeed       !== false, fn ($query) => $query->highspeed())
+            ->when($this->bookmarked      !== false, fn ($query) => $query->bookmarkedBy($user))
+            ->when($this->wished          !== false, fn ($query) => $query->wishedBy($user))
+            ->when($this->internal        !== false, fn ($query) => $query->internal())
             ->orderBy($this->sortField, $this->sortDirection)
             ->paginate($this->perPage);
     }

--- a/app/Http/Livewire/TorrentCardSearch.php
+++ b/app/Http/Livewire/TorrentCardSearch.php
@@ -68,49 +68,41 @@ class TorrentCardSearch extends Component
 
     public string $collectionId = '';
 
-    public $free0;
+    public array $free = [];
 
-    public $free25;
+    public bool $doubleup = false;
 
-    public $free50;
+    public bool $featured = false;
 
-    public $free75;
+    public bool $stream = false;
 
-    public $free100;
+    public bool $sd = false;
 
-    public $doubleup;
+    public bool $highspeed = false;
 
-    public $featured;
+    public bool $bookmarked = false;
 
-    public $stream;
+    public bool $wished = false;
 
-    public $sd;
+    public bool $internal = false;
 
-    public $highspeed;
+    public bool $personalRelease = false;
 
-    public $bookmarked;
+    public bool $alive = false;
 
-    public $wished;
+    public bool $dying = false;
 
-    public $internal;
+    public bool $dead = false;
 
-    public $personalRelease;
+    public bool $notDownloaded = false;
 
-    public $alive;
+    public bool $downloaded = false;
 
-    public $dying;
+    public bool $seeding = false;
 
-    public $dead;
+    public bool $leeching = false;
 
-    public $notDownloaded;
-
-    public $downloaded;
-
-    public $seeding;
-
-    public $leeching;
-
-    public $incomplete;
+    public bool $incomplete = false;
 
     public int $perPage = 24;
 
@@ -138,11 +130,7 @@ class TorrentCardSearch extends Component
         'malId'            => ['except' => ''],
         'playlistId'       => ['except' => ''],
         'collectionId'     => ['except' => ''],
-        'free0'            => ['except' => false],
-        'free25'           => ['except' => false],
-        'free50'           => ['except' => false],
-        'free75'           => ['except' => false],
-        'free100'          => ['except' => false],
+        'free'             => ['except' => []],
         'doubleup'         => ['except' => false],
         'featured'         => ['except' => false],
         'stream'           => ['except' => false],
@@ -200,181 +188,52 @@ class TorrentCardSearch extends Component
 
     final public function getTorrentsProperty(): \Illuminate\Contracts\Pagination\LengthAwarePaginator
     {
+        $user = \auth()->user();
+        $isRegexAllowed = $user->group->is_modo;
+        $isRegex = fn ($field) => $isRegexAllowed
+            && \strlen($field) >= 2
+            && $field[0] === '/'
+            && $field[-1] === '/';
+        
         return Torrent::with(['user:id,username,group_id', 'user.group', 'category', 'type', 'resolution'])
             ->withCount(['thanks', 'comments'])
-            ->when($this->name, function ($query) {
-                $terms = \explode(' ', $this->name);
-                $search = '';
-                foreach ($terms as $term) {
-                    $search .= '%'.$term.'%';
-                }
-
-                $query->where('name', 'LIKE', $search);
-            })
-            ->when($this->description, function ($query) {
-                $query->where('description', 'LIKE', '%'.$this->description.'%');
-            })
-            ->when($this->mediainfo, function ($query) {
-                $query->where('mediainfo', 'LIKE', '%'.$this->mediainfo.'%');
-            })
-            ->when($this->uploader, function ($query) {
-                $match = User::where('username', '=', $this->uploader)->first();
-                if ($match) {
-                    $query->where('user_id', '=', $match->id)->where('anon', '=', 0);
-                }
-            })
-            ->when($this->keywords, function ($query) {
-                $keywords = self::parseKeywords($this->keywords);
-                $keyword = Keyword::whereIn('name', $keywords)->pluck('torrent_id');
-                $query->whereIntegerInRaw('id', $keyword);
-            })
-            ->when($this->startYear && $this->endYear, function ($query) {
-                $query->whereBetween('release_year', [$this->startYear, $this->endYear]);
-            })
-            ->when($this->categories, function ($query) {
-                $query->whereIntegerInRaw('category_id', $this->categories);
-            })
-            ->when($this->types, function ($query) {
-                $query->whereIntegerInRaw('type_id', $this->types);
-            })
-            ->when($this->resolutions, function ($query) {
-                $query->whereIntegerInRaw('resolution_id', $this->resolutions);
-            })
-            ->when($this->genres, function ($query) {
-                $this->validate();
-
-                $tvCollection = DB::table('genre_tv')->whereIntegerInRaw('genre_id', $this->genres)->pluck('tv_id');
-                $movieCollection = DB::table('genre_movie')->whereIntegerInRaw('genre_id', $this->genres)->pluck('movie_id');
-                $mergedCollection = $tvCollection->merge($movieCollection);
-
-                $query->whereRaw("tmdb in ('".\implode("','", $mergedCollection->toArray())."')"); // Protected with Validation that IDs passed are not malicious
-            })
-            ->when($this->regions, function ($query) {
-                $query->whereIntegerInRaw('region_id', $this->regions);
-            })
-            ->when($this->distributors, function ($query) {
-                $query->whereIntegerInRaw('distributor_id', $this->distributors);
-            })
-            ->when($this->tmdbId === '0' || $this->tmdbId, function ($query) {
-                $query->where('tmdb', '=', $this->tmdbId);
-            })
-            ->when($this->imdbId === '0' || $this->imdbId, function ($query) {
-                if (\preg_match('/tt0*?(?=(\d{7,8}))/', $this->imdbId, $matches)) {
-                    $query->where('imdb', '=', $matches[1]);
-                } else {
-                    $query->where('imdb', '=', $this->imdbId);
-                }
-            })
-            ->when($this->tvdbId === '0' || $this->tvdbId, function ($query) {
-                $query->where('tvdb', '=', $this->tvdbId);
-            })
-            ->when($this->malId === '0' || $this->malId, function ($query) {
-                $query->where('mal', '=', $this->malId);
-            })
-            ->when($this->playlistId, function ($query) {
-                $playlist = PlaylistTorrent::where('playlist_id', '=', $this->playlistId)->pluck('torrent_id');
-                $query->whereIntegerInRaw('id', $playlist);
-            })
-            ->when($this->collectionId, function ($query) {
-                $categories = Category::where('movie_meta', '=', 1)->pluck('id');
-                $collection = DB::table('collection_movie')->where('collection_id', '=', $this->collectionId)->pluck('movie_id');
-                $query->whereIntegerInRaw('category_id', $categories)->whereIntegerInRaw('tmdb', $collection);
-            })
-            ->when($this->free0 === '0' || $this->free0 || $this->free25 || $this->free50 || $this->free75 || $this->free100, function ($query) {
-                $query->where(function ($query) {
-                    $query->where(function ($query) {
-                        if ($this->free0 === '0' || $this->free0) {
-                            $query->where('free', '=', 0);
-                        }
-                    })
-                    ->orWhere(function ($query) {
-                        if ($this->free25) {
-                            $query->where('free', '=', 25);
-                        }
-                    })
-                    ->orWhere(function ($query) {
-                        if ($this->free50) {
-                            $query->where('free', '=', 50);
-                        }
-                    })
-                    ->orWhere(function ($query) {
-                        if ($this->free75) {
-                            $query->where('free', '=', 75);
-                        }
-                    })
-                    ->orWhere(function ($query) {
-                        if ($this->free100) {
-                            $query->where('free', '=', 100);
-                        }
-                    });
-                });
-            })
-            ->when($this->doubleup, function ($query) {
-                $query->where('doubleup', '=', 1);
-            })
-            ->when($this->featured, function ($query) {
-                $query->where('featured', '=', 1);
-            })
-            ->when($this->stream, function ($query) {
-                $query->where('stream', '=', 1);
-            })
-            ->when($this->sd, function ($query) {
-                $query->where('sd', '=', 1);
-            })
-            ->when($this->highspeed, function ($query) {
-                $query->where('highspeed', '=', 1);
-            })
-            ->when($this->bookmarked, function ($query) {
-                $bookmarks = Bookmark::where('user_id', '=', \auth()->user()->id)->pluck('torrent_id');
-                $query->whereIntegerInRaw('id', $bookmarks);
-            })
-            ->when($this->wished, function ($query) {
-                $wishes = Wish::where('user_id', '=', \auth()->user()->id)->pluck('tmdb');
-                $query->whereIn('tmdb', $wishes);
-            })
-            ->when($this->internal, function ($query) {
-                $query->where('internal', '=', 1);
-            })
-            ->when($this->personalRelease, function ($query) {
-                $query->where('personal_release', '=', 1);
-            })
-            ->when($this->alive, function ($query) {
-                $query->where('seeders', '>=', 1);
-            })
-            ->when($this->dying, function ($query) {
-                $query->where('seeders', '=', 1)->where('times_completed', '>=', 3);
-            })
-            ->when($this->dead, function ($query) {
-                $query->where('seeders', '=', 0);
-            })
-            ->when($this->notDownloaded, function ($query) {
-                $history = History::where('user_id', '=', \auth()->user()->id)->pluck('torrent_id')->toArray();
-                if (! $history || ! \is_array($history)) {
-                    $history = [];
-                }
-
-                $query->whereIntergerNotIn('id', $history);
-            })
-            ->when($this->downloaded, function ($query) {
-                $query->whereHas('history', function ($query) {
-                    $query->where('user_id', '=', \auth()->user()->id);
-                });
-            })
-            ->when($this->seeding, function ($query) {
-                $query->whereHas('history', function ($q) {
-                    $q->where('user_id', '=', \auth()->user()->id)->where('active', '=', true)->where('seeder', '=', true);
-                });
-            })
-            ->when($this->leeching, function ($query) {
-                $query->whereHas('history', function ($q) {
-                    $q->where('user_id', '=', \auth()->user()->id)->where('active', '=', true)->where('seedtime', '=', '0');
-                });
-            })
-            ->when($this->incomplete, function ($query) {
-                $query->whereHas('history', function ($q) {
-                    $q->where('user_id', '=', \auth()->user()->id)->where('active', '=', false)->where('seeder', '=', false)->where('seedtime', '=', '0');
-                });
-            })
+            ->when($this->name            !== ''   , fn ($query) => $query->ofName($this->name, $isRegex($this->name)))
+            ->when($this->description     !== ''   , fn ($query) => $query->ofDescription($this->description, $isRegex($this->name)))
+            ->when($this->mediainfo       !== ''   , fn ($query) => $query->ofMediainfo($this->mediainfo, $isRegex($this->name)))
+            ->when($this->uploader        !== ''   , fn ($query) => $query->ofUploader($this->uploader))
+            ->when($this->keywords        !== ''   , fn ($query) => $query->ofKeyword(\array_map('trim', explode(',', $this->keywords))))
+            ->when($this->startYear       !== ''   , fn ($query) => $query->releasedAfterOrIn($this->startYear))
+            ->when($this->endYear         !== ''   , fn ($query) => $query->releasedBeforeOrIn($this->endYear))
+            ->when($this->categories      !== []   , fn ($query) => $query->ofCategory($this->categories))
+            ->when($this->types           !== []   , fn ($query) => $query->ofType($this->types))
+            ->when($this->resolutions     !== []   , fn ($query) => $query->ofResolution($this->resolutions))
+            ->when($this->genres          !== []   , fn ($query) => $query->ofGenre($this->genres))
+            ->when($this->regions         !== []   , fn ($query) => $query->ofRegion($this->regions))
+            ->when($this->distributors    !== []   , fn ($query) => $query->ofDistributor($this->distributors))
+            ->when($this->tmdbId          !== ''   , fn ($query) => $query->ofTmdb($this->tmdbId))
+            ->when($this->imdbId          !== ''   , fn ($query) => $query->ofImdb(\preg_match('/tt0*(?=(\d{7,}))/', $this->imdbId, $matches) ? $matches[1] : $this->imdbId))
+            ->when($this->tvdbId          !== ''   , fn ($query) => $query->ofTvdb($this->tvdbId))
+            ->when($this->malId           !== ''   , fn ($query) => $query->ofMal($this->malId))
+            ->when($this->playlistId      !== ''   , fn ($query) => $query->ofPlaylist($this->playlistId))
+            ->when($this->collectionId    !== ''   , fn ($query) => $query->ofCollection($this->collectionId))
+            ->when($this->free            !== []   , fn ($query) => $query->ofFreeleech($this->free))
+            ->when($this->doubleup        !== false, fn ($query) => $query->doubleup())
+            ->when($this->featured        !== false, fn ($query) => $query->featured())
+            ->when($this->stream          !== false, fn ($query) => $query->streamOptimized())
+            ->when($this->sd              !== false, fn ($query) => $query->sd())
+            ->when($this->highspeed       !== false, fn ($query) => $query->highspeed())
+            ->when($this->bookmarked      !== false, fn ($query) => $query->bookmarkedBy($user))
+            ->when($this->wished          !== false, fn ($query) => $query->wishedBy($user))
+            ->when($this->internal        !== false, fn ($query) => $query->internal())
+            ->when($this->personalRelease !== false, fn ($query) => $query->personalRelease())
+            ->when($this->alive           !== false, fn ($query) => $query->alive())
+            ->when($this->dying           !== false, fn ($query) => $query->dying())
+            ->when($this->dead            !== false, fn ($query) => $query->dead())
+            ->when($this->notDownloaded   !== false, fn ($query) => $query->notDownloadedBy($user))
+            ->when($this->downloaded      !== false, fn ($query) => $query->downloadedBy($user))
+            ->when($this->seeding         !== false, fn ($query) => $query->seededBy($user))
+            ->when($this->leeching        !== false, fn ($query) => $query->leechedBy($user))
+            ->when($this->incomplete      !== false, fn ($query) => $query->uncompletedBy($user))
             ->latest('sticky')
             ->orderBy($this->sortField, $this->sortDirection)
             ->paginate($this->perPage);

--- a/app/Http/Livewire/TorrentListSearch.php
+++ b/app/Http/Livewire/TorrentListSearch.php
@@ -13,15 +13,9 @@
 
 namespace App\Http\Livewire;
 
-use App\Models\Bookmark;
-use App\Models\Category;
-use App\Models\History;
-use App\Models\Keyword;
 use App\Models\PersonalFreeleech;
-use App\Models\PlaylistTorrent;
 use App\Models\Torrent;
 use App\Models\User;
-use App\Models\Wish;
 use Illuminate\Support\Facades\DB;
 use Livewire\Component;
 use Livewire\WithPagination;
@@ -68,49 +62,41 @@ class TorrentListSearch extends Component
 
     public string $collectionId = '';
 
-    public $free0;
+    public array $free = [];
 
-    public $free25;
+    public bool $doubleup = false;
 
-    public $free50;
+    public bool $featured = false;
 
-    public $free75;
+    public bool $stream = false;
 
-    public $free100;
+    public bool $sd = false;
 
-    public $doubleup;
+    public bool $highspeed = false;
 
-    public $featured;
+    public bool $bookmarked = false;
 
-    public $stream;
+    public bool $wished = false;
 
-    public $sd;
+    public bool $internal = false;
 
-    public $highspeed;
+    public bool $personalRelease = false;
 
-    public $bookmarked;
+    public bool $alive = false;
 
-    public $wished;
+    public bool $dying = false;
 
-    public $internal;
+    public bool $dead = false;
 
-    public $personalRelease;
+    public bool $notDownloaded = false;
 
-    public $alive;
+    public bool $downloaded = false;
 
-    public $dying;
+    public bool $seeding = false;
 
-    public $dead;
+    public bool $leeching = false;
 
-    public $notDownloaded;
-
-    public $downloaded;
-
-    public $seeding;
-
-    public $leeching;
-
-    public $incomplete;
+    public bool $incomplete = false;
 
     public int $perPage = 25;
 
@@ -138,11 +124,7 @@ class TorrentListSearch extends Component
         'malId'            => ['except' => ''],
         'playlistId'       => ['except' => ''],
         'collectionId'     => ['except' => ''],
-        'free0'            => ['except' => false],
-        'free25'           => ['except' => false],
-        'free50'           => ['except' => false],
-        'free75'           => ['except' => false],
-        'free100'          => ['except' => false],
+        'free'             => ['except' => []],
         'doubleup'         => ['except' => false],
         'featured'         => ['except' => false],
         'stream'           => ['except' => false],
@@ -200,198 +182,55 @@ class TorrentListSearch extends Component
 
     final public function getTorrentsProperty(): \Illuminate\Contracts\Pagination\LengthAwarePaginator
     {
+        $user = \auth()->user();
+        $isRegexAllowed = $user->group->is_modo;
+        $isRegex = fn ($field) => $isRegexAllowed
+            && \strlen($field) >= 2
+            && $field[0] === '/'
+            && $field[-1] === '/';
+        
         return Torrent::with(['user:id,username,group_id', 'user.group', 'category', 'type', 'resolution'])
             ->withCount(['thanks', 'comments'])
-            ->when($this->name, function ($query) {
-                $terms = \explode(' ', $this->name);
-                $search = '';
-                foreach ($terms as $term) {
-                    $search .= '%'.$term.'%';
-                }
-
-                $query->where('name', 'LIKE', $search);
-            })
-            ->when($this->description, function ($query) {
-                $query->where('description', 'LIKE', '%'.$this->description.'%');
-            })
-            ->when($this->mediainfo, function ($query) {
-                $query->where('mediainfo', 'LIKE', '%'.$this->mediainfo.'%');
-            })
-            ->when($this->uploader, function ($query) {
-                $match = User::where('username', '=', $this->uploader)->first();
-                if ($match) {
-                    $query->where('user_id', '=', $match->id)->where('anon', '=', 0);
-                }
-            })
-            ->when($this->keywords, function ($query) {
-                $keywords = self::parseKeywords($this->keywords);
-                $keyword = Keyword::whereIn('name', $keywords)->pluck('torrent_id');
-                $query->whereIntegerInRaw('id', $keyword);
-            })
-            ->when($this->startYear && $this->endYear, function ($query) {
-                $query->whereBetween('release_year', [$this->startYear, $this->endYear]);
-            })
-            ->when($this->categories, function ($query) {
-                $query->whereIntegerInRaw('category_id', $this->categories);
-            })
-            ->when($this->types, function ($query) {
-                $query->whereIntegerInRaw('type_id', $this->types);
-            })
-            ->when($this->resolutions, function ($query) {
-                $query->whereIntegerInRaw('resolution_id', $this->resolutions);
-            })
-            ->when($this->genres, function ($query) {
-                $this->validate();
-
-                $tvCollection = DB::table('genre_tv')->whereIntegerInRaw('genre_id', $this->genres)->pluck('tv_id');
-                $movieCollection = DB::table('genre_movie')->whereIntegerInRaw('genre_id', $this->genres)->pluck('movie_id');
-                $mergedCollection = $tvCollection->merge($movieCollection);
-
-                $query->whereRaw("tmdb in ('".\implode("','", $mergedCollection->toArray())."')"); // Protected with Validation that IDs passed are not malicious
-            })
-            ->when($this->regions, function ($query) {
-                $query->whereIntegerInRaw('region_id', $this->regions);
-            })
-            ->when($this->distributors, function ($query) {
-                $query->whereIntegerInRaw('distributor_id', $this->distributors);
-            })
-            ->when($this->tmdbId === '0' || $this->tmdbId, function ($query) {
-                $query->where('tmdb', '=', $this->tmdbId);
-            })
-            ->when($this->imdbId === '0' || $this->imdbId, function ($query) {
-                if (\preg_match('/tt0*?(?=(\d{7,8}))/', $this->imdbId, $matches)) {
-                    $query->where('imdb', '=', $matches[1]);
-                } else {
-                    $query->where('imdb', '=', $this->imdbId);
-                }
-            })
-            ->when($this->tvdbId === '0' || $this->tvdbId, function ($query) {
-                $query->where('tvdb', '=', $this->tvdbId);
-            })
-            ->when($this->malId === '0' || $this->malId, function ($query) {
-                $query->where('mal', '=', $this->malId);
-            })
-            ->when($this->playlistId, function ($query) {
-                $playlist = PlaylistTorrent::where('playlist_id', '=', $this->playlistId)->pluck('torrent_id');
-                $query->whereIntegerInRaw('id', $playlist);
-            })
-            ->when($this->collectionId, function ($query) {
-                $categories = Category::where('movie_meta', '=', 1)->pluck('id');
-                $collection = DB::table('collection_movie')->where('collection_id', '=', $this->collectionId)->pluck('movie_id');
-                $query->whereIntegerInRaw('category_id', $categories)->whereIntegerInRaw('tmdb', $collection);
-            })
-            ->when($this->free0 === '0' || $this->free0 || $this->free25 || $this->free50 || $this->free75 || $this->free100, function ($query) {
-                $query->where(function ($query) {
-                    $query->where(function ($query) {
-                        if ($this->free0 === '0' || $this->free0) {
-                            $query->where('free', '=', 0);
-                        }
-                    })
-                    ->orWhere(function ($query) {
-                        if ($this->free25) {
-                            $query->where('free', '=', 25);
-                        }
-                    })
-                    ->orWhere(function ($query) {
-                        if ($this->free50) {
-                            $query->where('free', '=', 50);
-                        }
-                    })
-                    ->orWhere(function ($query) {
-                        if ($this->free75) {
-                            $query->where('free', '=', 75);
-                        }
-                    })
-                    ->orWhere(function ($query) {
-                        if ($this->free100) {
-                            $query->where('free', '=', 100);
-                        }
-                    });
-                });
-            })
-            ->when($this->doubleup, function ($query) {
-                $query->where('doubleup', '=', 1);
-            })
-            ->when($this->featured, function ($query) {
-                $query->where('featured', '=', 1);
-            })
-            ->when($this->stream, function ($query) {
-                $query->where('stream', '=', 1);
-            })
-            ->when($this->sd, function ($query) {
-                $query->where('sd', '=', 1);
-            })
-            ->when($this->highspeed, function ($query) {
-                $query->where('highspeed', '=', 1);
-            })
-            ->when($this->bookmarked, function ($query) {
-                $bookmarks = Bookmark::where('user_id', '=', \auth()->user()->id)->pluck('torrent_id');
-                $query->whereIntegerInRaw('id', $bookmarks);
-            })
-            ->when($this->wished, function ($query) {
-                $wishes = Wish::where('user_id', '=', \auth()->user()->id)->pluck('tmdb');
-                $query->whereIn('tmdb', $wishes);
-            })
-            ->when($this->internal, function ($query) {
-                $query->where('internal', '=', 1);
-            })
-            ->when($this->personalRelease, function ($query) {
-                $query->where('personal_release', '=', 1);
-            })
-            ->when($this->alive, function ($query) {
-                $query->where('seeders', '>=', 1);
-            })
-            ->when($this->dying, function ($query) {
-                $query->where('seeders', '=', 1)->where('times_completed', '>=', 3);
-            })
-            ->when($this->dead, function ($query) {
-                $query->where('seeders', '=', 0);
-            })
-            ->when($this->notDownloaded, function ($query) {
-                $history = History::where('user_id', '=', \auth()->user()->id)->pluck('torrent_id')->toArray();
-                if (! $history || ! \is_array($history)) {
-                    $history = [];
-                }
-
-                $query->whereIntegerNotInRaw('id', $history);
-            })
-            ->when($this->downloaded, function ($query) {
-                $query->whereHas('history', function ($query) {
-                    $query->where('user_id', '=', \auth()->user()->id);
-                });
-            })
-            ->when($this->seeding, function ($query) {
-                $query->whereHas('history', function ($q) {
-                    $q->where('user_id', '=', \auth()->user()->id)->where('active', '=', true)->where('seeder', '=', true);
-                });
-            })
-            ->when($this->leeching, function ($query) {
-                $query->whereHas('history', function ($q) {
-                    $q->where('user_id', '=', \auth()->user()->id)->where('active', '=', true)->where('seedtime', '=', '0');
-                });
-            })
-            ->when($this->incomplete, function ($query) {
-                $query->whereHas('history', function ($q) {
-                    $q->where('user_id', '=', \auth()->user()->id)->where('active', '=', false)->where('seeder', '=', false)->where('seedtime', '=', '0');
-                });
-            })
+            ->when($this->name            !== ''   , fn ($query) => $query->ofName($this->name, $isRegex($this->name)))
+            ->when($this->description     !== ''   , fn ($query) => $query->ofDescription($this->description, $isRegex($this->name)))
+            ->when($this->mediainfo       !== ''   , fn ($query) => $query->ofMediainfo($this->mediainfo, $isRegex($this->name)))
+            ->when($this->uploader        !== ''   , fn ($query) => $query->ofUploader($this->uploader))
+            ->when($this->keywords        !== ''   , fn ($query) => $query->ofKeyword(\array_map('trim', explode(',', $this->keywords))))
+            ->when($this->startYear       !== ''   , fn ($query) => $query->releasedAfterOrIn($this->startYear))
+            ->when($this->endYear         !== ''   , fn ($query) => $query->releasedBeforeOrIn($this->endYear))
+            ->when($this->categories      !== []   , fn ($query) => $query->ofCategory($this->categories))
+            ->when($this->types           !== []   , fn ($query) => $query->ofType($this->types))
+            ->when($this->resolutions     !== []   , fn ($query) => $query->ofResolution($this->resolutions))
+            ->when($this->genres          !== []   , fn ($query) => $query->ofGenre($this->genres))
+            ->when($this->regions         !== []   , fn ($query) => $query->ofRegion($this->regions))
+            ->when($this->distributors    !== []   , fn ($query) => $query->ofDistributor($this->distributors))
+            ->when($this->tmdbId          !== ''   , fn ($query) => $query->ofTmdb($this->tmdbId))
+            ->when($this->imdbId          !== ''   , fn ($query) => $query->ofImdb(\preg_match('/tt0*(?=(\d{7,}))/', $this->imdbId, $matches) ? $matches[1] : $this->imdbId))
+            ->when($this->tvdbId          !== ''   , fn ($query) => $query->ofTvdb($this->tvdbId))
+            ->when($this->malId           !== ''   , fn ($query) => $query->ofMal($this->malId))
+            ->when($this->playlistId      !== ''   , fn ($query) => $query->ofPlaylist($this->playlistId))
+            ->when($this->collectionId    !== ''   , fn ($query) => $query->ofCollection($this->collectionId))
+            ->when($this->free            !== []   , fn ($query) => $query->ofFreeleech($this->free))
+            ->when($this->doubleup        !== false, fn ($query) => $query->doubleup())
+            ->when($this->featured        !== false, fn ($query) => $query->featured())
+            ->when($this->stream          !== false, fn ($query) => $query->streamOptimized())
+            ->when($this->sd              !== false, fn ($query) => $query->sd())
+            ->when($this->highspeed       !== false, fn ($query) => $query->highspeed())
+            ->when($this->bookmarked      !== false, fn ($query) => $query->bookmarkedBy($user))
+            ->when($this->wished          !== false, fn ($query) => $query->wishedBy($user))
+            ->when($this->internal        !== false, fn ($query) => $query->internal())
+            ->when($this->personalRelease !== false, fn ($query) => $query->personalRelease())
+            ->when($this->alive           !== false, fn ($query) => $query->alive())
+            ->when($this->dying           !== false, fn ($query) => $query->dying())
+            ->when($this->dead            !== false, fn ($query) => $query->dead())
+            ->when($this->notDownloaded   !== false, fn ($query) => $query->notDownloadedBy($user))
+            ->when($this->downloaded      !== false, fn ($query) => $query->downloadedBy($user))
+            ->when($this->seeding         !== false, fn ($query) => $query->seededBy($user))
+            ->when($this->leeching        !== false, fn ($query) => $query->leechedBy($user))
+            ->when($this->incomplete      !== false, fn ($query) => $query->uncompletedBy($user))
             ->latest('sticky')
             ->orderBy($this->sortField, $this->sortDirection)
             ->paginate($this->perPage);
-    }
-
-    private static function parseKeywords($text): array
-    {
-        $parts = \explode(', ', (string) $text);
-        $result = [];
-        foreach ($parts as $part) {
-            $part = \trim($part);
-            if ($part != '') {
-                $result[] = $part;
-            }
-        }
-
-        return $result;
     }
 
     final public function sortBy($field): void

--- a/app/Models/Torrent.php
+++ b/app/Models/Torrent.php
@@ -20,6 +20,7 @@ use App\Helpers\StringHelper;
 use App\Notifications\NewComment;
 use App\Notifications\NewThank;
 use App\Traits\Auditable;
+use App\Traits\TorrentFilter;
 use Hootlex\Moderation\Moderatable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -30,6 +31,7 @@ class Torrent extends Model
     use HasFactory;
     use Moderatable;
     use Auditable;
+    use TorrentFilter;
 
     /**
      * Belongs To A User.

--- a/app/Traits/TorrentFilter.php
+++ b/app/Traits/TorrentFilter.php
@@ -1,0 +1,276 @@
+<?php
+/**
+ * NOTICE OF LICENSE.
+ *
+ * UNIT3D Community Edition is open-sourced software licensed under the GNU Affero General Public License v3.0
+ * The details is bundled with this project in the file LICENSE.txt.
+ *
+ * @project    UNIT3D Community Edition
+ *
+ * @author     Roardom <roardom@protonmail.com>
+ * @license    https://www.gnu.org/licenses/agpl-3.0.en.html/ GNU Affero General Public License v3.0
+ */
+
+namespace App\Traits;
+
+use App\Models\Bookmark;
+use App\Models\Category;
+use App\Models\Keyword;
+use App\Models\PlaylistTorrent;
+use App\Models\User;
+use App\Models\Wish;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\DB;
+
+trait TorrentFilter
+{
+    public function scopeOfName(Builder $query, string $name, bool $isRegex = false): Builder
+    {
+        return $query->when($isRegex,
+                fn ($query) => $query->where('name', 'REGEXP', \substr($name, 1, -1)),
+                fn ($query) => $query->where('name', 'LIKE', '%'.\str_replace(' ', '%', $name).'%')
+            );
+    }
+
+    public function scopeOfDescription(Builder $query, string $description, bool $isRegex = false): Builder
+    {
+        return $query->when($isRegex,
+                fn ($query) => $query->where('description', 'REGEXP', \substr($description, 1, -1)),
+                fn ($query) => $query->where('description', 'LIKE', '%'.$description.'%')
+            );
+    }
+
+    public function scopeOfMediainfo(Builder $query, string $mediainfo, bool $isRegex = false): Builder
+    {
+        return $query->when($isRegex,
+                fn ($query) => $query->where('mediainfo', 'REGEXP', \substr($mediainfo, 1, -1)),
+                fn ($query) => $query->where('mediainfo', 'LIKE', '%'.$mediainfo.'%')
+            );
+    }
+
+    public function scopeOfUploader(Builder $query, string $username): Builder
+    {
+        return $query
+            ->whereIn('user_id', User::select('id')->where('username', '=', $username))
+            ->where('anon', '=', 0);
+    }
+    
+    public function scopeOfKeywords(Builder $query, array $keywords): Builder
+    {
+        return $query->whereIn('id', Keyword::select('torrent_id')->whereIn('name', $keywords));
+    }
+    
+    public function scopeReleasedAfterOrIn(Builder $query, int $year): Builder
+    {
+        return $query->where('release_year', '>=', $year);
+    }
+    
+    public function scopeReleasedBeforeOrIn(Builder $query, int $year): Builder
+    {
+        return $query->where('release_year', '<=', $year);
+    }
+    
+    public function scopeOfCategory(Builder $query, array $categories): Builder
+    {
+        return $query->whereIntegerInRaw('category_id', $categories);
+    }
+
+    public function scopeOfType(Builder $query, array $types): Builder
+    {
+        return $query->whereIntegerInRaw('type_id', $types);
+    }
+
+    public function scopeOfResolution(Builder $query, array $resolutions): Builder
+    {
+        return $query->whereIntegerInRaw('resolution_id', $resolutions);
+    }
+
+    public function scopeOfGenre(Builder $query, array $genres): Builder
+    {
+        return $query
+            ->where(fn ($query) => $query
+                ->where(fn ($query) => $query
+                    ->whereIn('category_id', Category::select('id')->where('movie_meta', '=', 1))
+                    ->whereIn('tmdb', DB::table('genre_movie')->select('movie_id')->whereIn('genre_id', $genres))
+                )
+                ->orWhere(fn ($query) => $query
+                    ->whereIn('category_id', Category::select('id')->where('tv_meta', '=', 1))
+                    ->whereIn('tmdb', DB::table('genre_tv')->select('tv_id')->whereIn('genre_id', $genres))
+                )
+            );
+    }
+
+    public function scopeOfRegion(Builder $query, array $regions): Builder
+    {
+        return $query->whereIntegerInRaw('region_id', $regions);
+    }
+
+    public function scopeOfDistributor(Builder $query, array $distributors): Builder
+    {
+        return $query->whereIntegerInRaw('distributor_id', $distributors);
+    }
+
+    public function scopeOfTmdb(Builder $query, int $tvdbId): Builder
+    {
+        return $query->where('tmdb', '=', $tvdbId);
+    }
+
+    public function scopeOfimdb(Builder $query, int $tvdbId): Builder
+    {
+        return $query->where('imdb', '=', $tvdbId);
+    }
+
+    public function scopeOfTvdb(Builder $query, int $tvdbId): Builder
+    {
+        return $query->where('tvdb', '=', $tvdbId);
+    }
+
+    public function scopeOfMal(Builder $query, int $malId): Builder
+    {
+        return $query->where('mal', '=', $malId);
+    }
+
+    public function scopeOfPlaylist(Builder $query, int $playlistId): Builder
+    {
+        return $query->whereIn('id', PlaylistTorrent::select('torrent_id')->where('playlist_id', '=', $playlistId));
+    }
+
+    public function scopeOfCollection(Builder $query, int $collectionId): Builder
+    {
+        return $query
+            ->whereIn('category_id', Category::select('id')->where('movie_meta', '=', 1))
+            ->whereIn('tmdb', DB::table('collection_movie')->select('movie_id')->where('collection_id', '=', $collectionId));
+    }
+
+    public function scopeOfFreeleech(Builder $query, array $free): Builder
+    {
+        return $query->whereIntegerInRaw('free', $free);
+    }
+
+    public function scopeDoubleup(Builder $query): Builder
+    {
+        return $query->where('doubleup', '=', 1);
+    }
+
+    public function scopeFeatured(Builder $query): Builder
+    {
+        return $query->where('featured', '=', 1);
+    }
+
+    public function scopeStreamOptimized(Builder $query): Builder
+    {
+        return $query->where('stream', '=', 1);
+    }
+
+    public function scopeSd(Builder $query): Builder
+    {
+        return $query->where('sd', '=', 1);
+    }
+
+    public function scopeHighSpeed(Builder $query): Builder
+    {
+        return $query->where('highspeed', '=', 1);
+    }
+
+    public function scopeBookmarkedBy(Builder $query, User $user): Builder
+    {
+        return $query->whereIn('id', Bookmark::select('torrent_id')->where('user_id', '=', $user->id));
+    }
+
+    public function scopeWishedBy(Builder $query, User $user): Builder
+    {
+        return $query->whereIn('tmdb', Wish::select('tmdb')->where('user_id', '=', $user->id));
+    }
+
+    public function scopeInternal(Builder $query): Builder
+    {
+        return $query->where('internal', '=', 1);
+    }
+
+    public function scopePersonalRelease(Builder $query): Builder
+    {
+        return $query->where('personal_release', '=', 1);
+    }
+
+    public function scopeAlive(Builder $query): Builder
+    {
+        return $query->where('seeders', '>', 0);
+    }
+
+    public function scopeDying(Builder $query): Builder
+    {
+        return $query
+            ->where('seeders', '=', 1)
+            ->where('times_completed', '>=', 3);
+    }
+
+    public function scopeDead(Builder $query): Builder
+    {
+        return $query->where('seeders', '=', 0);
+    }
+
+    public function scopeNotDownloadedBy(Builder $query, User $user): Builder
+    {
+        return $query
+            ->whereDoesntHave('history', fn ($query) => $query
+                ->where('user_id', '=', $user->id)
+            );
+    }
+
+    public function scopeDownloadedBy(Builder $query, User $user): Builder
+    {
+        return $query
+            ->whereHas('history', fn (Builder $query) => $query
+                ->where('user_id', '=', $user->id)
+            );
+    }
+
+    public function scopeSeededBy(Builder $query, User $user): Builder
+    {
+        return $query
+            ->whereHas('history', fn ($query) => $query
+                ->where('user_id', '=', $user->id)
+                ->where('active', '=', 1)
+                ->where('seeder', '=', 1)
+            );
+    }
+
+    public function scopeLeechedby(Builder $query, User $user): Builder
+    {
+        return $query
+            ->whereHas('history', fn ($query) => $query
+                ->where('user_id', '=', $user->id)
+                ->where('active', '=', 1)
+                ->where('seeder', '=', 0)
+            );
+    }
+
+    public function scopeUncompletedBy(Builder $query, User $user): Builder
+    {
+        return $query
+            ->whereHas('history', fn ($query) => $query
+                ->where('user_id', '=', $user->id)
+                ->where('active', '=', 0)
+                ->where('seeder', '=', 0)
+                ->where('seedtime', '=', 0)
+            );
+    }
+
+    public function scopeOfFilename(Builder $query, string $filename): Builder
+    {
+        return $query
+            ->whereHas('files', fn ($query) => $query
+                ->where('name', $filename)
+            );
+    }
+
+    public function scopeOfSeason(Builder $query, int $seasonNumber): Builder
+    {
+        return $query->where('season_number', '=', $seasonNumber);
+    }
+
+    public function scopeOfEpisode(Builder $query, int $episodeNumber): Builder
+    {
+        return $query->where('episode_number', '=', $episodeNumber);
+    }
+}

--- a/resources/views/livewire/graveyard-search.blade.php
+++ b/resources/views/livewire/graveyard-search.blade.php
@@ -96,8 +96,32 @@
                             <label for="extra" class="label label-default">Buff</label>
                             <span class="badge-user">
 								<label class="inline">
-									<input wire:model="free" type="checkbox" value="1">
-									Freeleech
+									<input wire:model.prefetch="free" type="checkbox" value="0">
+									0% Freeleech
+								</label>
+							</span>
+                            <span class="badge-user">
+								<label class="inline">
+									<input wire:model.prefetch="free" type="checkbox" value="25">
+									25% Freeleech
+								</label>
+							</span>
+                            <span class="badge-user">
+								<label class="inline">
+									<input wire:model.prefetch="free" type="checkbox" value="50">
+									50% Freeleech
+								</label>
+							</span>
+                            <span class="badge-user">
+								<label class="inline">
+									<input wire:model.prefetch="free" type="checkbox" value="75">
+									75% Freeleech
+								</label>
+							</span>
+                            <span class="badge-user">
+								<label class="inline">
+									<input wire:model.prefetch="free" type="checkbox" value="100">
+									100% Freeleech
 								</label>
 							</span>
                             <span class="badge-user">

--- a/resources/views/livewire/torrent-card-search.blade.php
+++ b/resources/views/livewire/torrent-card-search.blade.php
@@ -145,31 +145,31 @@
                             <label for="buffs" class="label label-default">Buff</label>
                             <span class="badge-user">
 								<label class="inline">
-									<input wire:model.prefetch="free0" type="checkbox" value="0">
+									<input wire:model.prefetch="free" type="checkbox" value="0">
 									0% Freeleech
 								</label>
 							</span>
                             <span class="badge-user">
 								<label class="inline">
-									<input wire:model.prefetch="free25" type="checkbox" value="25">
+									<input wire:model.prefetch="free" type="checkbox" value="25">
 									25% Freeleech
 								</label>
 							</span>
                             <span class="badge-user">
 								<label class="inline">
-									<input wire:model.prefetch="free50" type="checkbox" value="50">
+									<input wire:model.prefetch="free" type="checkbox" value="50">
 									50% Freeleech
 								</label>
 							</span>
                             <span class="badge-user">
 								<label class="inline">
-									<input wire:model.prefetch="free75" type="checkbox" value="75">
+									<input wire:model.prefetch="free" type="checkbox" value="75">
 									75% Freeleech
 								</label>
 							</span>
                             <span class="badge-user">
 								<label class="inline">
-									<input wire:model.prefetch="free100" type="checkbox" value="100">
+									<input wire:model.prefetch="free" type="checkbox" value="100">
 									100% Freeleech
 								</label>
 							</span>

--- a/resources/views/livewire/torrent-list-search.blade.php
+++ b/resources/views/livewire/torrent-list-search.blade.php
@@ -160,31 +160,31 @@
                             <label for="buffs" class="label label-default">Buff</label>
                             <span class="badge-user">
 								<label class="inline">
-									<input wire:model.prefetch="free0" type="checkbox" value="0">
+									<input wire:model.prefetch="free" type="checkbox" value="0">
 									0% Freeleech
 								</label>
 							</span>
                             <span class="badge-user">
 								<label class="inline">
-									<input wire:model.prefetch="free25" type="checkbox" value="25">
+									<input wire:model.prefetch="free" type="checkbox" value="25">
 									25% Freeleech
 								</label>
 							</span>
                             <span class="badge-user">
 								<label class="inline">
-									<input wire:model.prefetch="free50" type="checkbox" value="50">
+									<input wire:model.prefetch="free" type="checkbox" value="50">
 									50% Freeleech
 								</label>
 							</span>
                             <span class="badge-user">
 								<label class="inline">
-									<input wire:model.prefetch="free75" type="checkbox" value="75">
+									<input wire:model.prefetch="free" type="checkbox" value="75">
 									75% Freeleech
 								</label>
 							</span>
                             <span class="badge-user">
 								<label class="inline">
-									<input wire:model.prefetch="free100" type="checkbox" value="100">
+									<input wire:model.prefetch="free" type="checkbox" value="100">
 									100% Freeleech
 								</label>
 							</span>


### PR DESCRIPTION
Some of the torrent searches weren't kept as up to date as the main torrent search. Moving it into a trait allows better code reusability and makes sure all the searches are consistent in their implementation.

As a bonus feature, regex searching support has been added for the torrent name, description, and mediainfo fields on the website-facing searches (`TorrentListSearch.php`, `TorrentCardSearch.php`, and `GraveyardSearch.php`). It's currently only available for users with the modo permission, and requires the search to start and end with `/` to be recognized as a regex search.