### PR TITLE
(Fix) sidescrolling on fullwidth pages

### DIFF
--- a/resources/sass/pages/_home.scss
+++ b/resources/sass/pages/_home.scss
@@ -1,6 +1,5 @@
 .page__home {
     margin: 0 calc(-1 * max(0px, 10vw - 60px)); /* Inverses the magic numbers used in the main layout styles */
-    width: 100vw;
 }
 
 @media only screen and (min-width: 1600px) {

--- a/resources/sass/pages/_torrents.scss
+++ b/resources/sass/pages/_torrents.scss
@@ -1,6 +1,5 @@
 .page__torrents {
     margin: 0 calc(-1 * max(0px, 10vw - 60px)); /* Inverses the magic numbers used in the main layout styles */
-    width: 100vw;
 }
 
 @media only screen and (min-width: 1600px) {

--- a/resources/views/home/index.blade.php
+++ b/resources/views/home/index.blade.php
@@ -1,7 +1,7 @@
 @extends('layout.default')
 
 @section('content')
-    <div class="container-fluid page__home">
+    <div class="page__home">
         @include('blocks.news')
 
         @if (!auth()->user()->chat_hidden)


### PR DESCRIPTION
In browsers that have a vertical scrollbar, fullwidth pages have a horizontal scrollbar. This PR fixes this bug.

The bug is not present in browsers that don't have a vertical scrollbar, such as firefox on linux or any macos browser.