### PR TITLE
(Update) Add more mediainfo languages to flag mappings

### DIFF
--- a/app/Helpers/Helpers.php
+++ b/app/Helpers/Helpers.php
@@ -156,6 +156,7 @@ if (! \function_exists('language_flag')) {
             'French (CA)' => 'can-qc',
             'Georgian'    => 'ge',
             'German', 'German (DE)' => 'de',
+            'German (CH)' => 'ch',
             'Greek', 'Greek (GR)' => 'gr',
             'Hebrew', 'Hebrew (IL)' => 'il',
             'Hindi', 'Tamil', 'Telugu', 'Hindi (IN)', 'Tamil (IN)', 'Telugu (IN)' => 'in',


### PR DESCRIPTION
Map German (CH) mediainfo language to swiss flag