### PR TITLE
(Fix) bbcode color

### DIFF
--- a/app/Helpers/Bbcode.php
+++ b/app/Helpers/Bbcode.php
@@ -89,7 +89,7 @@ class Bbcode
             'closeHtml'   => '</span>',
         ],
         'color' => [
-            'openBbcode'  => '/^\[color=(\#[a-f0-9]{3}|\#[a-f0-9]{6}|\#[a-f0-9]{8}|[a-z])\]/i',
+            'openBbcode'  => '/^\[color=(\#[a-f0-9]{3,4}|\#[a-f0-9]{6}|\#[a-f0-9]{8}|[a-z]+)\]/i',
             'closeBbcode' => '[/color]',
             'openHtml'    => '<span style="color: $1;">',
             'closeHtml'   => '</span>',


### PR DESCRIPTION
Initially, characters were only allowed when there was only one of them, so `[color=r]` would be accepted, but not `[color=red]`. This issue is now fixed.

Additionally, short hex codes with transparency (e.g. `[color=#0123]`) were also broken. This has now been fixed.

Color values such as rgb(), rgba(), hsl() and hsla() are intentionally unsupported to prevent feature creep.