### PR TITLE
(Fix) Torrent icon colours

### DIFF
--- a/resources/views/components/partials/_torrent-icons.blade.php
+++ b/resources/views/components/partials/_torrent-icons.blade.php
@@ -13,19 +13,19 @@
     @endif
     @if ($torrent->personal_release)
         <i
-            class="{{ config('other.font-awesome') }} fa-user-plus torrent-icons__personal"
+            class="{{ config('other.font-awesome') }} fa-user-plus torrent-icons__personal-release"
             title="Personal Release"
         ></i>
     @endif
     @if ($torrent->stream)
         <i
-            class="{{ config('other.font-awesome') }} fa-play text-red torrent-icons__stream-optimized"
+            class="{{ config('other.font-awesome') }} fa-play torrent-icons__stream-optimized"
             title="{{ __('torrent.stream-optimized') }}"
         ></i>
     @endif
     @if ($torrent->featured)
         <i
-            class="{{ config('other.font-awesome') }} fa-certificate text-pink torrent-icons__featured"
+            class="{{ config('other.font-awesome') }} fa-certificate torrent-icons__featured"
             title="{{ __('torrent.featured') }}"
         ></i>
     @endif
@@ -45,31 +45,31 @@
     @endif
     @if (config('other.doubleup') || auth()->user()->group->is_double_upload || $torrent->doubleup)
         <i
-            class="{{ config('other.font-awesome') }} fa-chevron-double-up text-green torrent-icons__double-upload"
+            class="{{ config('other.font-awesome') }} fa-chevron-double-up torrent-icons__double-upload"
             title="@if(config('other.doubleup')){{ __('torrent.global-double-upload') }}&NewLine;@endif&ZeroWidthSpace;@if(auth()->user()->group->is_double_upload){{ __('torrent.special-double_upload') }}&NewLine;@endif&ZeroWidthSpace;@if($torrent->doubleup > 0)100% {{ __('torrent.double-upload') }}@if($torrent->du_until !== null) (expires {{ $torrent->du_until->diffForHumans() }})@endif&ZeroWidthSpace;@endif"
         ></i>
     @endif
     @if ($torrent->sticky)
         <i
-            class="{{ config('other.font-awesome') }} fa-thumbtack text-black torrent-icons__sticky"
+            class="{{ config('other.font-awesome') }} fa-thumbtack torrent-icons__sticky"
             title="{{ __('torrent.sticky') }}"
         ></i>
     @endif
     @if ($torrent->highspeed)
         <i
-            class="{{ config('other.font-awesome') }} fa-tachometer text-red torrent-icons__highspeed"
+            class="{{ config('other.font-awesome') }} fa-tachometer torrent-icons__highspeed"
             title="{{ __('common.high-speeds') }}"
         ></i>
     @endif
     @if ($torrent->sd)
         <i
-            class="{{ config('other.font-awesome') }} fa-ticket text-orange torrent-icons__sd"
+            class="{{ config('other.font-awesome') }} fa-ticket torrent-icons__sd"
             title="{{ __('torrent.sd-content') }}"
         ></i>
     @endif
     @if ($torrent->bumped_at != $torrent->created_at && $torrent->bumped_at < Illuminate\Support\Carbon::now()->addDay(2))
         <i
-            class="{{ config('other.font-awesome') }} fa-level-up-alt text-gold torrent-icons__bumped"
+            class="{{ config('other.font-awesome') }} fa-level-up-alt torrent-icons__bumped"
             title="{{ __('torrent.recent-bumped') }}: {{ $torrent->bumped_at }}"
         ></i>
     @endif


### PR DESCRIPTION
The colors are already styled with the `torrent-icons__*` classes. Also fix `torrent-icons__personal` which is intended to be `torrent-icons__personal-release`