### PR TITLE
(Update) Pagination background color

### DIFF
--- a/resources/sass/main/_custom.scss
+++ b/resources/sass/main/_custom.scss
@@ -128,12 +128,12 @@
     --notification-read: transparent;
     --notification-unread: #2bb666;
 
-    --paginate-bg: #e2e2e2;
-    --paginate-bg-hover: #d8d8d8;
-    --paginate-bg-current: #d2d2d2;
-    --paginate-fg: #555;
+    --paginate-bg: #373d43;
+    --paginate-bg-hover: #4f5964;
+    --paginate-bg-current: #454d55;
+    --paginate-fg: #ddd;
     --paginate-fg-disabled: #999;
-    --paginate-divider: #999;
+    --paginate-divider: #888;
 
     --panel-action-fg: #aaa;
     --panel-border: 1px solid #ddd;

--- a/resources/sass/themes/cosmic-void.scss
+++ b/resources/sass/themes/cosmic-void.scss
@@ -119,7 +119,7 @@
     --notification-unread: #444;
     --notification-read: transparent;
 
-    --paginate-bg: #272727;
+    --paginate-bg: #19191b;
     --paginate-bg-hover: #222;
     --paginate-bg-current: #202020;
     --paginate-fg: #888;

--- a/resources/sass/themes/galactic.scss
+++ b/resources/sass/themes/galactic.scss
@@ -143,7 +143,7 @@
     --notification-read: transparent;
     --notification-unread: var(--color-green);
 
-    --paginate-bg: #272727;
+    --paginate-bg: #1c1c1c;
     --paginate-bg-hover: #222;
     --paginate-bg-current: #202020;
     --paginate-fg: #888;


### PR DESCRIPTION
Make the pagination background color the same as the panel header background color for a better visual appearance.
Also inverts light theme's foreground colors so that it can be read on the new darker background color.