### PR TITLE
(Add) Link to torrent in torrent comment

### DIFF
--- a/app/Http/Controllers/TorrentDownloadController.php
+++ b/app/Http/Controllers/TorrentDownloadController.php
@@ -80,8 +80,12 @@ class TorrentDownloadController extends Controller
         if ($request->user() || ($rsskey && $user)) {
             // Set the announce key and add the user passkey
             $dict['announce'] = \route('announce', ['passkey' => $user->passkey]);
-            // Remove Other announce url
-            unset($dict['announce-list']);
+            // Set link to torrent as the comment
+            if (config('torrent.comment')) {
+                $dict['comment'] = \config('torrent.comment').'. '.\route('torrent', ['id' => $id]);
+            } else {
+                $dict['comment'] = \route('torrent', ['id' => $id]);
+            }
         } else {
             return \to_route('login');
         }


### PR DESCRIPTION
Also remove the `announce-list` key since that's already done when the torrent is normalized.

If the comment in the config is falsey, then it replaces the comment entirely with the link, otherwise it appends the link to the comment.