### PR TITLE
(Fix) Mediahub entries where no torrents exist

### DIFF
--- a/app/Http/Controllers/MediaHub/CollectionController.php
+++ b/app/Http/Controllers/MediaHub/CollectionController.php
@@ -31,7 +31,7 @@ class CollectionController extends Controller
      */
     public function show(int $id): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
     {
-        $collection = Collection::with(['movie', 'comments'])->findOrFail($id);
+        $collection = Collection::with(['movie' => fn ($query) => $query->has('torrents'), 'comments'])->findOrFail($id);
 
         return view('mediahub.collection.show', [
             'collection' => $collection,

--- a/app/Http/Controllers/MediaHub/CompanyController.php
+++ b/app/Http/Controllers/MediaHub/CompanyController.php
@@ -32,8 +32,8 @@ class CompanyController extends Controller
     public function show(int $id): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
     {
         $company = Company::withCount('tv', 'movie')->findOrFail($id);
-        $shows = $company->tv()->oldest('name')->paginate(25, ['*'], 'showsPage');
-        $movies = $company->movie()->oldest('title')->paginate(25, ['*'], 'moviesPage');
+        $shows = $company->tv()->has('torrents')->oldest('name')->paginate(25, ['*'], 'showsPage');
+        $movies = $company->movie()->has('torrents')->oldest('title')->paginate(25, ['*'], 'moviesPage');
 
         return view('mediahub.company.show', [
             'company' => $company,

--- a/app/Http/Controllers/MediaHub/GenreController.php
+++ b/app/Http/Controllers/MediaHub/GenreController.php
@@ -34,8 +34,8 @@ class GenreController extends Controller
     public function show(int $id): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
     {
         $genre = Genre::withCount(['tv', 'movie'])->findOrFail($id);
-        $shows = $genre->tv()->oldest('name')->paginate(25, ['*'], 'showsPage');
-        $movies = $genre->movie()->oldest('title')->paginate(25, ['*'], 'moviesPage');
+        $shows = $genre->tv()->has('torrents')->oldest('name')->paginate(25, ['*'], 'showsPage');
+        $movies = $genre->movie()->has('torrents')->oldest('title')->paginate(25, ['*'], 'moviesPage');
 
         return view('mediahub.genre.show', [
             'genre'  => $genre,

--- a/app/Http/Controllers/MediaHub/NetworkController.php
+++ b/app/Http/Controllers/MediaHub/NetworkController.php
@@ -32,7 +32,7 @@ class NetworkController extends Controller
     public function show(int $id): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
     {
         $network = Network::withCount('tv')->findOrFail($id);
-        $shows = $network->tv()->oldest('name')->paginate(25);
+        $shows = $network->tv()->has('torrents')->oldest('name')->paginate(25);
 
         return view('mediahub.network.show', [
             'network' => $network,

--- a/app/Http/Controllers/MediaHub/PersonController.php
+++ b/app/Http/Controllers/MediaHub/PersonController.php
@@ -31,8 +31,12 @@ class PersonController extends Controller
      */
     public function show(int $id): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
     {
-        $person = Person::findOrFail($id);
-        $person->load(['tv', 'tv.genres', 'movie', 'movie.genres']);
+        $person = Person::with([
+            'tv' => fn ($query) => $query->has('torrents'),
+            'tv.genres',
+            'movie' => fn ($query) => $query->has('torrents'),
+            'movie.genres'
+        ])->findOrFail($id);
 
         return view('mediahub.person.show', ['person' => $person]);
     }


### PR DESCRIPTION
Don't show movies/tv that don't have any related torrents.