### PR TITLE
(Update) Reduce database queries used to retrieve peers

### DIFF
--- a/app/Http/Controllers/AnnounceController.php
+++ b/app/Http/Controllers/AnnounceController.php
@@ -347,7 +347,7 @@ class AnnounceController extends Controller
     protected function checkTorrent($infoHash): object
     {
         // Check Info Hash Against Torrents Table
-        $torrent = Torrent::query()
+        $torrent = Torrent::with('peers')
             ->select(['id', 'free', 'doubleup', 'seeders', 'leechers', 'times_completed', 'status'])
             ->withAnyStatus()
             ->where('info_hash', '=', $infoHash)
@@ -385,12 +385,14 @@ class AnnounceController extends Controller
      */
     private function checkPeer($torrent, $queries, $user): void
     {
-        \throw_if(\strtolower($queries['event']) === 'completed' &&
-            ! Peer::query()
-                ->where('torrent_id', '=', $torrent->id)
+        \throw_if(
+            \strtolower($queries['event']) === 'completed'
+            && $torrent->peers
                 ->where('peer_id', $queries['peer_id'])
                 ->where('user_id', '=', $user->id)
-                ->exists(), new TrackerException(152));
+                ->isEmpty(),
+            new TrackerException(152)
+        );
     }
 
     /**
@@ -402,9 +404,7 @@ class AnnounceController extends Controller
      */
     private function checkMinInterval($torrent, $queries, $user): void
     {
-        $prevAnnounce = Peer::query()
-            ->select('updated_at')
-            ->where('torrent_id', '=', $torrent->id)
+        $prevAnnounce = $torrent->peers
             ->where('peer_id', '=', $queries['peer_id'])
             ->where('user_id', '=', $user->id)
             ->first();
@@ -426,8 +426,7 @@ class AnnounceController extends Controller
     private function checkMaxConnections($torrent, $user): void
     {
         // Pull Count On Users Peers Per Torrent For Rate Limiting
-        $connections = Peer::query()
-            ->where('torrent_id', '=', $torrent->id)
+        $connections = $torrent->peers
             ->where('user_id', '=', $user->id)
             ->count();
 
@@ -487,12 +486,12 @@ class AnnounceController extends Controller
             $limit = (min($queries['numwant'], 25));
 
             // Get Torrents Peers (Only include leechers in a seeder's peerlist)
-            $peers = Peer::query()
-                ->where('torrent_id', '=', $torrent->id)
+            $peers = $torrent->peers
                 ->when($queries['left'] == 0, fn ($query) => $query->where('seeder', '=', 0))
                 ->where('user_id', '!=', $user->id)
                 ->take($limit)
-                ->get(['ip', 'port'])
+                ->map
+                ->only(['ip', 'port'])
                 ->toArray();
 
             foreach ($peers as $peer) {

--- a/app/Jobs/ProcessAnnounce.php
+++ b/app/Jobs/ProcessAnnounce.php
@@ -24,7 +24,6 @@ use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\Middleware\WithoutOverlapping;
 use Illuminate\Queue\SerializesModels;
-use Illuminate\Support\Facades\DB;
 
 class ProcessAnnounce implements ShouldQueue
 {
@@ -64,8 +63,7 @@ class ProcessAnnounce implements ShouldQueue
         $event = \strtolower($this->queries['event']);
 
         // Get The Current Peer
-        $peer = Peer::query()
-            ->where('torrent_id', '=', $this->torrent->id)
+        $peer = $this->torrent->peers
             ->where('peer_id', '=', $this->queries['peer_id'])
             ->where('user_id', '=', $this->user->id)
             ->first();
@@ -294,13 +292,22 @@ class ProcessAnnounce implements ShouldQueue
                 // End User Update
         }
 
-        $peerCount = DB::table('peers')
-            ->where('torrent_id', '=', $this->torrent->id)
-            ->selectRaw('count(case when peers.left > 0 then 1 end) as leechers')
-            ->selectRaw('count(case when peers.left = 0 then 1 end) as seeders')
-            ->first();
-        $this->torrent->seeders = $peerCount->seeders;
-        $this->torrent->leechers = $peerCount->leechers;
+        $oldSeeders = $this->torrents->peers->where('left', '=', 0)->count();
+        $oldLeechers = $this->torrents->peers->where('left', '>', 0)->count();
+
+        $this->torrent->seeders = match ($event) {
+            'started'   => $oldSeeders + (int) ($this->queries['left'] == 0),
+            'completed' => $oldSeeders + 1,
+            'stopped'   => $oldSeeders - (int) ($this->queries['left'] == 0),
+            default     => $oldSeeders
+        };
+        $this->torrent->leechers = match ($event) {
+            'started'   => $oldLeechers + (int) ($this->queries['left'] > 0),
+            'completed' => $oldLeechers - 1,
+            'stopped'   => $oldLeechers - (int) ($this->queries['left'] > 0),
+            default     => $oldLeechers
+        };
+
         $this->torrent->save();
     }
 }


### PR DESCRIPTION
Implement eager loading and use Laravel collections to filter the result instead of executing additional queries.