### PR TITLE
(Update) History table

### DIFF
--- a/app/Http/Controllers/TorrentDownloadController.php
+++ b/app/Http/Controllers/TorrentDownloadController.php
@@ -42,7 +42,7 @@ class TorrentDownloadController extends Controller
             $user = User::where('rsskey', '=', $rsskey)->firstOrFail();
         }
         $torrent = Torrent::withAnyStatus()->findOrFail($id);
-        $hasHistory = $user->history()->where([['info_hash', '=', $torrent->info_hash], ['seeder', '=', 1]])->count();
+        $hasHistory = $user->history()->where([['torrent_id', '=', $torrent->id], ['seeder', '=', 1]])->count();
         // User's ratio is too low
         if ($user->getRatio() < \config('other.ratio') && ! ($torrent->user_id === $user->id || $hasHistory)) {
             return \to_route('torrent', ['id' => $torrent->id])

--- a/app/Jobs/ProcessAnnounce.php
+++ b/app/Jobs/ProcessAnnounce.php
@@ -152,7 +152,6 @@ class ProcessAnnounce implements ShouldQueue
 
         $history->user_id = $this->user->id;
         $history->torrent_id = $this->torrent->id;
-        $history->info_hash = $this->queries['info_hash'];
         $history->agent = $this->queries['user-agent'];
 
         switch ($event) {
@@ -161,11 +160,7 @@ class ProcessAnnounce implements ShouldQueue
                 $history->active = 1;
                 $history->seeder = (int) ($this->queries['left'] == 0);
                 $history->immune = $this->user->group->is_immune == 1;
-                $history->uploaded += 0;
-                $history->actual_uploaded += 0;
                 $history->client_uploaded = $realUploaded;
-                $history->downloaded += 0;
-                $history->actual_downloaded += 0;
                 $history->client_downloaded = $realDownloaded;
                 $history->save();
                 break;

--- a/app/Models/History.php
+++ b/app/Models/History.php
@@ -34,7 +34,6 @@ class History extends Model
      */
     protected $fillable = [
         'user_id',
-        'info_hash',
     ];
 
     /**

--- a/database/factories/HistoryFactory.php
+++ b/database/factories/HistoryFactory.php
@@ -18,7 +18,7 @@ class HistoryFactory extends Factory
         return [
             'user_id'           => fn () => User::factory()->create()->id,
             'agent'             => $this->faker->word(),
-            'info_hash'         => fn () => Torrent::factory()->create()->id,
+            'torrent_id'        => fn () => Torrent::factory()->create()->id,
             'uploaded'          => $this->faker->randomNumber(),
             'actual_uploaded'   => $this->faker->randomNumber(),
             'client_uploaded'   => $this->faker->randomNumber(),
@@ -32,7 +32,6 @@ class HistoryFactory extends Factory
             'hitrun'            => $this->faker->boolean(),
             'prewarn'           => $this->faker->boolean(),
             'completed_at'      => $this->faker->dateTime(),
-            'deleted_at'        => $this->faker->dateTime(),
         ];
     }
 }

--- a/database/migrations/2022_12_22_213142_update_history_table.php
+++ b/database/migrations/2022_12_22_213142_update_history_table.php
@@ -1,0 +1,45 @@
+<?php
+
+use App\Models\History;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        History::withoutGlobalScopes()
+            ->update([
+                'agent'             => DB::raw("COALESCE(agent, '')"),
+                'uploaded'          => DB::raw('COALESCE(uploaded, 0)'),
+                'actual_uploaded'   => DB::raw('COALESCE(actual_uploaded, 0)'),
+                'client_uploaded'   => DB::raw('COALESCE(client_uploaded, 0)'),
+                'downloaded'        => DB::raw('COALESCE(downloaded, 0)'),
+                'actual_downloaded' => DB::raw('COALESCE(actual_downloaded, 0)'),
+                'client_downloaded' => DB::raw('COALESCE(client_downloaded, 0)'),
+                'updated_at'        => DB::raw('updated_at'),
+            ]);
+        
+        Schema::table('history', function (Blueprint $table) {
+            $table->dropForeign(['info_hash']);
+            $table->dropIndex('info_hash');
+            $table->dropColumn('info_hash');
+
+            $table->string('agent', 64)->nullable(false)->change();
+            $table->unsignedBigInteger('uploaded')->nullable(false)->default('0')->change();
+            $table->unsignedBigInteger('actual_uploaded')->nullable(false)->default('0')->change();
+            $table->unsignedBigInteger('client_uploaded')->nullable(false)->change();
+            $table->unsignedBigInteger('downloaded')->nullable(false)->default('0')->change();
+            $table->unsignedBigInteger('actual_downloaded')->nullable(false)->default('0')->change();
+            $table->unsignedBigInteger('client_downloaded')->nullable(false)->change();
+            $table->boolean('seeder')->default(null)->change();
+            $table->boolean('active')->default('1')->change();
+            $table->boolean('immune')->default(null)->change();
+        });
+    }
+};


### PR DESCRIPTION
- Removes `info_hash` column, index, and foreign key (already uses torrent_id relation instead), removing 40 bytes per history (out of ~142 total).
- Defaults `uploaded`, `actual_uploaded`, `downloaded`, and `actual_downloaded` to `0`, since on the first announce, there should never be non-zero values since the peer hasn't been provided the peerlist yet.
- Disallows null on `client_uploaded`, `client_downloaded`: those values should always be known, and are validated for in the announce controller.
- Removes defaults on `seeder`, and `immune`, since those values should always be known before insertion.
- Defaults `active` to `1`, since if a history is being created, it is always considered a `started` event, and thus active.

In the future, `client_uploaded`, and `client_downloaded` should probably be removed as well, removing another 16 bytes per history. The only use case for these values are preventing a very simple bypassable cheat (which we already have other tools to detect), as well as for being able to continue a peer's session if their client disconnects for longer than the 2 hour peer expiry (caused by e.g. unstable internet). Note: this only helps if a user isn't seeding the torrent on multiple clients, otherwise only the value of the last client that announced is saved. Comparing with other trackers, Ocelot/Radiance doesn't handle this exceptional case at all. This can be fixed in the future by not deleting peers after 2 hours of no announces, but instead setting them as inactive and deleting them after no announces for e.g. 2 weeks (allows having no internet for 2 weeks and finally announcing the data uploaded/downloaded immediately before internet went down on the day it comes back. Otherwise, the announce isn't valid since no peer exists and the event is set to `started` and is assumed 0 bytes are uploaded/downloaded)