### PR TITLE
(Fix) Screenshot comparisons larger than screen resolution

### DIFF
--- a/resources/sass/components/_comparison.scss
+++ b/resources/sass/components/_comparison.scss
@@ -22,6 +22,7 @@
     list-style-type: none;
     margin: 0;
     padding: 0;
+    margin-left: max(0px, 50% - 50vw);
 }
 
 .comparison__image--hidden,


### PR DESCRIPTION
Currently, if the images are larger than the resolution of the screen being viewed on, then the images are center aligned, with the ability to horizontally scroll to the right, but not the left. This PR changes the logic so that if the images are larger than the screen resolution, then they are aligned to the left, otherwise, they still get centered.

This has the downside of if you're comparing images larger than your screen but one set has vertical dirty lines cropped, then you won't be able to flip back and forth, however, it still allows you to view the full image (including the text overlay of screenshot details usually found in the top left, that shows the frame number, frame type, source, etc.)