### PR TITLE
(Fix) Rss genres not showing on edit page

### DIFF
--- a/resources/views/Staff/rss/edit.blade.php
+++ b/resources/views/Staff/rss/edit.blade.php
@@ -243,7 +243,7 @@
                                             name="genres[]"
                                             type="checkbox"
                                             value="{{ $genre->id }}"
-                                            @checked(is_array($rss->object_torrent->genres) && in_array($genre->id, $rss->object_torrent->genres, true))
+                                            @checked(is_array($rss->object_torrent->genres) && in_array((string)$genre->id, $rss->object_torrent->genres, true))
                                         >
                                         {{ $genre->name }}
                                     </label>

--- a/resources/views/rss/edit.blade.php
+++ b/resources/views/rss/edit.blade.php
@@ -132,7 +132,7 @@
                                 <span class="badge-user">
                                     <label class="inline">
                                         @if(is_array($rss->object_torrent->genres) &&
-                                            in_array($genre->id, $rss->object_torrent->genres, true))
+                                            in_array((string)$genre->id, $rss->object_torrent->genres, true))
                                             <input type="checkbox" id="{{ $genre->name }}" name="genres[]"
                                                    value="{{ $genre->id }}"
                                                    class="genre" CHECKED> {{ $genre->name }}


### PR DESCRIPTION
Requires casting to string to work properly