### PR TITLE
(Fix) Description overflow

### DIFF
--- a/resources/sass/components/_meta.scss
+++ b/resources/sass/components/_meta.scss
@@ -19,6 +19,7 @@
 .meta__description {
     grid-area: description;
     max-height: 150px;
+    overflow-y: auto;
     color: var(--meta-description-fg);
 }
 


### PR DESCRIPTION
TMDb has a maximum description length of 1000. The max height value was already included in the css, but seems that the overflow property was forgotten.