### PR TITLE
(Update) Batch peer updates

### DIFF
--- a/app/Console/Commands/AutoFlushPeers.php
+++ b/app/Console/Commands/AutoFlushPeers.php
@@ -45,7 +45,7 @@ class AutoFlushPeers extends Command
     public function handle(): void
     {
         $carbon = new Carbon();
-        $peers = Peer::select(['id', 'torrent_id', 'user_id', 'updated_at'])->where('updated_at', '<', $carbon->copy()->subHours(2)->toDateTimeString())->get();
+        $peers = Peer::select(['torrent_id', 'user_id', 'peer_id', 'updated_at'])->where('updated_at', '<', $carbon->copy()->subHours(2)->toDateTimeString())->get();
 
         foreach ($peers as $peer) {
             $history = History::where('torrent_id', '=', $peer->torrent_id)->where('user_id', '=', $peer->user_id)->first();

--- a/app/Console/Commands/AutoInsertPeers.php
+++ b/app/Console/Commands/AutoInsertPeers.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * NOTICE OF LICENSE.
+ *
+ * UNIT3D Community Edition is open-sourced software licensed under the GNU Affero General Public License v3.0
+ * The details is bundled with this project in the file LICENSE.txt.
+ *
+ * @project    UNIT3D Community Edition
+ *
+ * @author     Roardom <roardom@protonmail.com>
+ * @license    https://www.gnu.org/licenses/agpl-3.0.en.html/ GNU Affero General Public License v3.0
+ */
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Redis;
+
+/**
+ * @see \Tests\Unit\Console\Commands\AutoFlushPeersTest
+ */
+class AutoInsertPeers extends Command
+{
+    /**
+     * MySql can handle a max of 65k placeholders per query,
+     * and there are 13 fields on each peer that are updated
+     */
+    const PEERS_PER_CYCLE = 65_000 / 13;
+
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'auto:insert_peers';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Inserts peers in batches';
+
+    /**
+     * Execute the console command.
+     *
+     * @throws \Exception
+     */
+    public function handle(): void
+    {
+        $key = config('cache.prefix').':peers:batch';
+        $peerCount = Redis::connection('cache')->command('LRANGE', [$key, '0', '-1']);
+        $cycles = ceil($peerCount / self::PEERS_PER_CYCLE);
+
+        for ($i = 0; $i < $cycles; $i++) {
+            $peers = Redis::connection('cache')->command('RPOP', [$key, self::PEERS_PER_CYCLE]);
+            $peers = array_map('unserialize', $peers);
+
+            DB::table('peers')->upsert(
+                $peers,
+                ['torrent_id', 'user_id', 'peer_id'],
+                [
+                    'peer_id',
+                    'md5_peer_id',
+                    'info_hash',
+                    'ip',
+                    'port',
+                    'agent',
+                    'uploaded',
+                    'downloaded',
+                    'seeder',
+                    'left',
+                    'torrent_id',
+                    'user_id',
+                    'updated_at'
+                ],
+            );
+        }
+
+        $this->comment('Automated insert peers command complete');
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -49,6 +49,7 @@ class Kernel extends ConsoleKernel
         $schedule->command('auto:stats_clients')->daily();
         $schedule->command('auto:remove_torrent_buffs')->hourly();
         $schedule->command('auto:torrent_balance')->hourly();
+        $schedule->command('auto:insert_peers')->everyMinute();
         //$schedule->command('auto:ban_disposable_users')->weekends();
         //$schedule->command('backup:clean')->daily();
         //$schedule->command('backup:run')->daily();

--- a/app/Http/Controllers/Staff/FlushController.php
+++ b/app/Http/Controllers/Staff/FlushController.php
@@ -41,7 +41,7 @@ class FlushController extends Controller
     public function peers(): \Illuminate\Http\RedirectResponse
     {
         $carbon = new Carbon();
-        $peers = Peer::select(['id', 'torrent_id', 'user_id', 'updated_at'])->where('updated_at', '<', $carbon->copy()->subHours(2)->toDateTimeString())->get();
+        $peers = Peer::select(['torrent_id', 'user_id', 'peer_id', 'updated_at'])->where('updated_at', '<', $carbon->copy()->subHours(2)->toDateTimeString())->get();
 
         foreach ($peers as $peer) {
             $history = History::where('torrent_id', '=', $peer->torrent_id)->where('user_id', '=', $peer->user_id)->first();

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -1442,7 +1442,7 @@ class UserController extends Controller
         $carbon = new Carbon();
 
         // Get Peer List from User
-        $peers = Peer::select(['id', 'torrent_id', 'user_id', 'updated_at'])
+        $peers = Peer::select(['torrent_id', 'user_id', 'peer_id', 'updated_at'])
             ->where('user_id', '=', $user->id)
             ->where('updated_at', '<', $carbon->copy()->subMinutes(70)->toDateTimeString())
             ->get();

--- a/app/Http/Livewire/UserActive.php
+++ b/app/Http/Livewire/UserActive.php
@@ -79,7 +79,6 @@ class UserActive extends Component
         return Peer::query()
             ->join('torrents', 'peers.torrent_id', '=', 'torrents.id')
             ->select(
-                'peers.id',
                 'peers.ip',
                 'peers.port',
                 'peers.agent',

--- a/app/Jobs/ProcessAnnounce.php
+++ b/app/Jobs/ProcessAnnounce.php
@@ -151,7 +151,7 @@ class ProcessAnnounce implements ShouldQueue
                 $peer->user_id = $this->user->id;
                 $peer->updateConnectableStateIfNeeded();
                 $peer->updated_at = \now();
-                $peer->save();
+                Redis::connection('cache')->command('LPUSH', [config('cache.prefix').':peers:batch', serialize($peer)]);
 
                 $history->user_id = $this->user->id;
                 $history->torrent_id = $this->torrent->id;
@@ -184,7 +184,7 @@ class ProcessAnnounce implements ShouldQueue
                 $peer->user_id = $this->user->id;
                 $peer->updateConnectableStateIfNeeded();
                 $peer->updated_at = \now();
-                $peer->save();
+                Redis::connection('cache')->command('LPUSH', [config('cache.prefix').':peers:batch', serialize($peer)]);
 
                 $history->user_id = $this->user->id;
                 $history->torrent_id = $this->torrent->id;
@@ -264,7 +264,7 @@ class ProcessAnnounce implements ShouldQueue
                 $peer->user_id = $this->user->id;
                 $peer->updateConnectableStateIfNeeded();
                 $peer->updated_at = \now();
-                $peer->save();
+                Redis::connection('cache')->command('LPUSH', [config('cache.prefix').':peers:batch', serialize($peer)]);
 
                 $history->user_id = $this->user->id;
                 $history->torrent_id = $this->torrent->id;

--- a/database/migrations/2022_10_30_064546_update_peers_table.php
+++ b/database/migrations/2022_10_30_064546_update_peers_table.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('peers', function (Blueprint $table) {
+            $table->dropColumn('id');
+            $table->primary(['torrent_id', 'user_id', 'peer_id']);
+        });
+    }
+};


### PR DESCRIPTION
Pushes peers to redis every announce, and then batch inserts them to the db every minute.

Untested.