### PR TITLE
(Fix) Button wrapping

### DIFF
--- a/resources/sass/components/form/button.scss
+++ b/resources/sass/components/form/button.scss
@@ -8,6 +8,9 @@
     filter: brightness(1);
     transition: filter 300ms;
     cursor: pointer;
+    display: flex;
+    align-items: center;
+    gap: 0.5ch;
 
     &:hover {
         filter: brightness(1.1);


### PR DESCRIPTION
When a button includes an icon, it wraps awkwardly. This PR fixes the wrapping by using flex.