### PR TITLE
(Update) Whitelist possible keys in metainfo dictionary

### DIFF
--- a/app/Helpers/TorrentTools.php
+++ b/app/Helpers/TorrentTools.php
@@ -31,25 +31,37 @@ class TorrentTools
     public static function normalizeTorrent($torrentFile)
     {
         $result = Bencode::bdecode_file($torrentFile);
+
+        // Whitelisted keys
+        $result = \array_intersect_key($result, [
+            'announce'   => '',
+            'comment'    => '',
+            'created by' => '',
+            'encoding'   => '',
+            'info'       => '',
+
+        ]);
+        $result['info'] = \array_intersect_key($result['info'], [
+            'files'        => '',
+            'length'       => '',
+            'name'         => '',
+            'piece length' => '',
+            'pieces'       => '',
+            'private'      => '',
+            'source'       => '',
+        ]);
+
         // The PID will be set if an user downloads the torrent, but for
         // security purposes it's better to overwrite the user-provided
         // announce URL.
-        $announce = \config('app.url');
-        $announce .= '/announce/PID';
-        $result['announce'] = $announce;
+        $result['announce'] = \config('app.url').'/announce/PID';
         $result['info']['source'] = \config('torrent.source');
         $result['info']['private'] = 1;
-        $createdBy = \config('torrent.created_by', null);
-        $createdByAppend = \config('torrent.created_by_append', false);
-        if ($createdBy !== null) {
-            if ($createdByAppend && \array_key_exists('created by', $result)) {
-                $c = $result['created by'];
-                $c = \trim($c, '. ');
-                $c .= '. '.$createdBy;
-                $createdBy = $c;
-            }
 
-            $result['created by'] = $createdBy;
+        if (\config('torrent.created_by_append') && \array_key_exists('created by', $result)) {
+            $result['created by'] = \trim($result['created by'], '. ').'. '.\config('torrent.created_by', '');
+        } else {
+            $result['created by'] = \config('torrent.created_by', '');
         }
 
         $comment = \config('torrent.comment', null);


### PR DESCRIPTION
Only certain keys should be included in the torrent. Some keys might be removed from the info dictionary, which will change the infohash and the user will be required to redownload the created torrent from the site instead of using their own initial torrent. However, any modern client doesn't use any keys other than what's whitelisted and will have no issue if they remember to include the tracker's configurable source key when creating the torrent.