### PR TITLE
(Fix) Alternative styles for browsers that don't support `:has()`

### DIFF
--- a/resources/sass/pages/_torrents.scss
+++ b/resources/sass/pages/_torrents.scss
@@ -1,16 +1,18 @@
-.page__torrents:not(:has(.torrent-search--grouped__results)) {
-  margin: 0 calc(-1 * max(0px, 10vw - 60px)); /* Inverses the magic numbers used in the main layout styles */
-}
-
-@media only screen and (min-width: 1600px) {
+@supports selector(:has(.torrent-search-grouped_-results)) {
   .page__torrents:not(:has(.torrent-search--grouped__results)) {
-    margin: 0 calc(-1 * max(0px, 25vw - 300px)); /* Inverses the magic numbers used in the main layout styles */
+    margin: 0 calc(-1 * max(0px, 10vw - 60px)); /* Inverses the magic numbers used in the main layout styles */
   }
-}
 
-@media only screen and (min-width: 2500px) {
-  .page__torrents:not(:has(.torrent-search--grouped__results)) {
-    margin: 0 calc(-1 * max(0px, 45vw - 800px)); /* Inverses the magic numbers used in the main layout styles */
+  @media only screen and (min-width: 1600px) {
+    .page__torrents:not(:has(.torrent-search--grouped__results)) {
+      margin: 0 calc(-1 * max(0px, 25vw - 300px)); /* Inverses the magic numbers used in the main layout styles */
+    }
+  }
+
+  @media only screen and (min-width: 2500px) {
+    .page__torrents:not(:has(.torrent-search--grouped__results)) {
+      margin: 0 calc(-1 * max(0px, 45vw - 800px)); /* Inverses the magic numbers used in the main layout styles */
+    }
   }
 }
 
@@ -20,8 +22,16 @@
   row-gap: 2rem;
 }
 
-.torrent-search__filters {
-  margin: 0 max(12px, 45vw - 600px)
+@supports selector(:has(.torrent-search-grouped_-results)) {
+  .torrent-search__filters {
+    margin: 0 max(12px, 45vw - 600px)
+  }
+}
+
+@supports not selector(:has(.torrent-search-grouped_-results)) {
+  .torrent-search__filters {
+    margin: 0 calc(-1 * max(0px, 45vw - 800px) + max(12px, 45vw - 600px));
+  }
 }
 
 .torrent-search__results {


### PR DESCRIPTION
Since firefox doesn't yet support has, provide alternative styles.

Diff looks pretty hairy for this one due to the adding nesting. All that was done was wrapping the existing styles in `@supports` as well as having the advanced torrent search filters margin be explicitly added to the assumed page margin.