### PR TITLE
(Fix) Wrong director

### DIFF
--- a/app/Jobs/ProcessMovieJob.php
+++ b/app/Jobs/ProcessMovieJob.php
@@ -97,7 +97,12 @@ class ProcessMovieJob implements ShouldQueue
 
         if (isset($this->movie['credits']['crew'])) {
             foreach ($this->movie['credits']['crew'] as $crew) {
-                Crew::updateOrCreate(['id' => $crew['id']], $tmdb->person_array($crew))->movie()->syncWithoutDetaching([$this->movie['id']]);
+                Crew::updateOrCreate(['id' => $crew['id']], $tmdb->person_array($crew))
+                    ->movie()
+                    ->syncWithoutDetaching([$this->movie['id'] => [
+                        'department' => $crew['department'] ?? null,
+                        'job'        => $crew['job'] ?? null,
+                    ]]);
             }
         }
 

--- a/app/Jobs/ProcessTvJob.php
+++ b/app/Jobs/ProcessTvJob.php
@@ -107,7 +107,12 @@ class ProcessTvJob implements ShouldQueue
 
         if (isset($this->tv['credits']['crew'])) {
             foreach ($this->tv['credits']['crew'] as $crew) {
-                Crew::updateOrCreate(['id' => $crew['id']], $tmdb->person_array($crew))->tv()->syncWithoutDetaching([$this->tv['id']]);
+                Crew::updateOrCreate(['id' => $crew['id']], $tmdb->person_array($crew))
+                    ->tv()
+                    ->syncWithoutDetaching([$this->tv['id'] => [
+                        'department' => $crew['department'] ?? null,
+                        'job'        => $crew['job'] ?? null,
+                    ]]);
             }
         }
 
@@ -168,7 +173,12 @@ class ProcessTvJob implements ShouldQueue
 
                 foreach ($season['credits']['crew'] as $crew) {
                     if (isset($crew['id'])) {
-                        Crew::updateOrCreate(['id' => $crew['id']], $tmdb->person_array($crew))->season()->syncWithoutDetaching([$season['id']]);
+                        Crew::updateOrCreate(['id' => $crew['id']], $tmdb->person_array($crew))
+                            ->season()
+                            ->syncWithoutDetaching([$season['id'] => [
+                                'department' => $season['department'] ?? null,
+                                'job'        => $season['job'] ?? null,
+                            ]]);
                         Person::updateOrCreate(['id' => $crew['id']], $tmdb->person_array($crew))->tv()->syncWithoutDetaching([$this->id]);
                     }
                 }

--- a/app/Models/Season.php
+++ b/app/Models/Season.php
@@ -56,6 +56,6 @@ class Season extends Model
 
     public function crew(): \Illuminate\Database\Eloquent\Relations\BelongsToMany
     {
-        return $this->belongsToMany(Crew::class);
+        return $this->belongsToMany(Crew::class, 'crew_season', 'person_id', 'season_id');
     }
 }

--- a/database/migrations/2022_08_31_075057_update_crew_movie_table.php
+++ b/database/migrations/2022_08_31_075057_update_crew_movie_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use App\Models\Movie;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration {
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('crew_movie', function (Blueprint $table) {
+            $table->string('department')->nullable();
+            $table->string('job')->nullable();
+        });
+
+        foreach (Movie::all() as $movie) {
+            $crew = (new \App\Services\Tmdb\Client\Movie($movie->id))->get_crew();
+
+            if (isset($crew)) {
+                foreach ($crew as $crewMember) {
+                    $movie->crew()->updateExistingPivot($crewMember['id'], [
+                        'department' => $crewMember['department'],
+                        'job'        => $crewMember['job'],
+                    ]);
+                }
+            }
+        }
+    }
+};

--- a/database/migrations/2022_08_31_101436_update_crew_tv_table.php
+++ b/database/migrations/2022_08_31_101436_update_crew_tv_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use App\Models\Tv;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration {
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('crew_tv', function (Blueprint $table) {
+            $table->string('department')->nullable();
+            $table->string('job')->nullable();
+        });
+
+        foreach (Tv::all() as $tv) {
+            $data = (new \App\Services\Tmdb\Client\TV($tv->id))->getData();
+
+            if (isset($data['credits']['crew'])) {
+                foreach ($data['credits']['crew'] as $crewMember) {
+                    $tv->crew()->updateExistingPivot($crewMember['id'], [
+                        'department' => $crewMember['department'],
+                        'job'        => $crewMember['job'],
+                    ]);
+                }
+            }
+        }
+    }
+};

--- a/database/migrations/2022_08_31_111509_update_crew_season_table.php
+++ b/database/migrations/2022_08_31_111509_update_crew_season_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use App\Models\Season;
+use App\Models\Tv;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration {
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('crew_season', function (Blueprint $table) {
+            $table->string('department')->nullable();
+            $table->string('job')->nullable();
+        });
+
+        foreach (Tv::all() as $tv) {
+            $data = (new \App\Services\Tmdb\Client\TV($tv->id))->getData();
+
+            foreach ($data['seasons'] as $season) {
+                $season = (new \App\Services\Tmdb\Client\Season($tv->id, \sprintf('%02d', $season['season_number'])))->getData();
+                $seasonModel = Season::find($season['id']);
+
+                if (isset($season['credits']['crew'])) {
+                    foreach ($season['credits']['crew'] as $crewMember) {
+                        $seasonModel->crew()->updateExistingPivot($crewMember['id'], [
+                            'department' => $crewMember['department'],
+                            'job'        => $crewMember['job'],
+                        ]);
+                    }
+                }
+            }
+        }
+    }
+};

--- a/resources/views/torrent/partials/movie_meta.blade.php
+++ b/resources/views/torrent/partials/movie_meta.blade.php
@@ -49,7 +49,7 @@
         <div class="movie-bottom">
             <div class="movie-details">
                 @if(isset($meta->crew))
-                    @if(!empty($directors = $meta->crew()->where('known_for_department' ,'=', 'Directing')->take(1)->get()))
+                    @if(!empty($directors = $meta->crew()->wherePivot('department' ,'=', 'Directing')->take(1)->get()))
                         <span class="badge-user text-bold text-purple">
                         <i class="{{ config('other.font-awesome') }} fa-camera-movie"></i> Directors:
                         @foreach($directors as $director)


### PR DESCRIPTION
Fixes #1824

Previously, only one `known_for_department` was stored for every person. Now, the person's department is stored on the pivot table, allowing every person to have a different department for every movie/show/season they worked on.

The crew_episode table is currently unused so I didn't change that.

Also, to note: the person_id and movie_id/tv_id/season_id/episode_id are incorrectly swapped (i.e. the movie_id is stored in the person_id column and the person_id is stored in the movie_id column). I just left this as is, but it should probably be cleaned up in the future.

Please test specifically crew_season to make sure that the two columns weren't swapped since the relation on the season side was broken.