### PR TITLE
(Refactor) User resurrections one less query

### DIFF
--- a/resources/views/livewire/user-resurrections.blade.php
+++ b/resources/views/livewire/user-resurrections.blade.php
@@ -109,10 +109,8 @@
                                 {{ $resurrection->created_at->diffForHumans() }}
                             </td>
                             <td>
-                                @php $torrent = App\Models\Torrent::where('id', '=',
-                                    $resurrection->torrent_id)->pluck('id') @endphp
                                 @php $history = App\Models\History::select(['seedtime'])->where('user_id', '=',
-                                    $user->id)->where('torrent_id', '=', $torrent)->first() @endphp
+                                    $user->id)->where('torrent_id', '=', $resurrection->torrent_id)->first() @endphp
                                 {{ empty($history) ? '0' : App\Helpers\StringHelper::timeElapsed($history->seedtime) }}
                             </td>
                             <td>


### PR DESCRIPTION
We already have the torrent object, so we don't need to query for it again.