### PR TITLE
(Fix) Typo in French translation

### DIFF
--- a/lang/fr/common.php
+++ b/lang/fr/common.php
@@ -91,7 +91,7 @@ return [
     'legend'               => 'Légende',
     'lists'                => 'Listes',
     'lock-account'         => 'Verrouiller le compte',
-    'logout'               => 'Déonnecter',
+    'logout'               => 'Déconnecter',
     'members'              => 'Membres',
     'message'              => 'Message',
     'minute'               => 'Minute',


### PR DESCRIPTION
'Déonnecter' -> 'Déconnecter'