### PR TITLE
(Fix) Crew with multiple roles on a film

### DIFF
--- a/app/Jobs/ProcessMovieJob.php
+++ b/app/Jobs/ProcessMovieJob.php
@@ -100,14 +100,14 @@ class ProcessMovieJob implements ShouldQueue
 
             foreach ($this->movie['credits']['crew'] as $crew) {
                 $crew_movie_relations[] = [
-                    'movie_id'  => $this->movie['id'],
-                    'person_id' => $crew['id'],
+                    'movie_id'   => $this->movie['id'],
+                    'person_id'  => $crew['id'],
                     'department' => $crew['department'] ?? null,
-                    'job' => $crew['job'] ?? null,
+                    'job'        => $crew['job'] ?? null,
                 ];
             }
 
-            $crew = \array_map([$tmdb, 'person_array'], $this->movie['credits']['crew']);
+            $crew = array_map([$tmdb, 'person_array'], $this->movie['credits']['crew']);
             Crew::upsert($crew, 'id');
 
             Movie::find($this->movie['id'])->crew()->sync($crew_movie_relations);

--- a/database/migrations/2023_02_27_150826_update_crew_movie_table.php
+++ b/database/migrations/2023_02_27_150826_update_crew_movie_table.php
@@ -1,0 +1,18 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('crew_movie', function (Blueprint $table): void {
+            $table->dropPrimary(['movie_id', 'person_id']);
+            $table->primary(['movie_id', 'person_id', 'department', 'job']);
+        });
+    }
+};


### PR DESCRIPTION
Proper fix for #1824.

Previously, if a crew member had multiple roles on a film, the most recent would overwrite all previous entries