### PR TITLE
(Fix) quick search returning titles without torrents

### DIFF
--- a/app/Http/Livewire/QuickSearchDropdown.php
+++ b/app/Http/Livewire/QuickSearchDropdown.php
@@ -21,6 +21,7 @@ class QuickSearchDropdown extends Component
                 ->select(['id', 'poster', 'title', 'release_date'])
                 ->selectRaw("concat(title, ' ', release_date) as title_and_year")
                 ->having('title_and_year', 'LIKE', $search)
+                ->has('torrents')
                 ->oldest('title')
                 ->take(10)
                 ->get(),
@@ -28,6 +29,7 @@ class QuickSearchDropdown extends Component
                 ->select(['id', 'poster', 'name', 'first_air_date'])
                 ->selectRaw("concat(name, ' ', first_air_date) as title_and_year")
                 ->having('title_and_year', 'LIKE', $search)
+                ->has('torrents')
                 ->oldest('name')
                 ->take(10)
                 ->get(),


### PR DESCRIPTION
Metadata is scraped when a new torrent or request is made. Quick search searches through this data. There are two cases where a title is returned in quick search but should not be returned:

- All of its torrents have been deleted
- Only a request is created, but a torrent was never uploaded.

Constraining the search to only include titles that have a torrent relationship fixes receiving 404s when selecting a title without torrents in the quick search.