### PR TITLE
(Update) Scrollbar styles

### DIFF
--- a/resources/sass/base/_scrollbar.scss
+++ b/resources/sass/base/_scrollbar.scss
@@ -1,13 +1,34 @@
-::-webkit-scrollbar {
-    background: transparent;
+/* purgecss start ignore */
+@supports(overflow: overlay) {
+    body {
+        overflow: overlay;
+    }
+
+    ::-webkit-scrollbar {
+        background: transparent;
+    }
+
+    ::-webkit-scrollbar:vertical {
+        width: 12px;
+    }
+
+    ::-webkit-scrollbar:horizontal {
+        height: 12px;
+    }
+
+    ::-webkit-scrollbar-thumb {
+        background-color: transparent;
+        border-radius: 9999px;
+        border-color: transparent;
+        border-style: solid;
+        border-width: 4px 1px 4px 8px;
+        box-shadow: 4px 0px 0px 4px var(--scrollbar-color) inset;
+    }
+
+    ::-webkit-scrollbar-thumb:hover {
+        background-color: var(--scrollbar-color);
+        border-width: 0 2px 0 0;
+        box-shadow: none;
+    }
 }
-::-webkit-scrollbar:vertical {
-    width: 4px;
-}
-::-webkit-scrollbar:horizontal {
-    height: 4px;
-}
-::-webkit-scrollbar-thumb {
-    background-color: #333;
-    border-radius: 9999px;
-}
+/* purgecss end ignore */

--- a/resources/sass/main/_custom.scss
+++ b/resources/sass/main/_custom.scss
@@ -159,6 +159,8 @@
     --post-aside-fg: #696969;
     --post-footer-fg: var(--panel-fg);
 
+    --scrollbar-color: #0004;
+
     --select-border: 1px solid #555;
     --select-border-active: 2px solid #2195f3;
     --select-border-error: 1px solid #ba1b1b;

--- a/resources/sass/themes/cosmic-void.scss
+++ b/resources/sass/themes/cosmic-void.scss
@@ -150,6 +150,8 @@
     --post-aside-fg: #ccc;
     --post-footer-fg: var(--text-color);
 
+    --scrollbar-color: #ffffff13;
+
     --select-border: 1px solid #555;
     --select-border-active: 2px solid #2195f3;
     --select-border-error: 1px solid #ba1b1b;

--- a/resources/sass/themes/galactic.scss
+++ b/resources/sass/themes/galactic.scss
@@ -174,6 +174,8 @@
     --post-aside-fg: #ccc;
     --post-footer-fg: var(--text-color);
 
+    --scrollbar-color: #ffffff19;
+
     --select-border: 1px solid #555;
     --select-border-active: 2px solid #2195f3;
     --select-border-error: 1px solid #ba1b1b;


### PR DESCRIPTION
Fixes styles being removed when compiling for production.
Updates styles to overlay the scrollbar so that the header doesn't have an empty gap to the right of it, and also so that the sidebar expands in size when hovered over to make it easier to click.