### PR TITLE
(Update) Torrent Keywords

### DIFF
--- a/app/Models/Keyword.php
+++ b/app/Models/Keyword.php
@@ -18,6 +18,15 @@ use Illuminate\Database\Eloquent\Model;
 class Keyword extends Model
 {
     /**
+     * The Attributes That Are Mass Assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'name',
+    ];
+
+    /**
      * Indicates If The Model Should Be Timestamped.
      *
      * @var bool

--- a/resources/views/torrent/edit_torrent.blade.php
+++ b/resources/views/torrent/edit_torrent.blade.php
@@ -104,6 +104,13 @@
                     @endif
 
                     <div class="form-group">
+                        <label for="name">{{ __('torrent.keywords') }} (<i>{{ __('torrent.keywords-example') }}</i>)</label>
+                        <label>
+                            <input type="text" name="keywords" value="{{ $keywords->implode(', ') }}" class="form-control">
+                        </label>
+                    </div>
+
+                    <div class="form-group">
                         <label for="category_id">{{ __('torrent.category') }}</label>
                         <label>
                             <select name="category_id" class="form-control">


### PR DESCRIPTION
- make keywords editable and use upserts.
- a future PR will make keywords belong to meta/media instead of torrent directly.