### PR TITLE
(Update) Restrict users from deleting forum topics

### DIFF
--- a/app/Http/Controllers/TopicController.php
+++ b/app/Http/Controllers/TopicController.php
@@ -289,7 +289,7 @@ class TopicController extends Controller
         $user = $request->user();
         $topic = Topic::findOrFail($id);
 
-        \abort_unless($user->group->is_modo || $user->id === $topic->first_post_user_id, 403);
+        \abort_unless($user->group->is_modo || ($user->id === $topic->first_post_user_id && $topic->num_post <= 1 && $topic->created_at->greaterThan(now()->subDay())), 403);
         $posts = $topic->posts();
         $posts->delete();
         $topic->delete();


### PR DESCRIPTION
There are times when a user has asked a question, and another user has spent their time responding but then the original user decides to delete the topic and all that information can no longer help people in the future. This PR fixes that by not allowing the user to delete their own topic if there are replies to it or if it's older than 24 hours old.