### PR TITLE
(Update) Modals

### DIFF
--- a/resources/sass/components/_dialog.scss
+++ b/resources/sass/components/_dialog.scss
@@ -4,13 +4,15 @@
     border-radius: var(--dialog-border-radius);
     padding: 0;
     color: inherit;
-    max-height: calc(100% - 12px);
+    max-height: calc(100vh - 12px);
     overflow-y: auto;
     width: 500px;
-    max-width: calc(100% - 12px);
-    position: absolute;
-    left: calc(50% - min(500px / 2, (100% - 12px) / 2));
-    right: calc(50% - min(500px / 2, (100% - 12px) / 2));
+    max-width: calc(100vw - 12px);
+    position: fixed;
+    left: calc(50vw - min(500px / 2, (100vw - 12px) / 2));
+    right: calc(50vw - min(500px / 2, (100vw - 12px) / 2));
+    top: calc(50vh - (100vh - 12px) / 2);
+    bottom: calc(50vh - (100vh - 12px) / 2);
 }
 
 .dialog::backdrop {

--- a/resources/views/Staff/application/show.blade.php
+++ b/resources/views/Staff/application/show.blade.php
@@ -134,7 +134,7 @@
                                     <button class="form__button form__button--filled">
                                         {{ __('request.approve') }}
                                     </button>
-                                    <button x-on:click.prevent="$refs.dialog.close()" class="form__button form__button--outlined">
+                                    <button formmethod="dialog" formnovalidate class="form__button form__button--outlined">
                                         {{ __('common.cancel') }}
                                     </button>
                                 </p>
@@ -180,7 +180,7 @@
                                     <button class="form__button form__button--filled">
                                         {{ __('request.reject') }}
                                     </button>
-                                    <button x-on:click.prevent="$refs.dialog.close()" class="form__button form__button--outlined">
+                                    <button formmethod="dialog" formnovalidate class="form__button form__button--outlined">
                                         {{ __('common.cancel') }}
                                     </button>
                                 </p>

--- a/resources/views/Staff/application/show.blade.php
+++ b/resources/views/Staff/application/show.blade.php
@@ -100,14 +100,14 @@
         @else
             <h2 class="panel__heading">{{ __('common.action') }}</h2>
             <div class="panel__body">
-                    <div x-data="{ open: false }">
+                    <div>
                         <p class="form__group form__group--horizontal">
-                            <button class="form__button form__button--filled" x-on:click.stop="open = true; $refs.dialog.showModal();">
+                            <button class="form__button form__button--filled" x-on:click.stop="$refs.dialog.showModal()">
                                 <i class="{{ config('other.font-awesome') }} fa-check"></i>
                                 {{ __('request.approve') }}
                             </button>
                         </p>
-                        <dialog class="dialog" x-ref="dialog" x-show="open" x-cloak>
+                        <dialog class="dialog" x-ref="dialog">
                             <h3 class="dialog__heading">
                                 {{ __('request.approve') }}
                                 {{ __('common.this') }}
@@ -117,7 +117,7 @@
                                 class="dialog__form"
                                 method="POST"
                                 action="{{ route('staff.applications.approve', ['id' => $application->id]) }}"
-                                x-on:click.outside="open = false; $refs.dialog.close();"
+                                x-on:click.outside="$refs.dialog.close()"
                             >
                                 @csrf
                                 <input
@@ -134,21 +134,21 @@
                                     <button class="form__button form__button--filled">
                                         {{ __('request.approve') }}
                                     </button>
-                                    <button x-on:click.prevent="open = false; $refs.dialog.close();" class="form__button form__button--outlined">
+                                    <button x-on:click.prevent="$refs.dialog.close()" class="form__button form__button--outlined">
                                         {{ __('common.cancel') }}
                                     </button>
                                 </p>
                             </form>
                         </dialog>
                     </div>
-                    <div x-data="{ open: false }">
+                    <div x-data>
                         <p class="form__group form__group--horizontal">
-                            <button class="form__button form__button--filled" x-on:click.stop="open = true; $refs.dialog.showModal();">
+                            <button class="form__button form__button--filled" x-on:click.stop="$refs.dialog.showModal()">
                                 <i class="{{ config('other.font-awesome') }} fa-times"></i>
                                 {{ __('request.reject') }}
                             </button>
                         </p>
-                        <dialog class="dialog" x-ref="dialog" x-show="open" x-cloak>
+                        <dialog class="dialog" x-ref="dialog">
                             <h3 class="dialog__heading">
                                 {{ __('request.reject') }}
                                 {{ __('common.this') }}
@@ -158,7 +158,7 @@
                                 class="dialog__form"
                                 method="POST"
                                 action="{{ route('staff.applications.reject', ['id' => $application->id]) }}"
-                                x-on:click.outside="open = false; $refs.dialog.close();"
+                                x-on:click.outside="$refs.dialog.close()"
                             >
                                 @csrf
                                 <input
@@ -180,7 +180,7 @@
                                     <button class="form__button form__button--filled">
                                         {{ __('request.reject') }}
                                     </button>
-                                    <button x-on:click.prevent="open = false; $refs.dialog.close();" class="form__button form__button--outlined">
+                                    <button x-on:click.prevent="$refs.dialog.close()" class="form__button form__button--outlined">
                                         {{ __('common.cancel') }}
                                     </button>
                                 </p>

--- a/resources/views/Staff/moderation/partials/_delete_dialog.blade.php
+++ b/resources/views/Staff/moderation/partials/_delete_dialog.blade.php
@@ -1,9 +1,9 @@
-<li class="data-table__action" x-data="{ open: false }">
-    <button class="form__button form__button--filled" x-on:click.stop="open = true; $refs.dialog.showModal();">
+<li class="data-table__action" x-data>
+    <button class="form__button form__button--filled" x-on:click.stop="$refs.dialog.showModal()">
         <i class="{{ config('other.font-awesome') }} fa-thumbs-down"></i>
         {{ __('common.delete') }}
     </button>
-    <dialog class="dialog" x-ref="dialog" x-show="open" x-cloak>
+    <dialog class="dialog" x-ref="dialog">
         <h4 class="dialog__heading">
             {{ __('common.delete') }} {{ __('torrent.torrent') }}: {{ $torrent->name }}
         </h4>
@@ -11,7 +11,7 @@
             class="dialog__form"
             method="POST"
             action="{{ route('delete') }}"
-            x-on:click.outside="open = false; $refs.dialog.close();"
+            x-on:click.outside="$refs.dialog.close()"
         >
             @csrf
             <p class="form__group">
@@ -26,7 +26,7 @@
                 <button class="form__button form__button--filled">
                     {{ __('common.delete') }}
                 </button>
-                <button x-on:click.prevent="open = false; $refs.dialog.close();" class="form__button form__button--outlined">
+                <button x-on:click.prevent="$refs.dialog.close()" class="form__button form__button--outlined">
                     {{ __('common.cancel') }}
                 </button>
             </p>

--- a/resources/views/Staff/moderation/partials/_delete_dialog.blade.php
+++ b/resources/views/Staff/moderation/partials/_delete_dialog.blade.php
@@ -26,7 +26,7 @@
                 <button class="form__button form__button--filled">
                     {{ __('common.delete') }}
                 </button>
-                <button x-on:click.prevent="$refs.dialog.close()" class="form__button form__button--outlined">
+                <button formmethod="dialog" formnovalidate class="form__button form__button--outlined">
                     {{ __('common.cancel') }}
                 </button>
             </p>

--- a/resources/views/Staff/moderation/partials/_postpone_dialog.blade.php
+++ b/resources/views/Staff/moderation/partials/_postpone_dialog.blade.php
@@ -1,9 +1,9 @@
-<li class="data-table__action" x-data="{ open: false }">
-    <button class="form__button form__button--filled" x-on:click.stop="open = true; $refs.dialog.showModal();">
+<li class="data-table__action" x-data>
+    <button class="form__button form__button--filled" x-on:click.stop="$refs.dialog.showModal()">
         <i class="{{ config('other.font-awesome') }} fa-pause"></i>
         {{ __('common.moderation-postpone') }}
     </button>
-    <dialog class="dialog" x-ref="dialog" x-show="open" x-cloak>
+    <dialog class="dialog" x-ref="dialog">
         <h4 class="dialog__heading">
             {{ __('common.moderation-postpone') }} {{ __('torrent.torrent') }}: {{ $torrent->name }}
         </h4>
@@ -11,7 +11,7 @@
             class="dialog__form"
             method="POST"
             action="{{ route('staff.moderation.update', ['id' => $torrent->id]) }}"
-            x-on:click.outside="open = false; $refs.dialog.close();"
+            x-on:click.outside="$refs.dialog.close()"
         >
             @csrf
             <input type="hidden" name="type" value="{{ __('torrent.torrent') }}">
@@ -26,7 +26,7 @@
                 <button class="form__button form__button--filled">
                     {{ __('common.moderation-postpone') }}
                 </button>
-                <button class="form__button form__button--outlined" x-on:click.prevent="open = false; $refs.dialog.close()">
+                <button class="form__button form__button--outlined" x-on:click.prevent="$refs.dialog.close()">
                     {{ __('common.cancel') }}
                 </button>
             </p>

--- a/resources/views/Staff/moderation/partials/_postpone_dialog.blade.php
+++ b/resources/views/Staff/moderation/partials/_postpone_dialog.blade.php
@@ -26,7 +26,7 @@
                 <button class="form__button form__button--filled">
                     {{ __('common.moderation-postpone') }}
                 </button>
-                <button class="form__button form__button--outlined" x-on:click.prevent="$refs.dialog.close()">
+                <button formmethod="dialog" formnovalidate class="form__button form__button--outlined">
                     {{ __('common.cancel') }}
                 </button>
             </p>

--- a/resources/views/Staff/moderation/partials/_reject_dialog.blade.php
+++ b/resources/views/Staff/moderation/partials/_reject_dialog.blade.php
@@ -26,7 +26,7 @@
                 <button class="form__button form__button--filled">
                     {{ __('common.moderation-reject') }}
                 </button>
-                <button x-on:click.prevent="$refs.dialog.close()" class="form__button form__button--outlined">
+                <button formmethod="dialog" formnovalidate class="form__button form__button--outlined">
                     {{ __('common.cancel') }}
                 </button>
             </p>

--- a/resources/views/Staff/moderation/partials/_reject_dialog.blade.php
+++ b/resources/views/Staff/moderation/partials/_reject_dialog.blade.php
@@ -1,9 +1,9 @@
-<li class="data-table__action" x-data="{ open: false }">
-    <button class="form__button form__button--filled" x-on:click.stop="open = true; $refs.dialog.showModal();">
+<li class="data-table__action" x-data>
+    <button class="form__button form__button--filled" x-on:click.stop="$refs.dialog.showModal()">
         <i class="{{ config('other.font-awesome') }} fa-thumbs-down"></i>
         {{ __('common.moderation-reject') }}
     </button>
-    <dialog class="dialog" x-ref="dialog" x-show="open" x-cloak>
+    <dialog class="dialog" x-ref="dialog">
         <h3 class="dialog__heading">
             {{ __('common.moderation-reject') }} {{ __('torrent.torrent') }}: {{ $torrent->name }}
         </h3>
@@ -11,7 +11,7 @@
             class="dialog__form"
             method="POST"
             action="{{ route("staff.moderation.update", ['id' => $torrent->id]) }}"
-            x-on:click.outside="open = false; $refs.dialog.close();"
+            x-on:click.outside="$refs.dialog.close()"
         >
             @csrf
             <input id="type" type="hidden" name="type" value="{{ __('torrent.torrent') }}">
@@ -26,7 +26,7 @@
                 <button class="form__button form__button--filled">
                     {{ __('common.moderation-reject') }}
                 </button>
-                <button x-on:click.prevent="open = false; $refs.dialog.close();" class="form__button form__button--outlined">
+                <button x-on:click.prevent="$refs.dialog.close()" class="form__button form__button--outlined">
                     {{ __('common.cancel') }}
                 </button>
             </p>

--- a/resources/views/Staff/region/index.blade.php
+++ b/resources/views/Staff/region/index.blade.php
@@ -97,7 +97,7 @@
                                                 <button class="form__button form__button--filled">
                                                     {{ __('common.delete') }}
                                                 </button>
-                                                <button class="form__button form__button--outlined" x-on:click.prevent="$refs.dialog.close()">
+                                                <button formmethod="dialog" formnovalidate class="form__button form__button--outlined">
                                                     {{ __('common.cancel') }}
                                                 </button>
                                             </p>

--- a/resources/views/Staff/region/index.blade.php
+++ b/resources/views/Staff/region/index.blade.php
@@ -54,8 +54,8 @@
                                         {{ __('common.edit') }}
                                     </a>
                                 </li>
-                                <li class="data-table__action" x-data="{ open: false }">
-                                    <button class="form__button form__button--text" x-on:click.stop="open = true; $refs.dialog.showModal();">
+                                <li class="data-table__action" x-data>
+                                    <button class="form__button form__button--text" x-on:click.stop="$refs.dialog.showModal()">
                                         {{ __('common.delete') }}
                                     </button>
                                     <dialog class="dialog" x-ref="dialog">
@@ -66,7 +66,7 @@
                                             class="dialog__form"
                                             method="POST"
                                             action="{{ route('staff.regions.destroy', ['id' => $region->id]) }}"
-                                            x-on:click.outside="open = false; $refs.dialog.close();"
+                                            x-on:click.outside="$refs.dialog.close()"
                                         >
                                             @csrf
                                             @method('DELETE')
@@ -97,7 +97,7 @@
                                                 <button class="form__button form__button--filled">
                                                     {{ __('common.delete') }}
                                                 </button>
-                                                <button class="form__button form__button--outlined" x-on:click.prevent="open = false; $refs.dialog.close();">
+                                                <button class="form__button form__button--outlined" x-on:click.prevent="$refs.dialog.close()">
                                                     {{ __('common.cancel') }}
                                                 </button>
                                             </p>

--- a/resources/views/playlist/show.blade.php
+++ b/resources/views/playlist/show.blade.php
@@ -16,12 +16,12 @@
         <section class="panelV2">
             <h2 class="panel__heading">{{ __('common.actions') }}</h2>
             <div class="panel__body">
-                <div class="form__group form__group--horizontal" x-data="{ open: false }">
-                    <button class="form__button form__button--filled form__button--centered" x-on:click.stop="open = true; $refs.dialog.showModal();">
+                <div class="form__group form__group--horizontal" x-data>
+                    <button class="form__button form__button--filled form__button--centered" x-on:click.stop="$refs.dialog.showModal()">
                         <i class="{{ config('other.font-awesome') }} fa-search-plus"></i>
                         {{ __('playlist.add-torrent') }}
                     </button>
-                    <dialog class="dialog" x-ref="dialog" x-show="open" x-cloak>
+                    <dialog class="dialog" x-ref="dialog">
                         <h4 class="dialog__heading">
                             {{ __('playlist.add-to-playlist') }}
                         </h4>
@@ -29,7 +29,7 @@
                             class="dialog__form"
                             method="POST"
                             action="{{ route('playlists.attach') }}"
-                            x-on:click.outside="open = false; $refs.dialog.close();"
+                            x-on:click.outside="$refs.dialog.close()"
                         >
                             @csrf
                             <p class="form__group">
@@ -49,7 +49,7 @@
                                 <button class="form__button form__button--filled">
                                     {{ __('common.add') }}
                                 </button>
-                                <button x-on:click.prevent="open = false; $refs.dialog.close();" class="form__button form__button--outlined">
+                                <button x-on:click.prevent="$refs.dialog.close()" class="form__button form__button--outlined">
                                     {{ __('common.cancel') }}
                                 </button>
                             </p>

--- a/resources/views/playlist/show.blade.php
+++ b/resources/views/playlist/show.blade.php
@@ -49,7 +49,7 @@
                                 <button class="form__button form__button--filled">
                                     {{ __('common.add') }}
                                 </button>
-                                <button x-on:click.prevent="$refs.dialog.close()" class="form__button form__button--outlined">
+                                <button formmethod="dialog" formnovalidate class="form__button form__button--outlined">
                                     {{ __('common.cancel') }}
                                 </button>
                             </p>

--- a/resources/views/requests/partials/claim.blade.php
+++ b/resources/views/requests/partials/claim.blade.php
@@ -30,7 +30,7 @@
                 <button class="form__button form__button--filled">
                     {{ __('request.claim-now') }}
                 </button>
-                <button x-on:click.prevent="$refs.dialog.close()" class="form__button form__button--outlined">
+                <button formmethod="dialog" formnovalidate class="form__button form__button--outlined">
                     {{ __('common.cancel') }}
                 </button>
             </p>

--- a/resources/views/requests/partials/claim.blade.php
+++ b/resources/views/requests/partials/claim.blade.php
@@ -1,8 +1,8 @@
-<div class="form__group form__group--short-horizontal" x-data="{ open: false }">
-    <button class="form__button form__button--filled form__button--centered" x-on:click.stop="open = true; $refs.dialog.showModal();">
+<div class="form__group form__group--short-horizontal" x-data>
+    <button class="form__button form__button--filled form__button--centered" x-on:click.stop="$refs.dialog.showModal()">
         {{ __('request.claim') }}
     </button>
-    <dialog class="dialog" x-ref="dialog" x-show="open" x-cloak>
+    <dialog class="dialog" x-ref="dialog">
         <h3 class="dialog__heading">
             {{ __('request.claim') }}
         </h3>
@@ -10,7 +10,7 @@
             class="dialog__form"
             method="POST"
             action="{{ route("claimRequest", ['id' => $torrentRequest->id]) }}"
-            x-on:click.outside="open = false; $refs.dialog.close();"
+            x-on:click.outside="$refs.dialog.close()"
         >
             @csrf
             <p class="form__group">
@@ -30,7 +30,7 @@
                 <button class="form__button form__button--filled">
                     {{ __('request.claim-now') }}
                 </button>
-                <button x-on:click.prevent="open = false; $refs.dialog.close();" class="form__button form__button--outlined">
+                <button x-on:click.prevent="$refs.dialog.close()" class="form__button form__button--outlined">
                     {{ __('common.cancel') }}
                 </button>
             </p>

--- a/resources/views/requests/partials/fulfill.blade.php
+++ b/resources/views/requests/partials/fulfill.blade.php
@@ -1,8 +1,8 @@
-<div class="form__group form__group--short-horizontal" x-data="{ open: false }">
-    <button class="form__button form__button--filled form__button--centered" x-on:click.stop="open = true; $refs.dialog.showModal();">
+<div class="form__group form__group--short-horizontal" x-data>
+    <button class="form__button form__button--filled form__button--centered" x-on:click.stop="$refs.dialog.showModal()">
         {{ __('request.fulfill') }}
     </button>
-    <dialog class="dialog" x-ref="dialog" x-show="open" x-cloak>
+    <dialog class="dialog" x-ref="dialog">
         <h3 class="dialog__heading">
             {{ __('request.fill-request') }}
         </h3>
@@ -10,7 +10,7 @@
             class="dialog__form"
             method="POST"
             action="{{ route("fill_request", ['id' => $torrentRequest->id]) }}"
-            x-on:click.outside="open = false; $refs.dialog.close();"
+            x-on:click.outside="$refs.dialog.close()"
         >
             @csrf
             <input id="type" type="hidden" name="request_id" value="{{ $torrentRequest->id }}">
@@ -43,7 +43,7 @@
                 <button class="form__button form__button--filled">
                     {{ __('request.fulfill') }}
                 </button>
-                <button x-on:click.prevent="open = false; $refs.dialog.close();" class="form__button form__button--outlined">
+                <button x-on:click.prevent="$refs.dialog.close()" class="form__button form__button--outlined">
                     {{ __('common.cancel') }}
                 </button>
             </p>

--- a/resources/views/requests/partials/fulfill.blade.php
+++ b/resources/views/requests/partials/fulfill.blade.php
@@ -43,7 +43,7 @@
                 <button class="form__button form__button--filled">
                     {{ __('request.fulfill') }}
                 </button>
-                <button x-on:click.prevent="$refs.dialog.close()" class="form__button form__button--outlined">
+                <button formmethod="dialog" formnovalidate class="form__button form__button--outlined">
                     {{ __('common.cancel') }}
                 </button>
             </p>

--- a/resources/views/requests/partials/report.blade.php
+++ b/resources/views/requests/partials/report.blade.php
@@ -1,8 +1,8 @@
-<div class="form__group form__group--short-horizontal" x-data="{ open: false }">
-    <button class="form__button form__button--filled form__button--centered" x-on:click.stop="open = true; $refs.dialog.showModal();">
+<div class="form__group form__group--short-horizontal" x-data>
+    <button class="form__button form__button--filled form__button--centered" x-on:click.stop="$refs.dialog.showModal()">
         {{ __('common.report') }}
     </button>
-    <dialog class="dialog" x-ref="dialog" x-show="open" x-cloak>
+    <dialog class="dialog" x-ref="dialog">
         <h3 class="dialog__heading">
             {{ __('request.report') }}: {{ $torrentRequest->name }}</h4>
         </h3>
@@ -10,7 +10,7 @@
             class="dialog__form"
             method="POST"
             action="{{ route("report_request", ['id' => $torrentRequest->id]) }}"
-            x-on:click.outside="open = false; $refs.dialog.close();"
+            x-on:click.outside="$refs.dialog.close()"
         >
             @csrf
             <input id="type" type="hidden" name="title" value="{{ $torrentRequest->name }}">
@@ -36,7 +36,7 @@
                 >
                     {{ __('request.report') }}
                 </button>
-                <button x-on:click.prevent="open = false; $refs.dialog.close();" class="form__button form__button--outlined">
+                <button x-on:click.prevent="$refs.dialog.close()" class="form__button form__button--outlined">
                     {{ __('common.cancel') }}
                 </button>
             </p>

--- a/resources/views/requests/partials/report.blade.php
+++ b/resources/views/requests/partials/report.blade.php
@@ -36,7 +36,7 @@
                 >
                     {{ __('request.report') }}
                 </button>
-                <button x-on:click.prevent="$refs.dialog.close()" class="form__button form__button--outlined">
+                <button formmethod="dialog" formnovalidate class="form__button form__button--outlined">
                     {{ __('common.cancel') }}
                 </button>
             </p>

--- a/resources/views/requests/partials/vote.blade.php
+++ b/resources/views/requests/partials/vote.blade.php
@@ -51,7 +51,7 @@
                 >
                     {{ __('request.vote') }}
                 </button>
-                <button x-on:click.prevent="$refs.dialog.close()" class="form__button form__button--outlined">
+                <button formmethod="dialog" formnovalidate class="form__button form__button--outlined">
                     {{ __('common.cancel') }}
                 </button>
             </p>

--- a/resources/views/requests/partials/vote.blade.php
+++ b/resources/views/requests/partials/vote.blade.php
@@ -1,8 +1,8 @@
-<div class="form__group form__group--short-horizontal" x-data="{ open: false }">
-    <button class="form__button form__button--filled form__button--centered" x-on:click.stop="open = true; $refs.dialog.showModal();">
+<div class="form__group form__group--short-horizontal" x-data>
+    <button class="form__button form__button--filled form__button--centered" x-on:click.stop="$refs.dialog.showModal()">
         {{ __('request.vote') }}
     </button>
-    <dialog class="dialog" x-ref="dialog" x-show="open" x-cloak>
+    <dialog class="dialog" x-ref="dialog">
         <h3 class="dialog__heading">
             {{ __('request.vote-that') }}
         </h3>
@@ -10,7 +10,7 @@
             class="dialog__form"
             method="POST"
             action="{{ route("add_votes", ['id' => $torrentRequest->id]) }}"
-            x-on:click.outside="open = false; $refs.dialog.close();"
+            x-on:click.outside="$refs.dialog.close()"
         >
             @csrf
             <input id="type" type="hidden" name="request_id" value="{{ $torrentRequest->id }}">
@@ -51,7 +51,7 @@
                 >
                     {{ __('request.vote') }}
                 </button>
-                <button x-on:click.prevent="open = false; $refs.dialog.close();" class="form__button form__button--outlined">
+                <button x-on:click.prevent="$refs.dialog.close()" class="form__button form__button--outlined">
                     {{ __('common.cancel') }}
                 </button>
             </p>

--- a/resources/views/user/seedbox/index.blade.php
+++ b/resources/views/user/seedbox/index.blade.php
@@ -26,11 +26,11 @@
         <header class="panel__header">
             <h2 class="panel__heading">{{ __('user.seedboxes') }}</h2>
             <div class="panel__actions">
-                <div class="panel__action" x-data="{ open: false }">
-                    <button class="form__button form__button--text" x-on:click.stop="open = true; $refs.dialog.showModal();">
+                <div class="panel__action" x-data>
+                    <button class="form__button form__button--text" x-on:click.stop="$refs.dialog.showModal()">
                         {{ __(('common.add')) }}
                     </button>
-                    <dialog class="dialog" x-ref="dialog" x-show="open" x-cloak>
+                    <dialog class="dialog" x-ref="dialog">
                         <h3 class="dialog__heading">
                             {{ __('user.add-seedbox') }}
                         </h3>
@@ -38,7 +38,7 @@
                             class="dialog__form"
                             method="POST"
                             action="{{ route('seedboxes.store', ['username' => $user->username]) }}"
-                            x-on:click.outside="open = false; $refs.dialog.close();"
+                            x-on:click.outside="$refs.dialog.close()"
                         >
                             @csrf
                             <p class="form__group">
@@ -70,7 +70,7 @@
                                 <button class="form__button form__button--filled">
                                     {{ __('common.submit') }}
                                 </button>
-                                <button x-on:click.prevent="open = false; $refs.dialog.close();" class="form__button form__button--outlined">
+                                <button x-on:click.prevent="$refs.dialog.close()" class="form__button form__button--outlined">
                                     {{ __('common.cancel') }}
                                 </button>
                             </p>

--- a/resources/views/user/seedbox/index.blade.php
+++ b/resources/views/user/seedbox/index.blade.php
@@ -70,7 +70,7 @@
                                 <button class="form__button form__button--filled">
                                     {{ __('common.submit') }}
                                 </button>
-                                <button x-on:click.prevent="$refs.dialog.close()" class="form__button form__button--outlined">
+                                <button formmethod="dialog" formnovalidate class="form__button form__button--outlined">
                                     {{ __('common.cancel') }}
                                 </button>
                             </p>


### PR DESCRIPTION
- Make sure modals are centered on the viewport, that way if you're scrolled down on the page, you don't have to scroll back up to see the modal.
- Also revert #2379. It's time to move on.
- Use html attributes instead of js for closing the modal.