### PR TITLE
(Fix) 3rd party upload bots sending unsupported bbcode

### DIFF
--- a/app/Helpers/Bbcode.php
+++ b/app/Helpers/Bbcode.php
@@ -239,7 +239,7 @@ class Bbcode
             $source
         );
         $source = \preg_replace_callback(
-            '/\[img=(\d+)\](.*?)\[\/img\]/i',
+            '/\[img=(\d+)(?:x\d+)?\](.*?)\[\/img\]/i',
             fn ($matches) => '<img src="'.\htmlspecialchars($matches[2]).'" loading="lazy" width="'.$matches[1].'px">',
             $source
         );


### PR DESCRIPTION
3rd party upload bots such as https://github.com/ryelogheat/xpbot have been using invalid/unsupported bbcode. This has caused issues now that the bbcode parser performs stricter validation. This PR includes a workaround so that images that are given a width of `350x350` ignore any number after an `x`.