### PR TITLE
(Update) Drop unused conversation tables

### DIFF
--- a/database/migrations/2022_12_05_012617_drop_conversations.php
+++ b/database/migrations/2022_12_05_012617_drop_conversations.php
@@ -1,0 +1,19 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::dropIfExists('conversation_messages');
+        Schema::dropIfExists('conversation_user');
+        Schema::dropIfExists('conversations');
+    }
+};


### PR DESCRIPTION
Conversations were never actually implemented, but their tables made it into the schema accidentally. Let's drop them.