### PR TITLE
(Add) Distributor views

### DIFF
--- a/app/Http/Controllers/Staff/DistributorController.php
+++ b/app/Http/Controllers/Staff/DistributorController.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * NOTICE OF LICENSE.
+ *
+ * UNIT3D Community Edition is open-sourced software licensed under the GNU Affero General Public License v3.0
+ * The details is bundled with this project in the file LICENSE.txt.
+ *
+ * @project    UNIT3D Community Edition
+ *
+ * @author     Roardom <roardom@protonmail.com>
+ * @license    https://www.gnu.org/licenses/agpl-3.0.en.html/ GNU Affero General Public License v3.0
+ */
+
+namespace App\Http\Controllers\Staff;
+
+use App\Http\Controllers\Controller;
+use App\Models\Distributor;
+use Illuminate\Http\Request;
+use Illuminate\Support\Str;
+use Illuminate\Validation\Rule;
+
+class DistributorController extends Controller
+{
+    /**
+     * Display All Distributors.
+     */
+    public function index(): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
+    {
+        $distributors = Distributor::all()->sortBy('position');
+
+        return \view('Staff.distributor.index', ['distributors' => $distributors]);
+    }
+
+    /**
+     * Show Distributor Create Form.
+     */
+    public function create(): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
+    {
+        return \view('Staff.distributor.create');
+    }
+
+    /**
+     * Store A New Distributor.
+     */
+    public function store(Request $request): \Illuminate\Http\RedirectResponse
+    {
+        $distributor = new Distributor();
+        $distributor->name = $request->input('name');
+        $distributor->slug = Str::slug($distributor->name);
+        $distributor->position = $request->input('position');
+
+        $v = \validator($distributor->toArray(), [
+            'name'     => 'required|unique:distributors,name',
+            'slug'     => 'required',
+            'position' => 'required',
+        ]);
+
+        if ($v->fails()) {
+            return \to_route('staff.distributors.index')
+                ->withErrors($v->errors());
+        }
+
+        $distributor->save();
+
+        return \to_route('staff.distributors.index')
+                ->withSuccess('Distributor Successfully Added');
+    }
+
+    /**
+     * Distributor Edit Form.
+     */
+    public function edit(int $id): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
+    {
+        $distributor = Distributor::findOrFail($id);
+
+        return \view('Staff.distributor.edit', ['distributor' => $distributor]);
+    }
+
+    /**
+     * Edit A Distributor.
+     */
+    public function update(Request $request, int $id): \Illuminate\Http\RedirectResponse
+    {
+        $distributor = Distributor::findOrFail($id);
+        $distributor->name = $request->input('name');
+        $distributor->slug = Str::slug($distributor->name);
+        $distributor->position = $request->input('position');
+
+        $v = \validator($distributor->toArray(), [
+            'name'     => 'required',
+            'slug'     => 'required',
+            'position' => 'required',
+        ]);
+
+        if ($v->fails()) {
+            return \to_route('staff.distributors.index')
+                ->withErrors($v->errors());
+        }
+
+        $distributor->save();
+
+        return \to_route('staff.distributors.index')
+                ->withSuccess('Distributor Successfully Modified');
+    }
+
+    /**
+     * Delete Edit Form.
+     */
+    public function delete(int $id): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
+    {
+        $distributors = Distributor::all()->sortBy('position');
+        $distributor = Distributor::findOrFail($id);
+
+        return \view('Staff.distributor.delete', ['distributors' => $distributors, 'distributor' => $distributor]);
+    }
+
+    /**
+     * Destroy A Distributor.
+     *
+     * @throws \Exception
+     */
+    public function destroy(Request $request, int $id): \Illuminate\Http\RedirectResponse
+    {
+        $distributor = Distributor::findOrFail($id);
+
+        $validated = $request->validate([
+            'distributor_id' => [
+                'required',
+                'exists:distributors,id',
+                Rule::notIn([$distributor->id]),
+            ],
+        ]);
+        $distributor->torrents()->update($validated);
+        $distributor->delete();
+
+        return \to_route('staff.distributors.index')
+            ->withSuccess('Distributor Successfully Deleted');
+    }
+}

--- a/app/Http/Controllers/Staff/RegionController.php
+++ b/app/Http/Controllers/Staff/RegionController.php
@@ -87,7 +87,7 @@ class RegionController extends Controller
         $region->position = $request->input('position');
 
         $v = \validator($region->toArray(), [
-            'name'     => 'required|unique:regions,name',
+            'name'     => 'required',
             'slug'     => 'required',
             'position' => 'required',
         ]);

--- a/resources/views/Staff/dashboard/index.blade.php
+++ b/resources/views/Staff/dashboard/index.blade.php
@@ -171,6 +171,12 @@
                     </a>
                 </p>
                 <p class="form__group form__group--horizontal">
+                    <a class="form__button form__button--text" href="{{ route('staff.distributors.index') }}">
+                        <i class="{{ config('other.font-awesome') }} fa-columns"></i>
+                        Torrent Distributors
+                    </a>
+                </p>
+                <p class="form__group form__group--horizontal">
                     <a class="form__button form__button--text" href="{{ route('staff.rss.index') }}">
                         <i class="{{ config('other.font-awesome') }} fa-rss"></i>
                         {{ __('staff.rss') }}

--- a/resources/views/Staff/distributor/create.blade.php
+++ b/resources/views/Staff/distributor/create.blade.php
@@ -1,0 +1,65 @@
+@extends('layout.default')
+
+@section('breadcrumbs')
+    <li class="breadcrumbV2">
+        <a href="{{ route('staff.dashboard.index') }}" class="breadcrumb__link">
+            {{ __('staff.staff-dashboard') }}
+        </a>
+    </li>
+    <li class="breadcrumbV2">
+        <a href="{{ route('staff.distributors.index') }}" class="breadcrumb__link">
+            Torrent Distributors
+        </a>
+    </li>
+    <li class="breadcrumb--active">
+        {{ __('common.new-adj') }}
+    </li>
+@endsection
+
+@section('page', 'page__distributor--create')
+
+@section('main')
+    <section class="panelV2">
+        <h2 class="panel__heading">Add A Torrent Distributor</h2>
+        <div class="panel__body">
+            <form
+                class="form"
+                method="POST"
+                action="{{ route('staff.distributors.store') }}"
+            >
+                @csrf
+                <p class="form__group">
+                    <input
+                        id="name"
+                        class="form__text"
+                        name="name"
+                        required
+                        type="text"
+                    >
+                    <label class="form__label form__label--floating" for="name">
+                        {{ __('common.name') }}
+                    </label>
+                </p>
+                <p class="form__group">
+                    <input
+                        id="position"
+                        class="form__text"
+                        inputmode="numeric"
+                        name="position"
+                        pattern="[0-9]*"
+                        type="text"
+                        required
+                    >
+                    <label class="form__label form__label--floating" for="name">
+                        {{ __('common.position') }}
+                    </label>
+                </p>
+                <p class="form__group">
+                    <button class="form__button form__button--filled">
+                        {{ __('common.add') }}
+                    </button>
+                </p>
+            </form>
+        </div>
+    </section>
+@endsection

--- a/resources/views/Staff/distributor/delete.blade.php
+++ b/resources/views/Staff/distributor/delete.blade.php
@@ -1,0 +1,82 @@
+@extends('layout.default')
+
+@section('breadcrumbs')
+    <li class="breadcrumbV2">
+        <a href="{{ route('staff.dashboard.index') }}" class="breadcrumb__link">
+            {{ __('staff.staff-dashboard') }}
+        </a>
+    </li>
+    <li class="breadcrumbV2">
+        <a href="{{ route('staff.distributors.index') }}" class="breadcrumb__link">
+            Torrent Distributors
+        </a>
+    </li>
+    <li class="breadcrumbV2">
+        {{ $distributor->name }}
+    </li>
+    <li class="breadcrumb--active">
+        {{ __('common.delete') }}
+    </li>
+@endsection
+
+@section('page', 'page__distributor--delete')
+
+@section('main')
+    <section class="panelV2">
+        <h2 class="panel__heading">
+            {{ __('common.delete') }} Torrent Distributor: {{ $distributor->name }}
+        </h2>
+        <div class="panel__body">
+            <form
+                class="form"
+                method="POST"
+                action="{{ route('staff.distributors.destroy', ['id' => $distributor->id]) }}"
+                x-data
+            >
+                @csrf
+                @method('DELETE')
+                <p class="form__group">
+                    An existing torrent on site may already use this distributor. Would you like to change it?
+                </p>
+                <p class="form__group">
+                    <select
+                        name="distributor_id"
+                        id="autoreg"
+                        class="form__select"
+                        x-data="{ distributor: '' }"
+                        x-model="distributor"
+                        x-bind:class="distributor === '' ? 'form__select--default' : ''"
+                    >
+                        <option hidden disabled selected value=""></option>
+                        @foreach ($distributors as $distributor)
+                            <option value="{{ $distributor->id }}">
+                                {{ $distributor->name }}
+                            </option>
+                        @endforeach
+                    </select>
+                    <label class="form__label form__label--floating" for="autoreg">
+                        Replacement distributor
+                    </label>
+                </p>
+                <p class="form__group">
+                    <button 
+                        x-on:click.prevent="Swal.fire({
+                            title: 'Are you sure?',
+                            text: 'Are you sure you want to delete this distributor: {{ $distributor->name }}?',
+                            icon: 'warning',
+                            showConfirmButton: true,
+                            showCancelButton: true,
+                        }).then((result) => {
+                            if (result.isConfirmed) {
+                                $root.submit();
+                            }
+                        })"
+                        class="form__button form__button--filled"
+                    >
+                        {{ __('common.delete') }}
+                    </button>
+                </p>
+            </form>
+        </div>
+    </div>
+@endsection

--- a/resources/views/Staff/distributor/edit.blade.php
+++ b/resources/views/Staff/distributor/edit.blade.php
@@ -1,0 +1,73 @@
+@extends('layout.default')
+
+@section('breadcrumbs')
+    <li class="breadcrumbV2">
+        <a href="{{ route('staff.dashboard.index') }}" class="breadcrumb__link">
+            {{ __('staff.staff-dashboard') }}
+        </a>
+    </li>
+    <li class="breadcrumbV2">
+        <a href="{{ route('staff.distributors.index') }}" class="breadcrumb__link">
+            Torrent Distributors
+        </a>
+    </li>
+    <li class="breadcrumbV2">
+        {{ $distributor->name }}
+    </li>
+    <li class="breadcrumb--active">
+        {{ __('common.edit') }}
+    </li>
+@endsection
+
+@section('page', 'page__distributor--edit')
+
+@section('main')
+    <section class="panelV2">
+        <h2 class="panel__heading">
+            {{ __('common.edit') }} Torrent Distributor: {{ $distributor->name }}
+        </h2>
+        <div class="panel__body">
+            <form
+                class="form"
+                method="POST"
+                action="{{ route('staff.distributors.update', ['id' => $distributor->id]) }}"
+            >
+                @method('PATCH')
+                @csrf
+                <p class="form__group">
+                    <input
+                        id="name"
+                        class="form__text"
+                        name="name"
+                        required
+                        type="text"
+                        value="{{ $distributor->name }}"
+                    >
+                    <label class="form__label form__label--floating" for="name">
+                        {{ __('common.name') }}
+                    </label>
+                </p>
+                <p class="form__group">
+                    <input
+                        id="position"
+                        class="form__text"
+                        inputmode="numeric"
+                        name="position"
+                        pattern="[0-9]*"
+                        required
+                        type="text"
+                        value="{{ $distributor->position }}"
+                    >
+                    <label class="form__label form__label--floating" for="name">
+                        {{ __('common.position') }}
+                    </label>
+                </p>
+                <p class="form__group">
+                    <button class="form__button form__button--filled">
+                        {{ __('common.submit') }}
+                    </button>
+                </p>
+            </form>
+        </div>
+    </div>
+@endsection

--- a/resources/views/Staff/distributor/index.blade.php
+++ b/resources/views/Staff/distributor/index.blade.php
@@ -1,0 +1,77 @@
+@extends('layout.default')
+
+@section('breadcrumbs')
+    <li class="breadcrumbV2">
+        <a href="{{ route('staff.dashboard.index') }}" class="breadcrumb__link">
+            {{ __('staff.staff-dashboard') }}
+        </a>
+    </li>
+    <li class="breadcrumb--active">
+        Torrent Distributors
+    </li>
+@endsection
+
+@section('page', 'page__distributor--index')
+
+@section('main')
+    <section class="panelV2">
+        <header class="panel__header">
+            <h2 class="panel__heading">Torrent Distributors</h2>
+            <div class="panel__actions">
+                <a
+                    href="{{ route('staff.distributors.create') }}"
+                    class="panel__action form__button form__button--text"
+                >
+                    {{ __('common.add') }}
+                </a>
+            </div>
+        </header>
+        <div class="data-table-wrapper">
+            <table class="data-table">
+                <thead>
+                <tr>
+                    <th>{{ __('common.position') }}</th>
+                    <th>{{ __('common.name') }}</th>
+                    <th>{{ __('common.action') }}</th>
+                </tr>
+                </thead>
+                <tbody>
+                @forelse ($distributors as $distributor)
+                    <tr>
+                        <td>{{ $distributor->position }}</td>
+                        <td>
+                            <a href="{{ route('staff.distributors.edit', ['id' => $distributor->id]) }}">
+                                {{ $distributor->name }}
+                            </a>
+                        </td>
+                        <td>
+                            <menu class="data-table__actions">
+                                <li class="data-table__action">
+                                    <a
+                                        href="{{ route('staff.distributors.edit', ['id' => $distributor->id]) }}"
+                                        class="form__button form__button--text"
+                                    >
+                                        {{ __('common.edit') }}
+                                    </a>
+                                </li>
+                                <li class="data-table__action">
+                                    <a
+                                        href="{{ route('staff.distributors.delete', ['id' => $distributor->id]) }}"
+                                        class="form__button form__button--text"
+                                    >
+                                        {{ __('common.delete') }}
+                                    </a>
+                                </li>
+                            </menu>
+                        </td>
+                    </tr>
+                @empty
+                    <tr>
+                        <td colspan="3">No distributors</td>
+                    </tr>
+                @endforelse
+                </tbody>
+            </table>
+        </div>
+    </section>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -716,6 +716,19 @@ Route::group(['middleware' => 'language'], function () {
             Route::post('/test-email', [App\Http\Controllers\Staff\CommandController::class, 'testEmail']);
         });
 
+        // Distributors
+        Route::group(['prefix' => 'distributors'], function () {
+            Route::name('staff.distributors.')->group(function () {
+                Route::get('/', [App\Http\Controllers\Staff\DistributorController::class, 'index'])->name('index');
+                Route::get('/create', [App\Http\Controllers\Staff\DistributorController::class, 'create'])->name('create');
+                Route::post('/store', [App\Http\Controllers\Staff\DistributorController::class, 'store'])->name('store');
+                Route::get('/{id}/edit', [App\Http\Controllers\Staff\DistributorController::class, 'edit'])->name('edit');
+                Route::patch('/{id}/update', [App\Http\Controllers\Staff\DistributorController::class, 'update'])->name('update');
+                Route::get('/{id}/delete', [App\Http\Controllers\Staff\DistributorController::class, 'delete'])->name('delete');
+                Route::delete('/{id}/destroy', [App\Http\Controllers\Staff\DistributorController::class, 'destroy'])->name('destroy');
+            });
+        });
+
         // Flush System
         Route::group(['prefix' => 'flush'], function () {
             Route::name('staff.flush.')->group(function () {


### PR DESCRIPTION
Allow staff to manipulate distributors. Upon deletion, torrents with the selected region are updated to a different region.