### PR TITLE
(Fix) Form element adjustments

### DIFF
--- a/resources/sass/components/form/select.scss
+++ b/resources/sass/components/form/select.scss
@@ -15,6 +15,10 @@
 
 .form__select {
     background-color: inherit !important; /* !important can be removed once site-wide `select` styling is removed */
+    background: var(--select-icon);
+    background-size: 16px;
+    background-position: calc(100% - 12px) center;
+    background-repeat: no-repeat;
     border: var(--select-border);
     border-radius: 5px;
     color: var(--select-fg);
@@ -23,8 +27,9 @@
     height: 40px;
     max-width: 100%;
     outline: none;
-    padding: 12px;
+    padding: var(--select-padding);
     width: 100%;
+    appearance: none;
 
     @media screen and (prefers-reduced-motion: no-preference) {
         transition: border-color 600ms cubic-bezier(0.25, 0.8, 0.25, 1), height 600ms cubic-bezier(0.25, 0.8, 0.25, 1);
@@ -32,11 +37,13 @@
 
     &:hover {
         border: var(--select-border-hover);
+        padding: var(--select-padding-hover);
     }
 
     &:focus,
     &:focus:hover {
         border: var(--select-border-active);
+        padding: var(--select-padding-active);
 
         & + .form__label--floating {
             top: -3px;

--- a/resources/sass/components/form/text.scss
+++ b/resources/sass/components/form/text.scss
@@ -20,7 +20,7 @@
     height: 40px;
     max-width: 100%;
     outline: none;
-    padding: 12px;
+    padding: var(--input-text-padding);
     width: 100%;
 
     @media screen and (prefers-reduced-motion: no-preference) {
@@ -29,11 +29,13 @@
 
     &:hover {
         border: var(--input-text-border-hover);
+        padding: var(--input-text-padding-hover);
     }
 
     &:focus,
     &:focus:hover {
         border: var(--input-text-border-active);
+        padding: var(--input-text-padding-active);
 
         & + .form__label--floating {
             top: -3px;

--- a/resources/sass/components/form/textarea.scss
+++ b/resources/sass/components/form/textarea.scss
@@ -20,7 +20,7 @@
     height: 40px;
     max-width: 100%;
     outline: none;
-    padding: 12px;
+    padding: var(--textarea-padding);
     width: 100%;
 
     @media screen and (prefers-reduced-motion: no-preference) {
@@ -29,11 +29,13 @@
 
     &:hover {
         border: var(--textarea-border-hover);
+        padding: var(--textarea-padding-hover);
     }
 
     &:focus,
     &:focus:hover {
         border: var(--textarea-border-active);
+        padding: var(--textarea-padding-active);
         height: 140px;
 
         & ~ .form__label--floating {

--- a/resources/sass/main/_custom.scss
+++ b/resources/sass/main/_custom.scss
@@ -85,6 +85,9 @@
     --input-text-border-hover: 2px solid #999;
     --input-text-border-radius: 5px;
     --input-text-fg: #444;
+    --input-text-padding: 12px;
+    --input-text-padding-active: 11px;
+    --input-text-padding-hover: 11px;
 
     --key-value-even-bg: #e2e2e2;
     --key-value-fg: inherit;
@@ -140,6 +143,10 @@
     --select-border-hover: 2px solid #999;
     --select-border-radius: 5px;
     --select-fg: #444;
+    --select-icon: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'><path fill='%23444' d='M6 8l-1 1l5 5l5-5l-1-1l-4 4l-4-4z'/></svg>");
+    --select-padding: 11px;
+    --select-padding-active: 10px;
+    --select-padding-hover: 10px;
 
     --subforum-listing-odd-bg: #ddd;
     --subforum-listing-even-bg: transparent;
@@ -150,6 +157,9 @@
     --textarea-border-hover: 2px solid #999;
     --textarea-border-radius: 5px;
     --textarea-fg: #444;
+    --textarea-padding: 12px;
+    --textarea-padding-active: 11px;
+    --textarea-padding-hover: 11px;
 
     --torrent-card-bg: #e2e2e2;
     --torrent-card-fg: inherit;

--- a/resources/sass/themes/cosmic-void.scss
+++ b/resources/sass/themes/cosmic-void.scss
@@ -77,6 +77,9 @@
     --input-text-border-hover: 2px solid #999;
     --input-text-border-radius: 5px;
     --input-text-fg: #bbb;
+    --input-text-padding: 12px;
+    --input-text-padding-active: 11px;
+    --input-text-padding-hover: 11px;
 
     --key-value-even-bg: #222;
     --key-value-fg: inherit;
@@ -132,6 +135,10 @@
     --select-border-hover: 2px solid #999;
     --select-border-radius: 5px;
     --select-fg: #bbb;
+    --select-icon: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'><path fill='%23bbb' d='M6 8l-1 1l5 5l5-5l-1-1l-4 4l-4-4z'/></svg>");
+    --select-padding: 11px;
+    --select-padding-active: 10px;
+    --select-padding-hover: 10px;
 
     --textarea-border: 1px solid #555;
     --textarea-border-active: 2px solid #2196f3;
@@ -139,6 +146,9 @@
     --textarea-border-hover: 2px solid #999;
     --textarea-border-radius: 5px;
     --textarea-fg: #bbb;
+    --textarea-padding: 12px;
+    --textarea-padding-active: 11px;
+    --textarea-padding-hover: 11px;
 
     --torrent-card-bg: #222;
     --torrent-card-fg: inherit;

--- a/resources/sass/themes/galactic.scss
+++ b/resources/sass/themes/galactic.scss
@@ -100,6 +100,9 @@
     --input-text-border-hover: 2px solid #999;
     --input-text-border-radius: 5px;
     --input-text-fg: #bbb;
+    --input-text-padding: 12px;
+    --input-text-padding-active: 11px;
+    --input-text-padding-hover: 11px;
 
     --key-value-even-bg: #272727;
     --key-value-fg: var(--text-color);
@@ -155,6 +158,10 @@
     --select-border-hover: 2px solid #999;
     --select-border-radius: 5px;
     --select-fg: #bbb;
+    --select-icon: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'><path fill='%23bbb' d='M6 8l-1 1l5 5l5-5l-1-1l-4 4l-4-4z'/></svg>");
+    --select-padding: 11px;
+    --select-padding-active: 10px;
+    --select-padding-hover: 10px;
 
     --subforum-listing-odd-bg: #2a2a2a;
     --subforum-listing-even-bg: transparent;
@@ -165,6 +172,9 @@
     --textarea-border-hover: 2px solid #999;
     --textarea-border-radius: 5px;
     --textarea-fg: #bbb;
+    --textarea-padding: 12px;
+    --textarea-padding-active: 11px;
+    --textarea-padding-hover: 11px;
 
     --torrent-card-bg: #272727;
     --torrent-card-fg: var(--text-color);


### PR DESCRIPTION
Prevents the form elements from changing size when hovered/activated. Also removes select styling and add the arrow manually since apparently safari likes to make the background glossy otherwise.