### PR TITLE
(update) order rss feed torrents by bumped date

### DIFF
--- a/app/Http/Controllers/RssController.php
+++ b/app/Http/Controllers/RssController.php
@@ -182,7 +182,7 @@ class RssController extends Controller
             ->when($search->alive !== null, fn ($query) => $query->alive())
             ->when($search->dying !== null, fn ($query) => $query->dying())
             ->when($search->dead !== null, fn ($query) => $query->dead())
-            ->latest()
+            ->orderByDesc('bumped_at')
             ->take(50)
             ->get();
 


### PR DESCRIPTION
RSS feeds should ideally be sorted by the bumped date, not created date. All the other torrent index pages (api, torrent search, torrent card search, torrent group search) already sort like this.