### PR TITLE
(Fix) Editing anon torrent requests

### DIFF
--- a/resources/views/requests/edit_request.blade.php
+++ b/resources/views/requests/edit_request.blade.php
@@ -192,7 +192,7 @@
                             id="anon"
                             name="anon"
                             value="1"
-                            @checked(old('anon'))
+                            @checked($torrentRequest->anon)
                         >
                         <label class="form__label" for="anon">{{ __('common.anonymous') }}?</label>
                     </p>


### PR DESCRIPTION
Without this PR, the anon box doesn't get ticked automatically on the edit page if the request was already marked as anon.