### PR TITLE
(Update) Mass actions

### DIFF
--- a/app/Http/Requests/Staff/StoreMassActionRequest.php
+++ b/app/Http/Requests/Staff/StoreMassActionRequest.php
@@ -31,8 +31,8 @@ class StoreMassActionRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'subject' => 'required|string|min:5',
-            'message' => 'required|string|min:5',
+            'subject' => 'required|string|max:255',
+            'message' => 'required|string|max:65536',
         ];
     }
 }


### PR DESCRIPTION
The button to send the mass pm already has a confirmation dialog, so there shouldn't be any reason to require at least 5 characters in the subject and message body. However, it'd be a good idea to limit the subject and message body to the maximum length that the database can store.