### PR TITLE
(Fix) Read-only text input label

### DIFF
--- a/resources/sass/components/form/text.scss
+++ b/resources/sass/components/form/text.scss
@@ -47,7 +47,8 @@
     }
 
     &:valid:not(:placeholder-shown),
-    &:focus:placeholder-shown {
+    &:focus:placeholder-shown,
+    &:read-only {
         & + .form__label--floating {
             top: -3px;
             font-size: 11px;


### PR DESCRIPTION
Read only text inputs should have their moved above the text input.