### PR TITLE
(Fix) top navigation shifting on mobile

### DIFF
--- a/resources/sass/layout/_top_nav.scss
+++ b/resources/sass/layout/_top_nav.scss
@@ -8,7 +8,7 @@
 
     &.mobile {
         grid-template: 'left toggle' 'menus menus' 'right right' auto / 1fr auto;
-        height: 100vh;
+        max-height: 100vh;
         overflow-y: auto;
     }
 }


### PR DESCRIPTION
If a touch-enabled device can fit the entire hamburger menu when opened, but can't fit the entire hamburger menu when a dropdown is open, then it will cause layout shifting resulting in misclicks. Changing the height to max-height prevents the hamburger menu from becoming bigger than it needs to be, while still allowing scrolling within the hamburger menu if the entire menu can't fit on the screen.