### PR TITLE
(Fix) Torrent model requests relationship

### DIFF
--- a/app/Models/Torrent.php
+++ b/app/Models/Torrent.php
@@ -191,11 +191,11 @@ class Torrent extends Model
     }
 
     /**
-     * Relationship To A Single Request.
+     * Relationship To Many Requests.
      */
-    public function request(): \Illuminate\Database\Eloquent\Relations\HasOne
+    public function requests(): \Illuminate\Database\Eloquent\Relations\HasMany
     {
-        return $this->hasOne(TorrentRequest::class);
+        return $this->hasMany(TorrentRequest::class);
     }
 
     /**


### PR DESCRIPTION
`->request()` isn't used anywhere, while `->requests()` is