### PR TITLE
(Fix) Bbcode in comments

### DIFF
--- a/resources/views/livewire/comment.blade.php
+++ b/resources/views/livewire/comment.blade.php
@@ -82,9 +82,9 @@
                 </p>
             </form>
         @else
-            <p class="comment__content">
+            <div class="comment__content">
                 @joypixels($comment->getContentHtml())
-            </p>
+            </div>
         @endif
     </article>
 


### PR DESCRIPTION
Bbcode uses html tags that aren't allowed in paragraph tags, which causes it to be wrongly rendered.