### PR TITLE
(Fix) mentioning users in anonymous comments notifiying recipient of s…

### DIFF
--- a/app/Http/Controllers/CommentController.php
+++ b/app/Http/Controllers/CommentController.php
@@ -122,7 +122,7 @@ class CommentController extends Controller
                         $comment
                     );
             } else {
-                $sender = $comment->anon !== 0 ? $user->username : 'Anonymous';
+                $sender = $comment->anon ? 'Anonymous' : $user->username;
                 $this->taggedUserRepository->messageTaggedCommentUsers(
                         'collection',
                         $request->input('content'),
@@ -220,7 +220,7 @@ class CommentController extends Controller
                     $comment
                 );
             } else {
-                $sender = $comment->anon !== 0 ? $user->username : 'Anonymous';
+                $sender = $comment->anon ? 'Anonymous' : $user->username;
                 $this->taggedUserRepository->messageTaggedCommentUsers(
                     'article',
                     $request->input('content'),
@@ -318,7 +318,7 @@ class CommentController extends Controller
                     $comment
                 );
             } else {
-                $sender = $comment->anon !== 0 ? $user->username : 'Anonymous';
+                $sender = $comment->anon ? 'Anonymous' : $user->username;
                 $this->taggedUserRepository->messageTaggedCommentUsers(
                     'playlist',
                     $request->input('content'),
@@ -421,7 +421,7 @@ class CommentController extends Controller
                     $comment
                 );
             } else {
-                $sender = $comment->anon !== 0 ? $user->username : 'Anonymous';
+                $sender = $comment->anon ? 'Anonymous' : $user->username;
                 $this->taggedUserRepository->messageTaggedCommentUsers(
                     'torrent',
                     $request->input('content'),
@@ -524,7 +524,7 @@ class CommentController extends Controller
                     $comment
                 );
             } else {
-                $sender = $comment->anon !== 0 ? $user->username : 'Anonymous';
+                $sender = $comment->anon ? 'Anonymous' : $user->username;
                 $this->taggedUserRepository->messageTaggedCommentUsers(
                     'request',
                     $request->input('content'),


### PR DESCRIPTION
…ender username.

If a user writes a comment that includes a mention (@ username), and ticks the "anonymous" tickbox, then the notification the receiver receives says the true username of the mentioner.