### PR TITLE
(Update) Peers table

### DIFF
--- a/app/Console/Commands/AutoHighspeedTag.php
+++ b/app/Console/Commands/AutoHighspeedTag.php
@@ -49,7 +49,7 @@ class AutoHighspeedTag extends Command
             ->leftJoinSub(
                 Peer::distinct()
                     ->select('torrent_id')
-                    ->whereRaw("ip IN ('".$seedboxIps->implode("','")."')"),
+                    ->whereRaw("INET6_NTOA(ip) IN ('".$seedboxIps->implode("','")."')"),
                 'highspeed_torrents',
                 fn ($join) => $join->on('torrents.id', '=', 'highspeed_torrents.torrent_id')
             )

--- a/app/Http/Controllers/TorrentPeerController.php
+++ b/app/Http/Controllers/TorrentPeerController.php
@@ -26,6 +26,8 @@ class TorrentPeerController extends Controller
         $torrent = Torrent::withAnyStatus()->findOrFail($id);
         $peers = Peer::query()
             ->with(['user'])
+            ->select(['torrent_id', 'user_id', 'uploaded', 'downloaded', 'left', 'port', 'agent', 'created_at', 'updated_at', 'seeder'])
+            ->selectRaw('INET6_NTOA(ip) as ip')
             ->where('torrent_id', '=', $id)
             ->latest('seeder')
             ->get()

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -85,7 +85,11 @@ class UserController extends Controller
         $requested = TorrentRequest::where('user_id', '=', $user->id)->count();
         $filled = TorrentRequest::where('filled_by', '=', $user->id)->whereNotNull('approved_by')->count();
 
-        $peers = Peer::where('user_id', '=', $user->id)->get();
+        $clients = $user->peers()
+            ->select('agent', 'port')
+            ->selectRaw('INET6_NTOA(ip) as ip, MIN(created_at), MAX(updated_at), COUNT(*) as num_peers')
+            ->groupBy(['ip', 'port', 'agent'])
+            ->get();
 
         $achievements = AchievementProgress::with('details')
             ->where('achiever_id', '=', $user->id)
@@ -117,7 +121,7 @@ class UserController extends Controller
             'requested'     => $requested,
             'filled'        => $filled,
             'invitedBy'     => $invitedBy,
-            'peers'         => $peers,
+            'clients'       => $clients,
             'achievements'  => $achievements,
         ]);
     }

--- a/app/Http/Livewire/UserActive.php
+++ b/app/Http/Livewire/UserActive.php
@@ -80,7 +80,6 @@ class UserActive extends Component
             ->join('torrents', 'peers.torrent_id', '=', 'torrents.id')
             ->select(
                 'peers.id',
-                'peers.ip',
                 'peers.port',
                 'peers.agent',
                 'peers.uploaded',
@@ -97,6 +96,7 @@ class UserActive extends Component
                 'torrents.leechers',
                 'torrents.times_completed',
             )
+            ->selectRaw('INET6_NTOA(ip) as ip')
             ->selectRaw('(1 - (peers.left / NULLIF(torrents.size, 0))) AS progress')
             ->where('peers.user_id', '=', $this->user->id)
             ->when(

--- a/app/Jobs/ProcessAnnounce.php
+++ b/app/Jobs/ProcessAnnounce.php
@@ -135,8 +135,6 @@ class ProcessAnnounce implements ShouldQueue
 
         // Common Parts Extracted From Switch
         $peer->peer_id = $this->queries['peer_id'];
-        $peer->md5_peer_id = \md5($this->queries['peer_id']);
-        $peer->info_hash = $this->queries['info_hash'];
         $peer->ip = $this->queries['ip-address'];
         $peer->port = $this->queries['port'];
         $peer->agent = $this->queries['user-agent'];

--- a/app/Models/Peer.php
+++ b/app/Models/Peer.php
@@ -59,7 +59,7 @@ class Peer extends Model
     public function updateConnectableStateIfNeeded(): void
     {
         if (\config('announce.connectable_check')) {
-            $tmp_ip = $this->ip;
+            $tmp_ip = inet_ntop(pack('A'.\strlen($this->ip), $this->ip));
             // IPv6 Check
             if (filter_var($tmp_ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6)) {
                 $tmp_ip = '['.$tmp_ip.']';

--- a/database/factories/PeerFactory.php
+++ b/database/factories/PeerFactory.php
@@ -16,11 +16,9 @@ class PeerFactory extends Factory
     public function definition(): array
     {
         return [
-            'peer_id'     => $this->faker->word(),
-            'md5_peer_id' => $this->faker->word(),
-            'info_hash'   => $this->faker->word(),
-            'ip'          => $this->faker->word(),
-            'port'        => $this->faker->randomNumber(),
+            'peer_id'     => $this->faker->asciify('-qB4450-************'),
+            'ip'          => \inet_pton($this->faker->ipv4()),
+            'port'        => $this->faker->numberBetween(0, 65535),
             'agent'       => $this->faker->word(),
             'uploaded'    => $this->faker->randomNumber(),
             'downloaded'  => $this->faker->randomNumber(),
@@ -28,7 +26,6 @@ class PeerFactory extends Factory
             'seeder'      => $this->faker->boolean(),
             'torrent_id'  => fn () => Torrent::factory()->create()->id,
             'user_id'     => fn () => User::factory()->create()->id,
-            'torrents.id' => fn () => Torrent::factory()->create()->id,
         ];
     }
 }

--- a/database/migrations/2022_12_22_004317_update_peers_table.php
+++ b/database/migrations/2022_12_22_004317_update_peers_table.php
@@ -1,0 +1,54 @@
+<?php
+
+use App\Models\Peer;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Peer::query()
+            ->update([
+                'ip' => DB::raw('INET6_ATON(`ip`)'),
+                'peer_id' => DB::raw('UNHEX(`peer_id`)'),
+            ]);
+
+        Peer::query()
+            ->whereNull('peer_id')
+            ->orWhereNull('ip')
+            ->orWhereNull('port')
+            ->orWhereNull('agent')
+            ->orWhereNull('uploaded')
+            ->orWhereNull('downloaded')
+            ->orWhereNull('left')
+            ->orWhereNull('seeder')
+            ->orWhereNull('torrent_id')
+            ->orWhereNull('user_id')
+            ->delete();
+
+        Schema::disableForeignKeyConstraints();
+
+        Schema::table('peers', function (Blueprint $table) {
+            $table->dropColumn(['md5_peer_id', 'info_hash', 'connectable']);
+            $table->unsignedSmallInteger('port')->nullable(false)->change();
+            $table->string('agent', 64)->nullable(false)->change();
+            $table->unsignedBigInteger('uploaded')->nullable(false)->change();
+            $table->unsignedBigInteger('downloaded')->nullable(false)->change();
+            $table->unsignedBigInteger('left')->nullable(false)->change();
+            $table->boolean('seeder')->nullable(false)->change();
+            $table->unsignedInteger('torrent_id')->nullable(false)->change();
+            $table->unsignedInteger('user_id')->nullable(false)->change();
+        });
+
+        Schema::enableForeignKeyConstraints();
+
+        DB::statement('ALTER TABLE `peers` MODIFY `peer_id` BINARY(20) NOT NULL');
+        DB::statement('ALTER TABLE `peers` MODIFY `ip` VARBINARY(16) NOT NULL');
+    }
+};

--- a/resources/views/user/profile.blade.php
+++ b/resources/views/user/profile.blade.php
@@ -564,44 +564,39 @@
                                 <th>{{ __('common.port') }}</th>
                                 <th>{{ __('torrent.started') }}</th>
                                 <th>{{ __('torrent.last-update') }}</th>
-                                <th>{{ __('torrent.torrents') }}</th>
+                                <th>{{ __('torrent.peers') }}</th>
                                 @if (\config('announce.connectable_check') == true)
                                     <th>Connectable</th>
                                 @endif
                             </tr>
                             </thead>
                             <tbody>
-                            @php $peer_array = []; @endphp
-                            @foreach ($peers as $p)
-                                @if (!in_array([$p->ip, $p->port], $peer_array))
-                                    @php $count = App\Models\Peer::where('user_id', '=', $user->id)->where('ip', '=', $p->ip)->where('port', '=', $p->port)->count(); @endphp
-                                    <tr>
-                                        <td>
-                                            <span class="badge-extra text-purple text-bold">{{ $p->agent }}</span>
-                                        </td>
-                                        <td><span class="badge-extra text-bold">{{ $p->ip }}</span></td>
-                                        <td><span class="badge-extra text-bold">{{ $p->port }}</span></td>
-                                        <td>{{ $p->created_at ? $p->created_at->diffForHumans() : 'N/A' }}</td>
-                                        <td>{{ $p->updated_at ? $p->updated_at->diffForHumans() : 'N/A' }}</td>
-                                        <td>
-                                            <a href="{{ route('user_active', ['username' => $user->username, 'ip' => $p->ip, 'port' => $p->port, 'client' => $p->agent]) }}"
-                                               itemprop="url" class="l-breadcrumb-item-link">
-                                                <span itemprop="title"
-                                                      class="l-breadcrumb-item-link-title">{{ $count }}</span>
-                                            </a>
-                                        </td>
-                                        @if (\config('announce.connectable_check') == true)
-                                            @php
-                                                $connectable = false;
-                                                if (cache()->has('peers:connectable:'.$p->ip.'-'.$p->port.'-'.$p->agent)) {
-                                                    $connectable = cache()->get('peers:connectable:'.$p->ip.'-'.$p->port.'-'.$p->agent);
-                                                }
-                                            @endphp
-                                            <td>@choice('user.client-connectable-state', $connectable)</td>
-                                        @endif
-                                    </tr>
-                                    @php $peer_array[] = [$p->ip, $p->port] @endphp
-                                @endif
+                            @foreach ($clients as $client)
+                                <tr>
+                                    <td>
+                                        <span class="badge-extra text-purple text-bold">{{ $client->agent }}</span>
+                                    </td>
+                                    <td><span class="badge-extra text-bold">{{ $client->ip }}</span></td>
+                                    <td><span class="badge-extra text-bold">{{ $client->port }}</span></td>
+                                    <td>{{ $client->created_at ? $client->created_at->diffForHumans() : 'N/A' }}</td>
+                                    <td>{{ $client->updated_at ? $client->updated_at->diffForHumans() : 'N/A' }}</td>
+                                    <td>
+                                        <a href="{{ route('user_active', ['username' => $user->username, 'ip' => $client->ip, 'port' => $client->port, 'client' => $client->agent]) }}"
+                                            itemprop="url" class="l-breadcrumb-item-link">
+                                            <span itemprop="title"
+                                                    class="l-breadcrumb-item-link-title">{{ $client->num_peers }}</span>
+                                        </a>
+                                    </td>
+                                    @if (\config('announce.connectable_check') == true)
+                                        @php
+                                            $connectable = false;
+                                            if (cache()->has('peers:connectable:'.$client->ip.'-'.$client->port.'-'.$client->agent)) {
+                                                $connectable = cache()->get('peers:connectable:'.$client->ip.'-'.$client->port.'-'.$client->agent);
+                                            }
+                                        @endphp
+                                        <td>@choice('user.client-connectable-state', $connectable)</td>
+                                    @endif
+                                </tr>
                             @endforeach
                             </tbody>
                         </table>


### PR DESCRIPTION
Size reductions:

- Converts `peer_id` from utf-encoded hex to binary, removing 20 bytes per peer.
- Removes `md5_peer_id` which isn't used, removing 32 bytes per peer.
- Removes `info_hash` which isn't used (uses `torrent_id` relation instead), removing 40 bytes per peer.
- Removes `connectable` which isn't used (used in redis instead), removing 1 byte per peer.
- Changes `ip` from utf-encoded dot notation to binary, saving 7 bytes per peer for ipv4, much more for ipv6.
- No null values anymore, removing at least 1 byte per peer.

Total savings: 100 bytes per peer. At 1 million peers, 100MB is saved. Assuming a common agent size of 16 characters, the size of the table is reduced by just over half.

Even though 4 billion peers are very unlikely, mysql does not recycle ids, and each new `started` event will increase the id, which significantly increases the chance of running out of ids, so it was kept as an 8-byte int.

Took advantage of requiring the usage of `INET6_NTOA` in all the controllers/views and optimized the clients table on the profile page to use `group by` instead of looping over all the peers.
 