### PR TITLE
(Update) Change imdb, tmdb, tvdb, mal ids to integer

### DIFF
--- a/database/migrations/2022_11_24_032502_update_torrents_table.php
+++ b/database/migrations/2022_11_24_032502_update_torrents_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('torrents', function (Blueprint $table) {
+            $table->integer('imdb')->unsigned()->change();
+            $table->integer('tvdb')->unsigned()->change();
+            $table->integer('tmdb')->unsigned()->change();
+            $table->integer('mal')->unsigned()->change();
+        });
+    }
+};

--- a/database/migrations/2022_11_24_032521_update_requests_table.php
+++ b/database/migrations/2022_11_24_032521_update_requests_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('requests', function (Blueprint $table) {
+            $table->integer('imdb')->unsigned()->change();
+            $table->integer('tvdb')->unsigned()->change();
+            $table->integer('tmdb')->unsigned()->change();
+            $table->integer('mal')->unsigned()->change();
+        });
+    }
+};


### PR DESCRIPTION
These ids should be changed to integer and be simply be auto-expanded to their zero-padded form when viewed. Reasons behind this change are the following:

- Users often forget to pad with zeros when copying the id, so let's automate that.
- Better performance when searching by id

In https://github.com/HDInnovations/UNIT3D-Community-Edition/pull/2347, imdb links are automatically zero padded and in https://github.com/HDInnovations/UNIT3D-Community-Edition/pull/2249, searches via id are cast to integer to strip zero padding before searching. So non-zero-padded ids should cause no issue.