### PR TITLE
(Fix) cookie banner intrusiveness

### DIFF
--- a/resources/views/layout/default.blade.php
+++ b/resources/views/layout/default.blade.php
@@ -4,6 +4,7 @@
     @include('partials.head')
 </head>
 <body>
+@include('cookie-consent::index')
 <header>
     @include('partials.top_nav')
     <nav class="secondary-nav">
@@ -21,7 +22,6 @@
             @yield('nav-tabs')
         </ul>
     </nav>
-    @include('cookie-consent::index')
     @include('partials.alerts')
     @if (Session::has('achievement'))
         @include('partials.achievement_modal')

--- a/resources/views/vendor/cookie-consent/dialogContents.blade.php
+++ b/resources/views/vendor/cookie-consent/dialogContents.blade.php
@@ -1,4 +1,8 @@
-<div class="alert alert-danger alert-dismissable js-cookie-consent cookie-consent">
+<section
+    class="alert alert-danger alert-dismissable js-cookie-consent cookie-consent"
+    aria-label="{{ __('cookie-consent::texts.agree') }}"
+    style="margin-bottom: 0; border-radius: 0;"
+>
     <div class="text-center">
     <span class="cookie-consent__message">
         {!! __('cookie-consent::texts.message') !!}
@@ -8,4 +12,4 @@
             {{ __('cookie-consent::texts.agree') }}
         </button>
     </div>
-</div>
+</section>


### PR DESCRIPTION
Allows the cookie banner to disappear when you scroll down the page.
Also moves the cookie banner to the top of the page improving accessibility.