### PR TITLE
(Fix) Filtering active torrents by client

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -1470,36 +1470,4 @@ class UserController extends Controller
 
         return \redirect()->back()->withSuccess('Peers were flushed successfully!');
     }
-
-    /**
-     * Get A Users Active Table by IP and Port.
-     */
-    public function activeByClient(Request $request, string $username, string $ip, string $port): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
-    {
-        $user = User::where('username', '=', $username)->firstOrFail();
-
-        \abort_unless($request->user()->group->is_modo || $request->user()->id == $user->id, 403);
-
-        $hisUpl = History::where('user_id', '=', $user->id)->sum('actual_uploaded');
-        $hisUplCre = History::where('user_id', '=', $user->id)->sum('uploaded');
-        $hisDownl = History::where('user_id', '=', $user->id)->sum('actual_downloaded');
-        $hisDownlCre = History::where('user_id', '=', $user->id)->sum('downloaded');
-
-        $active = Peer::with(['torrent' => function ($query) {
-            $query->withAnyStatus();
-        }])->where('user_id', '=', $user->id)
-            ->where('ip', '=', $ip)
-            ->where('port', '=', $port)
-            ->distinct('torrent_id')
-            ->paginate(50);
-
-        return \view('user.private.active', ['user' => $user,
-            'route'                                 => 'active',
-            'active'                                => $active,
-            'his_upl'                               => $hisUpl,
-            'his_upl_cre'                           => $hisUplCre,
-            'his_downl'                             => $hisDownl,
-            'his_downl_cre'                         => $hisDownlCre,
-        ]);
-    }
 }

--- a/app/Http/Livewire/UserActive.php
+++ b/app/Http/Livewire/UserActive.php
@@ -28,6 +28,12 @@ class UserActive extends Component
 
     public string $name = '';
 
+    public string $ip = '';
+
+    public string $port = '';
+
+    public string $client = '';
+
     public string $seeding = 'any';
 
     public string $sortField = 'created_at';
@@ -39,6 +45,9 @@ class UserActive extends Component
     protected $queryString = [
         'perPage'           => ['except' => 50],
         'name'              => ['except' => ''],
+        'ip'                => ['except' => ''],
+        'port'              => ['except' => ''],
+        'client'            => ['excpet' => ''],
         'seeding'           => ['except' => 'any'],
         'sortField'         => ['except' => 'created_at'],
         'sortDirection'     => ['except' => 'desc'],
@@ -93,6 +102,9 @@ class UserActive extends Component
             ->when($this->name, fn ($query) => $query
                 ->where('name', 'like', '%'.str_replace(' ', '%', $this->name).'%')
             )
+            ->when($this->ip !== '', fn ($query) => $query->where('ip', '=', $this->ip))
+            ->when($this->port !== '', fn ($query) => $query->where('port', '=', $this->port))
+            ->when($this->client !== '', fn ($query) => $query->where('agent', '=', $this->client))
             ->when($this->seeding === 'include', fn ($query) => $query->where('seeder', '=', 1))
             ->when($this->seeding === 'exclude', fn ($query) => $query->where('seeder', '=', 0))
             ->orderBy($this->sortField, $this->sortDirection)

--- a/resources/views/user/profile.blade.php
+++ b/resources/views/user/profile.blade.php
@@ -584,7 +584,7 @@
                                         <td>{{ $p->created_at ? $p->created_at->diffForHumans() : 'N/A' }}</td>
                                         <td>{{ $p->updated_at ? $p->updated_at->diffForHumans() : 'N/A' }}</td>
                                         <td>
-                                            <a href="{{ route('user_active_by_client', ['username' => $user->username, 'ip' => $p->ip, 'port' => $p->port]) }}"
+                                            <a href="{{ route('user_active', ['username' => $user->username, 'ip' => $p->ip, 'port' => $p->port, 'client' => $p->agent]) }}"
                                                itemprop="url" class="l-breadcrumb-item-link">
                                                 <span itemprop="title"
                                                       class="l-breadcrumb-item-link-title">{{ $count }}</span>

--- a/routes/web.php
+++ b/routes/web.php
@@ -281,7 +281,6 @@ Route::group(['middleware' => 'language'], function () {
             Route::get('/{username}/resurrections', [App\Http\Controllers\UserController::class, 'resurrections'])->name('user_resurrections');
             Route::get('/{username}/requested', [App\Http\Controllers\UserController::class, 'requested'])->name('user_requested');
             Route::get('/{username}/active', [App\Http\Controllers\UserController::class, 'active'])->name('user_active');
-            Route::get('/{username}/activeByClient/{ip}/{port}', [App\Http\Controllers\UserController::class, 'activeByClient'])->name('user_active_by_client');
             Route::get('/{username}/torrents', [App\Http\Controllers\UserController::class, 'torrents'])->name('user_torrents');
             Route::get('/{username}/uploads', [App\Http\Controllers\UserController::class, 'uploads'])->name('user_uploads');
             Route::get('/{username}/topics', [App\Http\Controllers\UserController::class, 'topics'])->name('user_topics');


### PR DESCRIPTION
Filtering active torrents by client was unintentionally broken with the earlier refactor to livewire (#2228). This feature is accessed from the user profile page by clicking on the torrent count of that client.

This PR adds back its functionality by integrated it into the livewire page. The unused routes and controller methods have also been removed.