### PR TITLE
(Fix) form doesn't submit bbcode when being previewed

### DIFF
--- a/resources/views/livewire/bbcode-input.blade.php
+++ b/resources/views/livewire/bbcode-input.blade.php
@@ -190,6 +190,7 @@
             <p class="bbcode-input__preview">
                 @joypixels($contentHtml)
             </p>
+            <input type="hidden" name="{{ $name }}" wire:model.defer="contentBbcode">
         @else
             <p class="form__group">
                 <textarea


### PR DESCRIPTION
The form bbcode input is removed when bbcode is being previewed, preventing the input from being submitted if currently being previewed. A hidden input is now added on preview to prevent form invalidation from occurring.