### PR TITLE
(Update) More filters for peer search

### DIFF
--- a/app/Http/Livewire/PeerSearch.php
+++ b/app/Http/Livewire/PeerSearch.php
@@ -14,6 +14,7 @@
 namespace App\Http\Livewire;
 
 use App\Models\Peer;
+use App\Models\Torrent;
 use Livewire\Component;
 use Livewire\WithPagination;
 
@@ -21,17 +22,32 @@ class PeerSearch extends Component
 {
     use WithPagination;
 
+    public bool $duplicateIpsOnly = false;
+    public bool $includeSeedsize = false;
     public int $perPage = 25;
     public string $ip = '';
     public string $port = '';
     public string $agent = '';
     public string $torrent = '';
+    public string $connectivity = 'any';
+    public string $groupBy = 'none';
     public string $sortField = 'created_at';
     public string $sortDirection = 'desc';
 
     protected $queryString = [
-        'page'    => ['except' => 1],
-        'perPage' => ['except' => ''],
+        'page'             => ['except' => 1],
+        'perPage'          => ['except' => ''],
+        'duplicateIpsOnly' => ['except' => false],
+        'includeSeedsize'  => ['except' => false],
+        'perPage'          => ['except' => 25],
+        'ip'               => ['except' => ''],
+        'port'             => ['except' => ''],
+        'agent'            => ['except' => ''],
+        'torrent'          => ['except' => ''],
+        'connectivity'     => ['except' => 'any'],
+        'groupBy'          => ['except' => 'none'],
+        'sortField'        => ['except' => 'created_at'],
+        'sortDirection'    => ['except' => 'desc'],
     ];
 
     final public function paginationView(): string
@@ -64,31 +80,120 @@ class PeerSearch extends Component
         $this->resetPage();
     }
 
+    final public function updatingGroupBy(): void
+    {
+        if ($this->groupBy === 'none' && $this->sortField === 'size') {
+            $this->sortField = 'created_at';
+        }
+    }
+
     final public function getPeersProperty(): \Illuminate\Contracts\Pagination\LengthAwarePaginator
     {
         return Peer::query()
-            ->select([
-                'peers.torrent_id',
-                'peers.user_id',
-                'peers.uploaded',
-                'peers.downloaded',
-                'peers.left',
-                'peers.port',
-                'peers.agent',
-                'peers.created_at',
-                'peers.updated_at',
-                'peers.seeder',
-                'torrents.size',
+            ->when(
+                $this->groupBy === 'none',
+                fn ($query) => $query
+                    ->select([
+                        'peers.torrent_id',
+                        'peers.user_id',
+                        'peers.uploaded',
+                        'peers.downloaded',
+                        'peers.left',
+                        'peers.port',
+                        'peers.agent',
+                        'peers.created_at',
+                        'peers.updated_at',
+                        'peers.seeder',
+                        'peers.connectable',
+                    ])
+                    ->selectRaw('INET6_NTOA(peers.ip) as ip')
+                    ->with(['user', 'user.group', 'torrent:id,name,size'])
+            )
+            ->when(
+                $this->groupBy === 'user_session',
+                fn ($query) => $query
+                    ->select(['peers.user_id', 'peers.port', 'peers.agent'])
+                    ->selectRaw('COUNT(DISTINCT(peers.torrent_id)) as torrent_id')
+                    ->selectRaw('INET6_NTOA(peers.ip) as ip')
+                    ->selectRaw('SUM(peers.uploaded) as uploaded')
+                    ->selectRaw('SUM(peers.downloaded) as downloaded')
+                    ->selectRaw('SUM(peers.`left`) as `left`')
+                    ->selectRaw('MIN(peers.created_at) as created_at')
+                    ->selectRaw('MAX(peers.updated_at) as updated_at')
+                    ->selectRaw('COUNT(DISTINCT(peers.id)) as peer_count')
+                    ->selectRaw('SUM(peers.connectable = 1) as connectable_count')
+                    ->selectRaw('SUM(peers.connectable = 0) as unconnectable_count')
+                    ->groupBy(['peers.user_id', 'peers.agent', 'peers.ip', 'peers.port'])
+                    ->with(['user', 'user.group'])
+            )
+            ->when(
+                $this->groupBy === 'user_ip',
+                fn ($query) => $query
+                    ->select(['peers.user_id'])
+                    ->selectRaw('COUNT(DISTINCT(peers.torrent_id)) as torrent_id')
+                    ->selectRaw('COUNT(DISTINCT(peers.agent)) as agent')
+                    ->selectRaw('INET6_NTOA(peers.ip) as ip')
+                    ->selectRaw('COUNT(DISTINCT(peers.port)) as port')
+                    ->selectRaw('SUM(peers.uploaded) as uploaded')
+                    ->selectRaw('SUM(peers.downloaded) as downloaded')
+                    ->selectRaw('SUM(`left`) as `left`')
+                    ->selectRaw('MIN(peers.created_at) as created_at')
+                    ->selectRaw('MAX(peers.updated_at) as updated_at')
+                    ->selectRaw('COUNT(*) as peer_count')
+                    ->selectRaw('SUM(peers.connectable = 1) as connectable_count')
+                    ->selectRaw('SUM(peers.connectable = 0) as unconnectable_count')
+                    ->groupBy(['peers.user_id', 'peers.ip'])
+                    ->with(['user', 'user.group'])
+            )
+            ->when(
+                $this->groupBy === 'user',
+                fn ($query) => $query
+                    ->select(['peers.user_id'])
+                    ->selectRaw('COUNT(DISTINCT(peers.torrent_id)) as torrent_id')
+                    ->selectRaw('COUNT(DISTINCT(peers.agent)) as agent')
+                    ->selectRaw('COUNT(DISTINCT(peers.ip)) as ip')
+                    ->selectRaw('COUNT(DISTINCT(peers.port)) as port')
+                    ->selectRaw('SUM(peers.uploaded) as uploaded')
+                    ->selectRaw('SUM(peers.downloaded) as downloaded')
+                    ->selectRaw('SUM(`left`) as `left`')
+                    ->selectRaw('MIN(peers.created_at) as created_at')
+                    ->selectRaw('MAX(peers.updated_at) as updated_at')
+                    ->selectRaw('COUNT(*) as peer_count')
+                    ->selectRaw('SUM(peers.connectable = 1) as connectable_count')
+                    ->selectRaw('SUM(peers.connectable = 0) as unconnectable_count')
+                    ->groupBy(['peers.user_id'])
+                    ->with(['user', 'user.group'])
+            )
+            ->when(
+                $this->duplicateIpsOnly,
+                fn ($query) => $query
+                    ->whereIn('peers.ip', Peer::select('ip')->groupBy('ip')->havingRaw('COUNT(ip) > 1'))
+            )
+            ->when(
+                $this->includeSeedsize,
+                fn ($query) => $query
+                    ->join('torrents', 'peers.torrent_id', '=', 'torrents.id')
+                    ->when(
+                        $this->groupBy === 'none',
+                        fn ($query) => $query
+                            ->selectRaw('torrents.size as size')
+                            ->selectRaw('IF(peers.connectable = 1, torrents.size, 0) as connectable_size')
+                            ->selectRaw('IF(peers.connectable = 0, torrents.size, 0) as unconnectable_size'),
+                        fn ($query) => $query
+                            ->selectRaw('SUM(torrents.size) as size')
+                            ->selectRaw('SUM(IF(peers.connectable = 1, torrents.size, 0)) as connectable_size')
+                            ->selectRaw('SUM(IF(peers.connectable = 0, torrents.size, 0)) as unconnectable_size')
+                    )
+            )
+            ->when($this->ip !== '', fn ($query) => $query->having('peers.ip', 'LIKE', '%'.$this->ip.'%'))
+            ->when($this->port !== '', fn ($query) => $query->where('peers.port', '=', $this->port))
+            ->when($this->agent !== '', fn ($query) => $query->where('peers.agent', 'LIKE', '%'.$this->agent.'%'))
+            ->when($this->torrent !== '', fn ($query) => $query->whereIn(
                 'torrents.name',
-            ])
-            ->selectRaw('INET6_NTOA(ip) as ip')
-            ->with(['user', 'user.group'])
-            ->join('users', 'users.id', '=', 'peers.user_id')
-            ->join('torrents', 'torrents.id', '=', 'peers.torrent_id')
-            ->when($this->ip !== '', fn ($query) => $query->having('ip', 'LIKE', '%'.$this->ip.'%'))
-            ->when($this->port !== '', fn ($query) => $query->where('port', '=', $this->port))
-            ->when($this->agent !== '', fn ($query) => $query->where('agent', 'LIKE', '%'.$this->agent.'%'))
-            ->when($this->torrent !== '', fn ($query) => $query->where('torrents.name', 'LIKE', '%'.str_replace(' ', '%', $this->torrent).'%'))
+                Torrent::select('id')->where('name', 'LIKE', '%'.str_replace(' ', '%', $this->torrent).'%')
+            ))
+            ->when($this->connectivity === 'connectable', fn ($query) => $query->where('connectable', '=', 1))
+            ->when($this->connectivity === 'unconnectable', fn ($query) => $query->where('connectable', '=', 0))
             ->orderBy($this->sortField, $this->sortDirection)
             ->paginate($this->perPage);
     }

--- a/resources/views/livewire/peer-search.blade.php
+++ b/resources/views/livewire/peer-search.blade.php
@@ -22,6 +22,35 @@
                         <input wire:model="agent" class="form__text" placeholder="">
                         <label class="form__label form__label--floating">Agent</label>
                     </p>
+                    <p class="form__group">
+                        <select wire:model="connectivity" class="form__select" placeholder="">
+                            <option value="any">Any</option>
+                            <option value="connectable">Connectable</option>
+                            <option value="unconnectable">Unconnectable</option>
+                        </select>
+                        <label class="form__label form__label--floating">Connectivity</label>
+                    </p>
+                    <p class="form__group">
+                        <select wire:model="groupBy" class="form__select" placeholder="">
+                            <option value="none">None</option>
+                            <option value="user_session">User Session</option>
+                            <option value="user_ip">User IP</option>
+                            <option value="user">User</option>
+                        </select>
+                        <label class="form__label form__label--floating">Group By</label>
+                    </p>
+                    <p class="form__group">
+                        <label class="form__label">
+                            <input wire:model="duplicateIpsOnly" type="checkbox" class="form__checkbox">
+                            Duplicate Ips Only
+                        </label>
+                    </p>
+                    <p class="form__group">
+                        <label class="form__label">
+                            <input wire:model="includeSeedsize" type="checkbox" class="form__checkbox">
+                            Include Seedsize
+                        </label>
+                    </p>
                 </div>
             </form>
         </div>
@@ -32,29 +61,48 @@
             <table class="data-table">
                 <thead>
                     <tr>
-                        <th wire:click="sortBy('username')" role="columnheader button">
+                        <th wire:click="sortBy('peers.user_id')" role="columnheader button">
                             {{ __('user.user') }}
-                            @include('livewire.includes._sort-icon', ['field' => 'username'])
+                            @include('livewire.includes._sort-icon', ['field' => 'peers.user_id'])
                         </th>
-                        <th wire:click="sortBy('name')" role="columnheader button">
-                            {{ __('torrent.torrent') }}
-                            @include('livewire.includes._sort-icon', ['field' => 'name'])
+                        @if ($groupBy !== 'none')
+                            <th wire:click="sortBy('peer_count')" role="columnheader button" style="text-align: right">
+                                {{ __('torrent.peers') }}
+                                @include('livewire.includes._sort-icon', ['field' => 'peer_count'])
+                            </th>
+                        @endif
+                        <th wire:click="sortBy('torrent_id')" role="columnheader button">
+                            @if ($groupBy === 'none')
+                                {{ __('torrent.torrent') }}
+                            @else
+                                {{ __('torrent.torrents') }}
+                                @include('livewire.includes._sort-icon', ['field' => 'torrent_id'])
+                            @endif
                         </th>
                         <th wire:click="sortBy('agent')" role="columnheader button">
-                            {{ __('torrent.agent') }}
+                            @if ($groupBy === 'user_ip' || $groupBy === 'user')
+                                Agents
+                            @else
+                                {{ __('torrent.agent') }}
+                            @endif
                             @include('livewire.includes._sort-icon', ['field' => 'agent'])
                         </th>
                         <th wire:click="sortBy('ip')" role="columnheader button" style="text-align: right">
-                            IP
+                            @if ($groupBy === 'none' || $groupBy === 'user_ip' || $groupBy === 'user_session')
+                                IP
+                            @else
+                                IPs
+                            @endif
                             @include('livewire.includes._sort-icon', ['field' => 'ip'])
                         </th>
                         <th wire:click="sortBy('port')" role="columnheader button" style="text-align: right">
-                            Port
+                            @if ($groupBy === 'user_ip' || $groupBy === 'user')
+                                Ports
+                            @else
+                                Port
+                            @endif
                             @include('livewire.includes._sort-icon', ['field' => 'port'])
                         </th>
-                        @if (\config('announce.connectable_check'))
-                            <th>Connectable</th>
-                        @endif
                         <th wire:click="sortBy('uploaded')" role="columnheader button" style="text-align: right">
                             {{ __('torrent.uploaded') }}
                             @include('livewire.includes._sort-icon', ['field' => 'uploaded'])
@@ -67,13 +115,57 @@
                             {{ __('torrent.left') }}
                             @include('livewire.includes._sort-icon', ['field' => 'left'])
                         </th>
-                        <th wire:click="sortBy('size')" role="columnheader button" style="text-align: right">
-                            {{ __('torrent.size') }}
-                            @include('livewire.includes._sort-icon', ['field' => 'size'])
-                        </th>
+                        @if ($groupBy === 'none')
+                            @if ($includeSeedsize)
+                                <th wire:click="sortBy('size')" wire:key="size" role="columnheader button" style="text-align: right">
+                                    {{ __('torrent.size') }}
+                                    @include('livewire.includes._sort-icon', ['field' => 'size'])
+                                </th>
+                            @else
+                                <th style="text-align: right">{{ __('torrent.size') }}</th>
+                            @endif
+                        @else
+                            @if ($includeSeedsize)
+                                <th wire:click="sortBy('size')" role="columnheader button" style="text-align: right">
+                                    {{ __('torrent.size') }}
+                                    @include('livewire.includes._sort-icon', ['field' => 'size'])
+                                </th>
+                                @if (\config('announce.connectable_check'))
+                                    <th wire:click="sortBy('connectable_size')" role="columnheader button" style="text-align: right">
+                                        Connectable {{ __('torrent.size') }}
+                                        @include('livewire.includes._sort-icon', ['field' => 'connectable_size'])
+                                    </th>
+                                    <th wire:click="sortBy('unconnectable_size')" role="columnheader button" style="text-align: right">
+                                        Unconnectable {{ __('torrent.size') }}
+                                        @include('livewire.includes._sort-icon', ['field' => 'unconnectable_size'])
+                                    </th>
+                                @endif
+                            @endif
+                        @endif
+                        @if (\config('announce.connectable_check'))
+                            @if ($groupBy === 'none')
+                                <th wire:click="sortBy('connectable')" role="columnheader button" style="text-align: right">
+                                    Connectable
+                                    @include('livewire.includes._sort-icon', ['field' => 'connectable'])
+                                </th>
+                            @else
+                                <th wire:click="sortBy('connectable_count')" role="columnheader button" style="text-align: right">
+                                    Connectable {{ __('torrent.peers') }}
+                                    @include('livewire.includes._sort-icon', ['field' => 'connectable_count'])
+                                </th>
+                                <th wire:click="sortBy('unconnectable_count')" role="columnheader button" style="text-align: right">
+                                    Unconnectable {{ __('torrent.peers') }}
+                                    @include('livewire.includes._sort-icon', ['field' => 'unconnectable_count'])
+                                </th>
+                            @endif
+                        @endif
                         <th wire:click="sortBy('created_at')" role="columnheader button" style="text-align: right">
                             Started
                             @include('livewire.includes._sort-icon', ['field' => 'created_at'])
+                        </th>
+                        <th wire:click="sortBy('updated_at')" role="columnheader button" style="text-align: right">
+                            Announced
+                            @include('livewire.includes._sort-icon', ['field' => 'updated_at'])
                         </th>
                     </tr>
                 </thead>
@@ -83,35 +175,35 @@
                             <td>
                                 <x-user_tag :user="$peer->user" :anon="false" />
                             </td>
-                            <td>
-                                <a href="{{ route('torrent', ['id' => $peer->torrent_id]) }}">
-                                    {{ $peer->name }}
-                                </a>
-                            </td>
-                            <td>
-                                {{ $peer->agent }}
-                            </td>
+                            @if ($groupBy !== 'none')
+                                <td style="text-align: right">
+                                    {{ $peer->peer_count }}
+                                </td>
+                            @endif
+                            @if ($groupBy === 'none')
+                                <td>
+                                    <a href="{{ route('torrent', ['id' => $peer->torrent_id]) }}">
+                                        {{ $peer->torrent->name ?? '' }}
+                                    </a>
+                                </td>
+                            @else
+                                <td style="text-align: right">
+                                    {{ $peer->torrent_id }}
+                                </td>
+                            @endif
+                            @if ($groupBy === 'none' || $groupBy === 'user_session')
+                                <td>{{ $peer->agent }}</td>
+                            @else
+                                <td style="text-align: right">
+                                    {{ $peer->agent }}
+                                </td>
+                            @endif
                             <td style="text-align: right">
                                 {{ $peer->ip }}
                             </td>
                             <td style="text-align: right">
                                 {{ $peer->port }}
                             </td>
-                            @if (\config('announce.connectable_check'))
-                                <td>
-                                    @php
-                                        $connectable = false;
-                                        if (cache()->has('peers:connectable:'.$peer->ip.'-'.$peer->port.'-'.$peer->agent)) {
-                                            $connectable = cache()->get('peers:connectable:'.$peer->ip.'-'.$peer->port.'-'.$peer->agent);
-                                        }
-                                    @endphp
-                                    @if ($connectable)
-                                        <i class="{{ config('other.font-awesome') }} text-green fa-check" title="Connectable"></i>
-                                    @else
-                                        <i class="{{ config('other.font-awesome') }} text-red fa-times" title="Not Connectable"></i>
-                                    @endif
-                                </td>
-                            @endif
                             <td style="text-align: right">
                                 {{ App\Helpers\StringHelper::formatBytes($peer->uploaded, 2) }}
                             </td>
@@ -121,10 +213,41 @@
                             <td style="text-align: right">
                                 {{ App\Helpers\StringHelper::formatBytes($peer->left, 2) }}
                             </td>
-                            <td style="text-align: right">
-                                {{ App\Helpers\StringHelper::formatBytes($peer->size) }}
-                            </td>
+                            @if ($groupBy === 'none')
+                                <td style="text-align: right">
+                                    {{ App\Helpers\StringHelper::formatBytes($peer->torrent->size ?? 0) }}
+                                </td>
+                            @else
+                                @if ($includeSeedsize)
+                                    <td style="text-align: right">
+                                        {{ App\Helpers\StringHelper::formatBytes($peer->size ?? 0) }}
+                                    </td>
+                                    @if (\config('announce.connectable_check'))
+                                        <td style="text-align: right">
+                                            {{ App\Helpers\StringHelper::formatBytes($peer->connectable_size ?? 0) }}
+                                        </td>
+                                        <td style="text-align: right">
+                                            {{ App\Helpers\StringHelper::formatBytes($peer->unconnectable_size ?? 0) }}
+                                        </td>
+                                    @endif
+                                @endif
+                            @endif
+                            @if (\config('announce.connectable_check'))
+                                @if ($groupBy === 'none')
+                                    <td style="text-align: right">
+                                        @if ($peer->connectable)
+                                            <i class="{{ config('other.font-awesome') }} text-green fa-check" title="Connectable"></i>
+                                        @else
+                                            <i class="{{ config('other.font-awesome') }} text-red fa-times" title="Not Connectable"></i>
+                                        @endif
+                                    </td>
+                                @else
+                                    <td style="text-align: right">{{ $peer->connectable_count }}</td>
+                                    <td style="text-align: right">{{ $peer->unconnectable_count }}</td>
+                                @endif
+                            @endif
                             <td style="text-align: right">{{ $peer->created_at?->diffForHumans() ?? 'N/A' }}</td>
+                            <td style="text-align: right">{{ $peer->updated_at?->diffForHumans() ?? 'N/A' }}</td>
                         </tr>
                     @endforeach
                 </tbody>


### PR DESCRIPTION
Doesn't join any extra tables anymore unless the "include seedsize" checkbox is ticked. Also no longer able to sort by torrent name or username, although can still sort by user id and torrent id (done for performance reasons). Many more filters added for grouping peers by user, by torrent client session, or by ip and shows how many ips/ports/agents/peers/torrents are being used by each user. Also adds more useful columns such as connectable and unconnectable seedsize, for narrowing down users seeding a lot but nobody actually being able to efficiently connect to them.