### PR TITLE
(Fix) 4-digit mediainfo filesizes

### DIFF
--- a/app/Helpers/MediaInfo.php
+++ b/app/Helpers/MediaInfo.php
@@ -320,8 +320,8 @@ class MediaInfo
 
     private function parseFileSize($string): float
     {
-        $number = (float) $string;
-        \preg_match('#[KMGTPEZ]#i', $string, $size);
+        $number = (float) \str_replace(' ', '', $string);
+        \preg_match('/[KMGTPEZ]/i', $string, $size);
         if (! empty($size[0])) {
             $number = $this->computerSize($number, $size[0].'b');
         }


### PR DESCRIPTION
When casting to a float, everything after the space disappears. To solve this, remove spaces before casting. The letters still end up being removed from the casting anyways.

This fixes cases where when mediainfo returns;
```
File size                                : 1 023 MiB
```
Before, `1 MiB` was returned. Now, `1023 MiB` is returned.