### PR TITLE
(Fix) Rss foreign key constraint

### DIFF
--- a/app/Http/Controllers/Staff/RssController.php
+++ b/app/Http/Controllers/Staff/RssController.php
@@ -62,14 +62,13 @@ class RssController extends Controller
      */
     public function store(StoreRssRequest $request): \Illuminate\Http\RedirectResponse|\Illuminate\Http\Response
     {
-        $staff = $request->user();
+        $user = $request->user();
 
         $rss = new Rss();
         $rss->name = $request->name;
-        $rss->user_id = $staff->id;
+        $rss->user_id = $user->id;
         $rss->json_torrent = \array_merge($rss->expected_fields, $request->validated());
         $rss->is_private = 0;
-        $rss->staff_id = $staff->id;
         $rss->position = $request->position;
         $rss->save();
 

--- a/database/migrations/2023_02_03_094806_update_rss_table.php
+++ b/database/migrations/2023_02_03_094806_update_rss_table.php
@@ -1,0 +1,18 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('rss', function (Blueprint $table) {
+            $table->dropForeign(['staff_id']);
+            $table->dropColumn('staff_id');
+        });
+    }
+};


### PR DESCRIPTION
Potential fix for #2558.

Doesn't seem like the staff_id in the rss table is actually used for anything so should just be able to drop the column instead of making it nullable for private user rss feeds.