### PR TITLE
(Fix) Peer progress bar

### DIFF
--- a/app/Http/Controllers/TorrentPeerController.php
+++ b/app/Http/Controllers/TorrentPeerController.php
@@ -24,7 +24,21 @@ class TorrentPeerController extends Controller
     public function index(int $id): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
     {
         $torrent = Torrent::withAnyStatus()->findOrFail($id);
-        $peers = Peer::with(['user'])->where('torrent_id', '=', $id)->latest('seeder')->get();
+        $peers = Peer::query()
+            ->with(['user'])
+            ->where('torrent_id', '=', $id)
+            ->latest('seeder')
+            ->get()
+            ->map(function ($peer) use ($torrent) {
+                $progress = 100 * (1 - $peer->left / $torrent->size);
+                $peer['progress'] = match (true) {
+                    0 < $progress && $progress < 1    => 1,
+                    99 < $progress && $progress < 100 => 99,
+                    default                           => round($progress),
+                };
+
+                return $peer;
+            });
 
         return \view('torrent.peers', ['torrent' => $torrent, 'peers' => $peers]);
     }

--- a/resources/views/torrent/peers.blade.php
+++ b/resources/views/torrent/peers.blade.php
@@ -83,29 +83,17 @@
                                                 {{ $p->user->username }}</span></a>
                                 </td>
                             @endif
-                            @if ($p->seeder == 0)
-                                <td>
-                                    <div class="progress">
-                                        <div class="progress-bar progress-bar-striped active" role="progressbar"
-                                             aria-valuenow="{{ ($p->downloaded / $torrent->size) * 100 }}"
-                                             aria-valuemin="0"
-                                             aria-valuemax="100"
-                                             style="width: {{ ($p->downloaded / $torrent->size) * 100 }}%;">
-                                            {{ round(($p->downloaded / $torrent->size) * 100) }}%
-                                        </div>
+                            <td>
+                                <div class="progress">
+                                    <div class="progress-bar progress-bar-striped active" role="progressbar"
+                                            aria-valuenow="{{ $p->progress }}"
+                                            aria-valuemin="0"
+                                            aria-valuemax="100"
+                                            style="width: {{ $p->progress }}%;">
+                                        {{ $p->progress }}%
                                     </div>
-                                </td>
-                            @elseif ($p->seeder == 1)
-                                <td>
-                                    <div class="progress">
-                                        <div class="progress-bar progress-bar-striped active" role="progressbar"
-                                             aria-valuenow="100" aria-valuemin="0" aria-valuemax="100"
-                                             style="width: 100%;">
-                                            100%
-                                        </div>
-                                    </div>
-                                </td>
-                            @endif
+                                </div>
+                            </td>
                             <td>
                                     <span
                                             class="badge-extra text-green text-bold">{{ \App\Helpers\StringHelper::formatBytes($p->uploaded, 2) }}</span>


### PR DESCRIPTION
Currently, the progress bar on the peers percentage complete page uses an algorithm that will provide the wrong value if a user resets their torrent session (i.e. restarts their client). Calculating the progress based on `left` is more accurate in cases like these.

Progress is also rounded differently at either end of 0 and 100 so that a user who downloads 1 byte is considered at 1% and a user who has 1 byte remaining is considered at 99%. This helps in cases where a peer is missing a single piece and they won't show as having (a rounded) 100%.