### PR TITLE
(Fix) Safari table issues

### DIFF
--- a/resources/sass/components/_data-table.scss
+++ b/resources/sass/components/_data-table.scss
@@ -3,7 +3,6 @@
     border: 0;
     color: var(--data-table-fg);
     border-collapse: collapse;
-    height: 1px;
 }
 
 .data-table-wrapper {
@@ -15,7 +14,6 @@
 .data-table > tbody > tr,
 .data-table > tfoot > tr {
     border: 0 !important; /* Can be removed after global table styles are removed */
-    height: 100%;
 }
 
 /* header */
@@ -29,7 +27,6 @@
     padding: 7px;
     font-size: 12px;
     font-weight: bold;
-    height: 100%;
 }
 
 /* cell */
@@ -39,7 +36,6 @@
 .data-table > tfoot > tr > td {
     padding: 7px;
     font-size: 14px;
-    height: 100%;
 }
 
 .data-table > tr:not(.data-table > tr:last-child) > td,


### PR DESCRIPTION
Safari doesn't like this hacky workaround required to get css grid/flex working inside table cells, but it seems it's not needed if each table cell contains a span, div, etc. instead of a text node.