### PR TITLE
(Fix) Upload and request buttons on meta when value is missing

### DIFF
--- a/app/Http/Controllers/RequestController.php
+++ b/app/Http/Controllers/RequestController.php
@@ -120,7 +120,7 @@ class RequestController extends Controller
     /**
      * Torrent Request Add Form.
      */
-    public function addRequestForm(Request $request, string $title = '', int $imdb = 0, int $tmdb = 0): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
+    public function addRequestForm(Request $request): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
     {
         $user = $request->user();
 
@@ -129,9 +129,13 @@ class RequestController extends Controller
             'types'       => Type::all()->sortBy('position'),
             'resolutions' => Resolution::all()->sortBy('position'),
             'user'        => $user,
-            'title'       => $title,
-            'imdb'        => str_replace('tt', '', $imdb),
-            'tmdb'        => $tmdb,
+            'category_id' => $request->category_id,
+            'title'       => urldecode($request->title),
+            'imdb'        => $request->imdb,
+            'tmdb'        => $request->tmdb,
+            'mal'         => $request->mal,
+            'tvdb'        => $request->tvdb,
+            'igdb'        => $request->igdb,
         ]);
     }
 

--- a/app/Http/Controllers/TorrentController.php
+++ b/app/Http/Controllers/TorrentController.php
@@ -394,7 +394,7 @@ class TorrentController extends Controller
     /**
      * Torrent Upload Form.
      */
-    public function create(Request $request, int $categoryId = 0, string $title = '', string $imdb = '0', string $tmdb = '0'): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
+    public function create(Request $request): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
     {
         $user = $request->user();
         $categories = [];
@@ -420,10 +420,13 @@ class TorrentController extends Controller
             'regions'      => Region::all()->sortBy('position'),
             'distributors' => Distributor::all()->sortBy('position'),
             'user'         => $user,
-            'category_id'  => $categoryId,
-            'title'        => $title,
-            'imdb'         => str_replace('tt', '', $imdb),
-            'tmdb'         => $tmdb,
+            'category_id'  => $request->category_id,
+            'title'        => urldecode($request->title),
+            'imdb'         => $request->imdb,
+            'tmdb'         => $request->tmdb,
+            'mal'          => $request->mal,
+            'tvdb'         => $request->tvdb,
+            'igdb'         => $request->igdb,
         ]);
     }
 

--- a/resources/views/requests/add_request.blade.php
+++ b/resources/views/requests/add_request.blade.php
@@ -46,7 +46,7 @@
                         >
                             <option hidden selected disabled value=""></option>
                             @foreach ($categories as $category)
-                                <option class="form__option" value="{{ $category->id }}">
+                                <option class="form__option" value="{{ $category->id }}" @selected((old('category_id') ?: $category_id) ==  $category->id)>
                                     {{ $category->name }}
                                 </option>
                             @endforeach
@@ -102,7 +102,7 @@
                                 pattern="[0-9]*"
                                 required
                                 type="text"
-                                x-bind:value="{{ $tmdb ?: old('tmdb') }}"
+                                value="{{ $tmdb ?: old('tmdb') }}"
                             >
                             <label class="form__label form__label--floating" for="autotmdb">TMDB ID</label>
                             <output name="apimatch" id="apimatch" for="torrent"></output>
@@ -117,7 +117,7 @@
                                 pattern="[0-9]*"
                                 required
                                 type="text"
-                                x-bind:value="{{ $imdb ?: old('imdb') }}"
+                                value="{{ $imdb ?: old('imdb') }}"
                             >
                             <label class="form__label form__label--floating" for="autoimdb">IMDB ID</label>
                         </p>
@@ -131,7 +131,7 @@
                                 pattern="[0-9]*"
                                 placeholder=""
                                 type="text"
-                                x-bind:value="{{ old('tvdb') }}"
+                                value="{{ $tvdb ?: old('tvdb') }}"
                             >
                             <label class="form__label form__label--floating" for="autotvdb">TVDB ID</label>
                         </p>
@@ -145,7 +145,7 @@
                                 pattern="[0-9]*"
                                 placeholder=""
                                 type="text"
-                                value="{{ old('mal') }}"
+                                value="{{ $mal ?: old('mal') }}"
                             >
                             <label class="form__label form__label--floating" for="automal">MAL ID ({{ __('torrent.required-anime') }})</label>
                         </p>
@@ -158,7 +158,7 @@
                                 pattern="[0-9]*"
                                 placeholder
                                 type="text"
-                                value="{{ old('igdb') ?? '0' }}"
+                                value="{{ $igdb ?: old('igdb') ?? '0' }}"
                             >
                             <label class="form__label form__label--floating" for="name">
                                 IGDB ID ({{ __('request.required') }} For Games)

--- a/resources/views/torrent/partials/game_meta.blade.php
+++ b/resources/views/torrent/partials/game_meta.blade.php
@@ -19,8 +19,29 @@
         </a>
         <ul class="meta__dropdown">
             <li>
-                <a href="{{ route('upload_form', ['category_id' => $category->id, 'title' => rawurlencode($meta->name ?? $meta->title ?? '') ?? 'Unknown']) }}">
+                <a href="{{ route('upload_form', [
+                    'category_id' => $category->id,
+                    'title'       => rawurlencode(($meta?->name ?? '') . ' ' . substr($meta->release_date ?? '', 0, 4) ?? ''),
+                    'imdb'        => $torrent->imdb ?? '',
+                    'tmdb'        => $torrent->tmdb ?? '',
+                    'mal'         => $torrent->mal ?? '',
+                    'tvdb'        => $torrent->tvdb ?? '',
+                    'igdb'        => $torrent->igdb ?? '',
+                ]) }}">
                     {{ __('common.upload') }}
+                </a>
+            </li>
+            <li>
+                <a href="{{ route('add_request_form', [
+                    'category_id' => $category->id,
+                    'title'       => rawurlencode(($meta?->name ?? '') . ' ' . substr($meta->release_date ?? '', 0, 4) ?? ''),
+                    'imdb'        => $torrent->imdb ?? '',
+                    'tmdb'        => $torrent->tmdb ?? '',
+                    'mal'         => $torrent->mal ?? '',
+                    'tvdb'        => $torrent->tvdb ?? '',
+                    'igdb'        => $torrent->igdb ?? '',
+                ]) }}">
+                    Request similar
                 </a>
             </li>
         </ul>

--- a/resources/views/torrent/partials/movie_meta.blade.php
+++ b/resources/views/torrent/partials/movie_meta.blade.php
@@ -19,12 +19,28 @@
         </a>
         <ul class="meta__dropdown">
             <li>
-                <a href="{{ route('upload_form', ['category_id' => $category->id, 'title' => rawurlencode($meta?->title ?? '') ?? 'Unknown', 'imdb' => $torrent->imdb ?? '', 'tmdb' => $meta?->id ?? '']) }}">
+                <a href="{{ route('upload_form', [
+                    'category_id' => $category->id,
+                    'title'       => rawurlencode(($meta?->title ?? '') . ' ' . substr($meta->release_date ?? '', 0, 4) ?? ''),
+                    'imdb'        => $torrent->imdb ?? '',
+                    'tmdb'        => $meta?->id ?? '',
+                    'mal'         => $torrent->mal ?? '',
+                    'tvdb'        => $torrent->tvdb ?? '',
+                    'igdb'        => $torrent->igdb ?? '',
+                ]) }}">
                     {{ __('common.upload') }}
                 </a>
             </li>
             <li>
-                <a href="{{ route('add_request_form', ['title' => rawurlencode($meta->title ?? ''), 'imdb' => $torrent->imdb ?? '', 'tmdb' => $meta?->id ?? '']) }}">
+                <a href="{{ route('add_request_form', [
+                    'category_id' => $category->id,
+                    'title'       => rawurlencode(($meta?->title ?? '') . ' ' . substr($meta->release_date ?? '', 0, 4) ?? ''),
+                    'imdb'        => $torrent->imdb ?? '',
+                    'tmdb'        => $meta?->id ?? '',
+                    'mal'         => $torrent->mal ?? '',
+                    'tvdb'        => $torrent->tvdb ?? '',
+                    'igdb'        => $torrent->igdb ?? '',
+                ]) }}">
                     Request similar
                 </a>
             </li>
@@ -43,15 +59,15 @@
                 </a>
             </li>
         @endif
-        @if ($torrent->tmdb ?? 0 > 0)
+        @if ($meta->id ?? 0 > 0)
             <li class="meta__tmdb">
                 <a
                     class="meta-id-tag"
-                    href="https://www.themoviedb.org/movie/{{ $torrent->tmdb }}"
+                    href="https://www.themoviedb.org/movie/{{ $meta->id }}"
                     title="The Movie Database"
                     target="_blank"
                 >
-                    TMDB: {{ $torrent->tmdb }}
+                    TMDB: {{ $meta->id }}
                 </a>
             </li>
         @endif

--- a/resources/views/torrent/partials/tv_meta.blade.php
+++ b/resources/views/torrent/partials/tv_meta.blade.php
@@ -19,12 +19,28 @@
         </a>
         <ul class="meta__dropdown">
             <li>
-                <a href="{{ route('upload_form', ['category_id' => $category->id, 'title' => rawurlencode($meta?->name ?? $meta?->title ?? '') ?? 'Unknown', 'imdb' => $torrent->imdb ?? 0, 'tmdb' => $tmdb]) }}">
+                <a href="{{ route('upload_form', [
+                    'category_id' => $category->id,
+                    'title'       => rawurlencode(($meta?->name ?? '') . ' ' . substr($meta->first_air_date ?? '', 0, 4) ?? ''),
+                    'imdb'        => $torrent->imdb ?? '',
+                    'tmdb'        => $meta?->id ?? '',
+                    'mal'         => $torrent->mal ?? '',
+                    'tvdb'        => $torrent->tvdb ?? '',
+                    'igdb'        => $torrent->igdb ?? '',
+                ]) }}">
                     {{ __('common.upload') }}
                 </a>
             </li>
             <li>
-                <a href="{{ route('add_request_form', ['title' => rawurlencode($meta?->title ?? ''), 'imdb' => $torrent->imdb ?? '', 'tmdb' => $tmdb]) }}">
+                <a href="{{ route('add_request_form', [
+                    'category_id' => $category->id,
+                    'title'       => rawurlencode(($meta?->name ?? '') . ' ' . substr($meta->first_air_date ?? '', 0, 4) ?? ''),
+                    'imdb'        => $torrent->imdb ?? '',
+                    'tmdb'        => $meta?->id ?? '',
+                    'mal'         => $torrent->mal ?? '',
+                    'tvdb'        => $torrent->tvdb ?? '',
+                    'igdb'        => $torrent->igdb ?? '',
+                ]) }}">
                     Request similar
                 </a>
             </li>
@@ -43,15 +59,15 @@
                 </a>
             </li>
         @endif
-        @if ($tmdb > 0)
+        @if ($meta->id ?? 0 > 0)
             <li class="meta__tmdb">
                 <a
                     class="meta-id-tag"
-                    href="https://www.themoviedb.org/tv/{{ $tmdb }}"
+                    href="https://www.themoviedb.org/tv/{{ $meta->id }}"
                     title="The Movie Database"
                     target="_blank"
                 >
-                    TMDB: {{ $tmdb }}
+                    TMDB: {{ $meta->id }}
                 </a>
             </li>
         @endif

--- a/resources/views/torrent/upload.blade.php
+++ b/resources/views/torrent/upload.blade.php
@@ -285,7 +285,7 @@
                                 id="autotvdb"
                                 inputmode="numeric"
                                 pattern="[0-9]*"
-                                x-bind:value="cats[cat].type === 'tv' ? '{{ old('tvdb') }}' : '0'"
+                                x-bind:value="cats[cat].type === 'tv' ? '{{ $tvdb ?: old('tvdb') }}' : '0'"
                                 class="form__text"
                                 x-bind:required="cats[cat].type === 'tv'"
                             >
@@ -299,7 +299,7 @@
                                 id="automal"
                                 inputmode="numeric"
                                 pattern="[0-9]*"
-                                x-bind:value="(cats[cat].type === 'movie' || cats[cat].type === 'tv') ? '{{ old('mal') }}' : '0'"
+                                x-bind:value="(cats[cat].type === 'movie' || cats[cat].type === 'tv') ? '{{ $mal ?: old('mal') }}' : '0'"
                                 x-bind:required="cats[cat].type === 'movie' || cats[cat].type === 'tv'"
                                 class="form__text"
                                 placeholder=""
@@ -314,7 +314,7 @@
                             id="autoigdb"
                             inputmode="numeric"
                             pattern="[0-9]*"
-                            x-bind:value="cats[cat].type === 'game' ? '{{ old('igdb') }}' : '0'"
+                            x-bind:value="cats[cat].type === 'game' ? '{{ $igdb ?: old('igdb') }}' : '0'"
                             class="form__text"
                             x-bind:required="cats[cat].type === 'game'"
                         >

--- a/routes/web.php
+++ b/routes/web.php
@@ -158,7 +158,7 @@ Route::group(['middleware' => 'language'], function (): void {
         });
 
         Route::group(['prefix' => 'requests'], function (): void {
-            Route::get('/add/{title?}/{imdb?}/{tmdb?}', [App\Http\Controllers\RequestController::class, 'addRequestForm'])->name('add_request_form');
+            Route::get('/add', [App\Http\Controllers\RequestController::class, 'addRequestForm'])->name('add_request_form');
             Route::post('/add', [App\Http\Controllers\RequestController::class, 'addRequest'])->name('add_request');
             Route::get('/{id}/edit', [App\Http\Controllers\RequestController::class, 'editRequestForm'])->name('edit_request_form');
             Route::post('/{id}/edit', [App\Http\Controllers\RequestController::class, 'editRequest'])->name('edit_request');
@@ -182,7 +182,7 @@ Route::group(['middleware' => 'language'], function (): void {
 
         // Torrents System
         Route::group(['prefix' => 'upload'], function (): void {
-            Route::get('/{category_id}/{title?}/{imdb?}/{tmdb?}', [App\Http\Controllers\TorrentController::class, 'create'])->name('upload_form');
+            Route::get('/', [App\Http\Controllers\TorrentController::class, 'create'])->name('upload_form');
             Route::post('/', [App\Http\Controllers\TorrentController::class, 'store'])->name('upload');
             Route::post('/preview', [App\Http\Controllers\TorrentController::class, 'preview']);
         });


### PR DESCRIPTION
Can't have empty route parameters, but seems like empty query parameters work. Fixes the issue where if a torrent doesn't have an imdb, then it wouldn't leave the route parameter empty, without having to default to an undesired value (e.g. 0).