### PR TITLE
(Update) Prevent duplicate history and peers

### DIFF
--- a/database/migrations/2022_11_23_024350_update_history_table.php
+++ b/database/migrations/2022_11_23_024350_update_history_table.php
@@ -1,0 +1,51 @@
+<?php
+
+use App\Models\History;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        $duplicates = DB::table('history')
+            ->select(
+                'torrent_id',
+                'user_id',
+                DB::raw('COUNT(*) as `count`')
+            )
+            ->groupBy('torrent_id', 'user_id')
+            ->having('count', '>', 1)
+            ->get();
+
+        foreach($duplicates as $duplicate) {
+            $records = History::query()
+                ->where('torrent_id', '=', $duplicate->torrent_id)
+                ->where('user_id', '=', $duplicate->user_id)
+                ->get();
+
+            $merged = $records->first();
+
+            $merged->seedtime = $records->sum('seedtime');
+            $merged->downloaded = $records->sum('downloaded');
+            $merged->actual_downloaded = $records->sum('actual_downloaded');
+            $merged->uploaded = $records->sum('uploaded');
+            $merged->actual_uploaded = $records->sum('actual_uploaded');
+            $merged->save();
+
+            foreach($records->where('id', '!=', $merged->id) as $record) {
+                $record->delete();
+            }
+        }
+
+        Schema::table('history', function (Blueprint $table) {
+            $table->unique(['user_id', 'torrent_id']);
+        });
+    }    
+};

--- a/database/migrations/2022_11_23_195306_update_peers_table.php
+++ b/database/migrations/2022_11_23_195306_update_peers_table.php
@@ -1,0 +1,45 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        $duplicates = DB::table('peers')
+            ->select(
+                'torrent_id',
+                'user_id',
+                'peer_id',
+                DB::raw('COUNT(*) as `count`')
+            )
+            ->groupBy('torrent_id', 'user_id', 'peer_id')
+            ->having('count', '>', 1)
+            ->get();
+
+        foreach($duplicates as $duplicate) {
+            $records = Peer::query()
+                ->where('torrent_id', '=', $duplicate->torrent_id)
+                ->where('user_id', '=', $duplicate->user_id)
+                ->where('peer_id', '=', $duplicate->peer_id)
+                ->get();
+
+            $first = $records->first();
+
+            foreach($records->where('id', '!=', $first->id) as $record) {
+                $record->delete();
+            }
+        }
+
+        Schema::table('peers', function (Blueprint $table) {
+            $table->unique(['user_id', 'torrent_id', 'peer_id']);
+        });
+    }    
+};


### PR DESCRIPTION
Enforces only one duplicate history record per torrent per user, and one peer per torrent per user per peer id. These composite unique indexes will be used to implement a batch "Insert ... on duplicate key update" query optimization for the announce logic.