### PR TITLE
(Fix) Dedupe keyword parsing

### DIFF
--- a/app/Helpers/TorrentTools.php
+++ b/app/Helpers/TorrentTools.php
@@ -241,6 +241,6 @@ class TorrentTools
      */
     public static function parseKeywords($text): array
     {
-        return \array_filter(\array_map('trim', explode(',', $text)));
+        return \array_filter(\array_unique(\array_map('trim', explode(',', $text))));
     }
 }


### PR DESCRIPTION
The API relies on this function to parse keywords. Deduping the keywords will help prevent errors if multiple identical keywords are passed to the api.