### PR TITLE
(Fix) Clean torrent files

### DIFF
--- a/app/Http/Controllers/PlaylistController.php
+++ b/app/Http/Controllers/PlaylistController.php
@@ -275,9 +275,6 @@ class PlaylistController extends Controller
                 // Set the announce key and add the user passkey
                 $dict['announce'] = $announceUrl;
 
-                // Remove multi-tracker announce url possibly still stored by legacy upload system
-                unset($dict['announce-list']);
-
                 // Set link to torrent as the comment
                 if (config('torrent.comment')) {
                     $dict['comment'] = config('torrent.comment').'. '.route('torrent', ['id' => $torrent->id]);

--- a/app/Http/Controllers/TorrentDownloadController.php
+++ b/app/Http/Controllers/TorrentDownloadController.php
@@ -84,9 +84,6 @@ class TorrentDownloadController extends Controller
                 // Set the announce key and add the user passkey
                 $dict['announce'] = route('announce', ['passkey' => $user->passkey]);
 
-                // Remove multi-tracker announce url possibly still stored by legacy upload system
-                unset($dict['announce-list']);
-
                 // Set link to torrent as the comment
                 if (config('torrent.comment')) {
                     $dict['comment'] = config('torrent.comment').'. '.route('torrent', ['id' => $id]);

--- a/app/Http/Controllers/User/TorrentZipController.php
+++ b/app/Http/Controllers/User/TorrentZipController.php
@@ -60,9 +60,6 @@ class TorrentZipController extends Controller
                 // Set the announce key and add the user passkey
                 $dict['announce'] = $announceUrl;
 
-                // Remove multi-tracker announce url possibly still stored by legacy upload system
-                unset($dict['announce-list']);
-
                 // Set link to torrent as the comment
                 if (config('torrent.comment')) {
                     $dict['comment'] = config('torrent.comment').'. '.route('torrent', ['id' => $torrent->id]);

--- a/database/migrations/2023_02_09_113903_clean_torrent_files.php
+++ b/database/migrations/2023_02_09_113903_clean_torrent_files.php
@@ -1,0 +1,39 @@
+<?php
+
+use App\Helpers\Bencode;
+use App\Models\Torrent;
+use Illuminate\Database\Migrations\Migration;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        $directory = public_path().'/files/torrents/';
+
+        Torrent::select('file_name')->orderBy('id')->chunk(100, function ($torrents) use ($directory): void {
+            foreach ($torrents as $torrent) {
+                $dict = Bencode::bdecode_file($directory.$torrent->file_name);
+
+                // Whitelisted keys
+                $dict = array_intersect_key($dict, [
+                    'announce'   => '',
+                    'comment'    => '',
+                    'created by' => '',
+                    'encoding'   => '',
+                    'info'       => '',
+                ]);
+
+                $dict['announce'] = config('app.url').'/announce/PID';
+
+                $comment = config('torrent.comment', null);
+                if ($comment !== null) {
+                    $result['comment'] = $comment;
+                }
+
+                file_put_contents($directory.$torrent->file_name, Bencode::bencode($dict));
+            }
+        });
+    }
+};


### PR DESCRIPTION
We didn't used to always clean torrent files on upload, but only on download. Let's make sure all previous torrent files are properly cleaned.