### PR TITLE
(Fix) table horizontal scrollbars

### DIFF
--- a/resources/sass/components/_data-table.scss
+++ b/resources/sass/components/_data-table.scss
@@ -6,7 +6,7 @@
 }
 
 .data-table-wrapper {
-    overflow-x: scroll;
+    overflow-x: auto;
 }
 
 /* header */


### PR DESCRIPTION
Setting the overflow to auto will make sure tables only have scrollbars if they're too large to fit in their container.