### PR TITLE
(Fix) approved torrents show different chatbox messages

### DIFF
--- a/app/Http/Controllers/Staff/ModerationController.php
+++ b/app/Http/Controllers/Staff/ModerationController.php
@@ -67,11 +67,11 @@ class ModerationController extends Controller
             // Announce To Shoutbox
             if ($anon == 0) {
                 $this->chatRepository->systemMessage(
-                    \sprintf('User [url=%s/users/', $appurl).$username.']'.$username.\sprintf('[/url] has uploaded [url=%s/torrents/', $appurl).$torrent->id.']'.$torrent->name.'[/url] grab it now! :slight_smile:'
+                    \sprintf('User [url=%s/users/', $appurl).$username.']'.$username.\sprintf('[/url] has uploaded a new '.$torrent->category->name.'. [url=%s/torrents/', $appurl).$torrent->id.']'.$torrent->name.'[/url], grab it now! :slight_smile:'
                 );
             } else {
                 $this->chatRepository->systemMessage(
-                    \sprintf('An anonymous user has uploaded [url=%s/torrents/', $appurl).$torrent->id.']'.$torrent->name.'[/url] grab it now! :slight_smile:'
+                    \sprintf('An anonymous user has uploaded a new '.$torrent->category->name.'. [url=%s/torrents/', $appurl).$torrent->id.']'.$torrent->name.'[/url], grab it now! :slight_smile:'
                 );
             }
 


### PR DESCRIPTION
There are three locations where newly uploaded torrents send out a chatbox message:
- app/Http/Controllers/API/TorrentController.php
- app/Http/Controllers/Staff/ModerationController.php
- app/Http/Controllers/TorrentController.php

The moderation controller sends a different chatbox message than the other two. This PR brings all three locations in line so that they all send the same message in the chatbox.