### PR TITLE
(Update) Automatically correct imdb link

### DIFF
--- a/resources/views/torrent/partials/movie_meta.blade.php
+++ b/resources/views/torrent/partials/movie_meta.blade.php
@@ -67,8 +67,8 @@
                 <br>
                 @if ($torrent->imdb != 0 && $torrent->imdb != null)
                     <span class="badge-user text-bold">
-                    <a href="https://www.imdb.com/title/tt{{ $torrent->imdb }}" title="IMDB" target="_blank">
-                        <i class="{{ config('other.font-awesome') }} fa-film"></i> IMDB: {{ $torrent->imdb }}
+                    <a href="https://www.imdb.com/title/tt{{ \str_pad((int) $torrent->imdb, \max(\strlen((int) $torrent->imdb), 7), '0', STR_PAD_LEFT) }}" title="IMDB" target="_blank">
+                        <i class="{{ config('other.font-awesome') }} fa-film"></i> IMDB: {{ \str_pad((int) $torrent->imdb, \max(\strlen((int) $torrent->imdb), 7), '0', STR_PAD_LEFT) }}
                     </a>
                 </span>
                 @endif

--- a/resources/views/torrent/partials/tv_meta.blade.php
+++ b/resources/views/torrent/partials/tv_meta.blade.php
@@ -79,8 +79,8 @@
                 <br>
                 @if ($torrent->imdb != 0 && $torrent->imdb != null)
                     <span class="badge-user text-bold">
-                    <a href="https://www.imdb.com/title/tt{{ $torrent->imdb }}" title="IMDB" target="_blank">
-                        <i class="{{ config('other.font-awesome') }} fa-film"></i> IMDB: {{ $torrent->imdb }}
+                    <a href="https://www.imdb.com/title/tt{{ \str_pad((int) $torrent->imdb, \max(\strlen((int) $torrent->imdb), 7), '0', STR_PAD_LEFT) }}" title="IMDB" target="_blank">
+                        <i class="{{ config('other.font-awesome') }} fa-film"></i> IMDB: {{ \str_pad((int) $torrent->imdb, \max(\strlen((int) $torrent->imdb), 7), '0', STR_PAD_LEFT) }}
                     </a>
                 </span>
                 @endif


### PR DESCRIPTION
IMDb requires their URLs to have at least 7 digits (zero padded if necessary) and no zero padding beyond 7 digits.

Ideally, IMDb IDs (as well as the other IDs) should be stored as an int, and be simply zero padded on demand.