### PR TITLE
(Add) Backwards compatible modals

### DIFF
--- a/resources/sass/components/_data-table.scss
+++ b/resources/sass/components/_data-table.scss
@@ -63,15 +63,14 @@
 .data-table__actions {
     display: flex;
     justify-content: end;
+    align-items: center;
     gap: 18px;
     margin: 0;
     padding: 0;
     list-style-type: none;
 }
 
-.data-table__action {
-    display: contents;
-
+.data-table__action > :not(.dialog) {
     @media (hover: hover) {
         visibility: hidden;
     }

--- a/resources/sass/components/_dialog.scss
+++ b/resources/sass/components/_dialog.scss
@@ -8,6 +8,9 @@
     overflow-y: auto;
     width: 500px;
     max-width: calc(100% - 12px);
+    position: absolute;
+    left: calc(50% - min(500px / 2, (100% - 12px) / 2));
+    right: calc(50% - min(500px / 2, (100% - 12px) / 2));
 }
 
 .dialog::backdrop {

--- a/resources/sass/components/_panel.scss
+++ b/resources/sass/components/_panel.scss
@@ -12,7 +12,6 @@
     background-color: var(--panel-bg);
     box-shadow: var(--panel-box-shadow);
     border-radius: var(--panel-border-radius);
-    contain: content;
     height: fit-content;
     break-inside: avoid;
 }

--- a/resources/views/Staff/application/show.blade.php
+++ b/resources/views/Staff/application/show.blade.php
@@ -100,14 +100,14 @@
         @else
             <h2 class="panel__heading">{{ __('common.action') }}</h2>
             <div class="panel__body">
-                    <div x-data>
+                    <div x-data="{ open: false }">
                         <p class="form__group form__group--horizontal">
-                            <button class="form__button form__button--filled" x-on:click.stop="$refs.dialog.showModal()">
+                            <button class="form__button form__button--filled" x-on:click.stop="open = true; $refs.dialog.showModal();">
                                 <i class="{{ config('other.font-awesome') }} fa-check"></i>
                                 {{ __('request.approve') }}
                             </button>
                         </p>
-                        <dialog class="dialog" x-ref="dialog">
+                        <dialog class="dialog" x-ref="dialog" x-show="open" x-cloak>
                             <h3 class="dialog__heading">
                                 {{ __('request.approve') }}
                                 {{ __('common.this') }}
@@ -117,7 +117,7 @@
                                 class="dialog__form"
                                 method="POST"
                                 action="{{ route('staff.applications.approve', ['id' => $application->id]) }}"
-                                x-on:click.outside="$refs.dialog.close()"
+                                x-on:click.outside="open = false; $refs.dialog.close();"
                             >
                                 @csrf
                                 <input
@@ -134,21 +134,21 @@
                                     <button class="form__button form__button--filled">
                                         {{ __('request.approve') }}
                                     </button>
-                                    <button x-on:click.prevent="$refs.dialog.close()" class="form__button form__button--outlined">
+                                    <button x-on:click.prevent="open = false; $refs.dialog.close();" class="form__button form__button--outlined">
                                         {{ __('common.cancel') }}
                                     </button>
                                 </p>
                             </form>
                         </dialog>
                     </div>
-                    <div x-data>
+                    <div x-data="{ open: false }">
                         <p class="form__group form__group--horizontal">
-                            <button class="form__button form__button--filled" x-on:click.stop="$refs.dialog.showModal()">
+                            <button class="form__button form__button--filled" x-on:click.stop="open = true; $refs.dialog.showModal();">
                                 <i class="{{ config('other.font-awesome') }} fa-times"></i>
                                 {{ __('request.reject') }}
                             </button>
                         </p>
-                        <dialog class="dialog" x-ref="dialog">
+                        <dialog class="dialog" x-ref="dialog" x-show="open" x-cloak>
                             <h3 class="dialog__heading">
                                 {{ __('request.reject') }}
                                 {{ __('common.this') }}
@@ -158,7 +158,7 @@
                                 class="dialog__form"
                                 method="POST"
                                 action="{{ route('staff.applications.reject', ['id' => $application->id]) }}"
-                                x-on:click.outside="$refs.dialog.close()"
+                                x-on:click.outside="open = false; $refs.dialog.close();"
                             >
                                 @csrf
                                 <input
@@ -180,7 +180,7 @@
                                     <button class="form__button form__button--filled">
                                         {{ __('request.reject') }}
                                     </button>
-                                    <button x-on:click.prevent="$refs.dialog.close()" class="form__button form__button--outlined">
+                                    <button x-on:click.prevent="open = false; $refs.dialog.close();" class="form__button form__button--outlined">
                                         {{ __('common.cancel') }}
                                     </button>
                                 </p>

--- a/resources/views/Staff/moderation/partials/_delete_dialog.blade.php
+++ b/resources/views/Staff/moderation/partials/_delete_dialog.blade.php
@@ -1,9 +1,9 @@
-<li class="data-table__action" x-data>
-    <button class="form__button form__button--filled" x-on:click.stop="$refs.dialog.showModal()">
+<li class="data-table__action" x-data="{ open: false }">
+    <button class="form__button form__button--filled" x-on:click.stop="open = true; $refs.dialog.showModal();">
         <i class="{{ config('other.font-awesome') }} fa-thumbs-down"></i>
         {{ __('common.delete') }}
     </button>
-    <dialog class="dialog" x-ref="dialog">
+    <dialog class="dialog" x-ref="dialog" x-show="open" x-cloak>
         <h4 class="dialog__heading">
             {{ __('common.delete') }} {{ __('torrent.torrent') }}: {{ $torrent->name }}
         </h4>
@@ -11,7 +11,7 @@
             class="dialog__form"
             method="POST"
             action="{{ route('delete') }}"
-            x-on:click.outside="$refs.dialog.close()"
+            x-on:click.outside="open = false; $refs.dialog.close();"
         >
             @csrf
             <p class="form__group">
@@ -27,7 +27,7 @@
                 <button class="form__button form__button--filled">
                     {{ __('common.delete') }}
                 </button>
-                <button x-on:click.prevent="$refs.dialog.close()" class="form__button form__button--outlined">
+                <button x-on:click.prevent="open = false; $refs.dialog.close();" class="form__button form__button--outlined">
                     {{ __('common.cancel') }}
                 </button>
             </p>

--- a/resources/views/Staff/moderation/partials/_postpone_dialog.blade.php
+++ b/resources/views/Staff/moderation/partials/_postpone_dialog.blade.php
@@ -1,9 +1,9 @@
-<li class="data-table__action" x-data>
-    <button class="form__button form__button--filled" x-on:click.stop="$refs.dialog.showModal()">
+<li class="data-table__action" x-data="{ open: false }">
+    <button class="form__button form__button--filled" x-on:click.stop="open = true; $refs.dialog.showModal();">
         <i class="{{ config('other.font-awesome') }} fa-pause"></i>
         {{ __('common.moderation-postpone') }}
     </button>
-    <dialog class="dialog" x-ref="dialog">
+    <dialog class="dialog" x-ref="dialog" x-show="open" x-cloak>
         <h4 class="dialog__heading">
             {{ __('common.moderation-postpone') }} {{ __('torrent.torrent') }}: {{ $torrent->name }}
         </h4>
@@ -11,7 +11,7 @@
             class="dialog__form"
             method="POST"
             action="{{ route('staff.moderation.postpone') }}"
-            x-on:click.outside="$refs.dialog.close()"
+            x-on:click.outside="open = false; $refs.dialog.close();"
         >
             @csrf
             <input type="hidden" name="type" value="{{ __('torrent.torrent') }}">
@@ -25,7 +25,7 @@
                 <button class="form__button form__button--filled">
                     {{ __('common.moderation-postpone') }}
                 </button>
-                <button class="form__button form__button--outlined" x-on:click.prevent="$refs.dialog.close()">
+                <button class="form__button form__button--outlined" x-on:click.prevent="open = false; $refs.dialog.close()">
                     {{ __('common.cancel') }}
                 </button>
             </p>

--- a/resources/views/Staff/moderation/partials/_reject_dialog.blade.php
+++ b/resources/views/Staff/moderation/partials/_reject_dialog.blade.php
@@ -1,9 +1,9 @@
-<li class="data-table__action" x-data>
-    <button class="form__button form__button--filled" x-on:click.stop="$refs.dialog.showModal()">
+<li class="data-table__action" x-data="{ open: false }">
+    <button class="form__button form__button--filled" x-on:click.stop="open = true; $refs.dialog.showModal();">
         <i class="{{ config('other.font-awesome') }} fa-thumbs-down"></i>
         {{ __('common.moderation-reject') }}
     </button>
-    <dialog class="dialog" x-ref="dialog">
+    <dialog class="dialog" x-ref="dialog" x-show="open" x-cloak>
         <h3 class="dialog__heading">
             {{ __('common.moderation-reject') }} {{ __('torrent.torrent') }}: {{ $torrent->name }}
         </h3>
@@ -11,7 +11,7 @@
             class="dialog__form"
             method="POST"
             action="{{ route("staff.moderation.reject") }}"
-            x-on:click.outside="$refs.dialog.close()"
+            x-on:click.outside="open = false; $refs.dialog.close();"
         >
             @csrf
             <input id="type" type="hidden" name="type" value="{{ __('torrent.torrent') }}">
@@ -25,7 +25,7 @@
                 <button class="form__button form__button--filled">
                     {{ __('common.moderation-reject') }}
                 </button>
-                <button x-on:click.prevent="$refs.dialog.close()" class="form__button form__button--outlined">
+                <button x-on:click.prevent="open = false; $refs.dialog.close();" class="form__button form__button--outlined">
                     {{ __('common.cancel') }}
                 </button>
             </p>


### PR DESCRIPTION
The `<dialog>` element currently only has a caniuse of 91%. It's probably a good idea to make them a bit more compatible with older browsers until there exists better support.