### PR TITLE
(Update) Optimize announce history query

### DIFF
--- a/app/Jobs/ProcessAnnounce.php
+++ b/app/Jobs/ProcessAnnounce.php
@@ -82,6 +82,7 @@ class ProcessAnnounce implements ShouldQueue, ShouldBeUnique
 
         // Get history information
         $history = History::query()
+            ->where('created_at', '>', $this->user->created_at)
             ->where('torrent_id', '=', $this->torrent->id)
             ->where('user_id', '=', $this->user->id)
             ->first();


### PR DESCRIPTION
There shouldn't ever be a case where a user has history created before their account was created. Filtering out impossible histories before filtering for the torrent id and user id helps speed up queries on sites with massive history tables.