### PR TITLE
(Fix) Front-end validation for mal entry

### DIFF
--- a/resources/views/torrent/edit_torrent.blade.php
+++ b/resources/views/torrent/edit_torrent.blade.php
@@ -288,6 +288,7 @@
                             type="text"
                             value="{{ old('mal') ?? $torrent->mal }}"
                             x-bind:value="(cats[cat].type === 'movie' || cats[cat].type === 'tv') ? '{{ old('mal') ?? $torrent->mal }}' : '0'"
+                            x-bind:required="cats[cat].type === 'movie' || cats[cat].type === 'tv'"
                         >
                         <label class="form__label form__label--floating" for="mal">
                             MAL ID <b>({{ __('request.required') }} For Anime)</b>

--- a/resources/views/torrent/edit_torrent.blade.php
+++ b/resources/views/torrent/edit_torrent.blade.php
@@ -230,7 +230,6 @@
                             inputmode="numeric"
                             name="tmdb"
                             pattern="[0-9]*"
-                            required
                             type="text"
                             value="{{ old('tmdb') ?? $torrent->tmdb }}"
                             x-bind:value="(cats[cat].type === 'movie' || cats[cat].type === 'tv') ? '{{ old('tmdb') ?? $torrent->tmdb }}' : '0'"
@@ -248,7 +247,6 @@
                             inputmode="numeric"
                             name="imdb"
                             pattern="[0-9]*"
-                            required
                             type="text"
                             value="{{ old('imdb') ?? $torrent->imdb }}"
                             x-bind:value="(cats[cat].type === 'movie' || cats[cat].type === 'tv') ? '{{ old('imdb') ?? $torrent->imdb }}' : '0'"
@@ -266,7 +264,6 @@
                             inputmode="numeric"
                             name="tvdb"
                             pattern="[0-9]*"
-                            required
                             type="text"
                             value="{{ old('tvdb') ?? $torrent->tvdb }}"
                             x-bind:value="cats[cat].type === 'tv' ? '{{ old('tvdb') ?? $torrent->tvdb }}' : '0'"
@@ -284,7 +281,6 @@
                             inputmode="numeric"
                             name="mal"
                             pattern="[0-9]*"
-                            required
                             type="text"
                             value="{{ old('mal') ?? $torrent->mal }}"
                             x-bind:value="(cats[cat].type === 'movie' || cats[cat].type === 'tv') ? '{{ old('mal') ?? $torrent->mal }}' : '0'"
@@ -301,7 +297,6 @@
                         id="igdb"
                         class="form__text"
                         name="igdb"
-                        required
                         type="text"
                         value="{{ old('igdb') ?? $torrent->igdb }}"
                         inputmode="numeric"

--- a/resources/views/torrent/upload.blade.php
+++ b/resources/views/torrent/upload.blade.php
@@ -304,6 +304,7 @@
                                 inputmode="numeric"
                                 pattern="[0-9]*"
                                 x-bind:value="(cats[cat].type === 'movie' || cats[cat].type === 'tv') ? '{{ old('mal') }}' : '0'"
+                                x-bind:required="cats[cat].type === 'movie' || cats[cat].type === 'tv'"
                                 class="form__text"
                                 placeholder=""
                             >


### PR DESCRIPTION
Prevents infinite loop of forgetting mal, then forgetting to upload the torrent file, and repeat. Since files in forms are not able to be refilled after submission error, prevent the submission to begin with if the mal is incorrect.