### PR TITLE
(Fix) bonus earnings stats

### DIFF
--- a/resources/views/bonus/index.blade.php
+++ b/resources/views/bonus/index.blade.php
@@ -169,19 +169,19 @@
         <h2 class="panel__heading">{{ __('bon.your-points') }}</h2>
         <dl class="key-value">
             <dt>{{ __('bon.per-second') }}</dt>
-            <dd>{{ $total / 60 / 60 }}</dd>
+            <dd>{{ number_format($total / 60 / 60, 2) }}</dd>
             <dt>{{ __('bon.per-minute') }}</dt>
-            <dd>{{ $total / 60 }}</dd>
-            <dt>{{ __('bon.per-day') }}</dt>
-            <dd>{{ $total * 24 }}</dd>
+            <dd>{{ number_format($total / 60, 2) }}</dd>
             <dt>{{ __('bon.per-hour') }}</dt>
-            <dd>{{ $total }}</dd>
+            <dd>{{ number_format($total, 2) }}</dd>
+            <dt>{{ __('bon.per-day') }}</dt>
+            <dd>{{ number_format($total * 24, 2) }}</dd>
             <dt>{{ __('bon.per-week') }}</dt>
-            <dd>{{ $total * 24 * 7 }}</dd>
+            <dd>{{ number_format($total * 24 * 7, 2) }}</dd>
             <dt>{{ __('bon.per-month') }}</dt>
-            <dd>{{ $total * 24 * 30 }}</dd>
+            <dd>{{ number_format($total * 24 * 30, 2) }}</dd>
             <dt>{{ __('bon.per-year') }}</dt>
-            <dd>{{ $total * 365 }}</dd>
+            <dd>{{ number_format($total * 24 * 365, 2) }}</dd>
         </dl>
         <div class="panel__body">
             <a


### PR DESCRIPTION
Yearly bonus earning stats are currently incorrectly calculated. This PR fixes that.
I also reordered the earning statistics from smallest to largest.
I also rounded the stats to 2 decimal places. 