### PR TITLE
(Update) Order unsolved reports first

### DIFF
--- a/app/Http/Controllers/Staff/ReportController.php
+++ b/app/Http/Controllers/Staff/ReportController.php
@@ -28,7 +28,7 @@ class ReportController extends Controller
      */
     public function index(): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
     {
-        $reports = Report::latest()->paginate(25);
+        $reports = Report::orderBy('solved')->latest()->paginate(25);
 
         return \view('Staff.report.index', ['reports' => $reports]);
     }


### PR DESCRIPTION
When there are multiple pages of unsolved reports with solved reports mixed within, it's much more convenient to have unsolved reports at the top.