### PR TITLE
(Update) Minimum bot command length

### DIFF
--- a/app/Http/Requests/Staff/UpdateChatBotRequest.php
+++ b/app/Http/Requests/Staff/UpdateChatBotRequest.php
@@ -31,8 +31,8 @@ class UpdateChatBotRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'name'     => 'required|min:3|max:255',
-            'command'  => 'required|alpha_dash|min:3|max:255',
+            'name'     => 'required|min:1|max:255',
+            'command'  => 'required|alpha_dash|min:1|max:255',
             'position' => 'required',
             'color'    => 'required',
             'icon'     => 'required',


### PR DESCRIPTION
Fixes a common CI error.

IMO, decreasing the minimum length makes more sense than changing the factory to make sure the word generated is at least 3 characters. It should be up to the tracker operator to decide the minimum length. If they want a 1-character long bot name and/or command, we shouldn't stop them.