### PR TITLE
(Update) Swap infohash from ascii-encoded hex to binary

### DIFF
--- a/app/Helpers/Bencode.php
+++ b/app/Helpers/Bencode.php
@@ -213,7 +213,7 @@ class Bencode
 
     public static function get_infohash($t): string
     {
-        return sha1(self::bencode($t['info']));
+        return sha1(self::bencode($t['info']), true);
     }
 
     public static function get_meta($t): array

--- a/app/Http/Controllers/AnnounceController.php
+++ b/app/Http/Controllers/AnnounceController.php
@@ -390,7 +390,7 @@ class AnnounceController extends Controller
                     ->selectRaw('INET6_NTOA(ip) as ip')
             ])
             ->select(['id', 'free', 'doubleup', 'seeders', 'leechers', 'times_completed', 'status'])
-            ->where('info_hash', '=', $infoHash)
+            ->where('info_hash', '=', hex2bin($infoHash))
             ->first();
 
         // If Torrent Doesn't Exsist Return Error to Client

--- a/app/Http/Resources/TorrentResource.php
+++ b/app/Http/Resources/TorrentResource.php
@@ -52,7 +52,7 @@ class TorrentResource extends JsonResource
                 'media_info'      => $this->mediainfo,
                 'bd_info'         => $this->bdinfo,
                 'description'     => $this->description,
-                'info_hash'       => $this->info_hash,
+                'info_hash'       => bin2hex($this->info_hash),
                 'size'            => $this->size,
                 'num_file'        => $this->num_file,
                 'freeleech'       => $this->free.'%',
@@ -74,7 +74,7 @@ class TorrentResource extends JsonResource
                 'region_id'       => $this->when($this->region_id !== null, $this->region_id),
                 'created_at'      => $this->created_at,
                 'download_link'   => route('torrent.download.rsskey', ['id' => $this->id, 'rsskey' => auth('api')->user()->rsskey]),
-                'magnet_link'     => $this->when(config('torrent.magnet') === true, 'magnet:?dn='.$this->name.'&xt=urn:btih:'.$this->info_hash.'&as='.route('torrent.download.rsskey', ['id' => $this->id, 'rsskey' => auth('api')->user()->rsskey]).'&tr='.route('announce', ['passkey' => auth('api')->user()->passkey]).'&xl='.$this->size),
+                'magnet_link'     => $this->when(config('torrent.magnet') === true, 'magnet:?dn='.$this->name.'&xt=urn:btih:'.bin2hex($this->info_hash).'&as='.route('torrent.download.rsskey', ['id' => $this->id, 'rsskey' => auth('api')->user()->rsskey]).'&tr='.route('announce', ['passkey' => auth('api')->user()->passkey]).'&xl='.$this->size),
                 'details_link'    => route('torrent', ['id' => $this->id]),
             ],
         ];

--- a/app/Models/Torrent.php
+++ b/app/Models/Torrent.php
@@ -46,6 +46,15 @@ class Torrent extends Model
     ];
 
     /**
+     * The attributes that should not be included in audit log.
+     *
+     * @var array
+     */
+    protected $discarded = [
+        'info_hash',
+    ];
+
+    /**
      * Belongs To A User.
      */
     public function user(): \Illuminate\Database\Eloquent\Relations\BelongsTo

--- a/app/Services/Unit3dAnnounce.php
+++ b/app/Services/Unit3dAnnounce.php
@@ -27,7 +27,7 @@ class Unit3dAnnounce
         $isSuccess = self::put('torrents', [
             'id'              => $torrent->id,
             'status'          => $torrent->status,
-            'info_hash'       => $torrent->info_hash,
+            'info_hash'       => bin2hex($torrent->info_hash),
             'is_deleted'      => false,
             'seeders'         => $torrent->seeders,
             'leechers'        => $torrent->leechers,
@@ -47,7 +47,7 @@ class Unit3dAnnounce
     {
         $isSuccess = self::delete('torrents', [
             'id'        => $torrent->id,
-            'info_hash' => $torrent->info_hash,
+            'info_hash' => bin2hex($torrent->info_hash),
         ]);
 
         if (! $isSuccess) {
@@ -97,7 +97,7 @@ class Unit3dAnnounce
     {
         $isSuccess = self::delete('users', [
             'id'      => $user->id,
-            'passkey' => $user->info_hash,
+            'passkey' => $user->passkey,
         ]);
 
         if (! $isSuccess) {

--- a/database/factories/TorrentFactory.php
+++ b/database/factories/TorrentFactory.php
@@ -24,7 +24,7 @@ class TorrentFactory extends Factory
             'name'            => $this->faker->name(),
             'description'     => $this->faker->text(),
             'mediainfo'       => $this->faker->text(),
-            'info_hash'       => $this->faker->word(),
+            'info_hash'       => $this->faker->asciify('********************'),
             'file_name'       => $this->faker->word(),
             'num_file'        => $this->faker->randomNumber(),
             'size'            => $this->faker->randomFloat(),

--- a/database/migrations/2023_04_08_053641_alter_torrents_table.php
+++ b/database/migrations/2023_04_08_053641_alter_torrents_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        DB::statement("ALTER TABLE torrents ADD COLUMN info_hash2 BINARY(20) NOT NULL");
+        DB::table('torrents')->update([
+            'info_hash2' => DB::raw('UNHEX(info_hash)'),
+            'updated_at' => DB::raw('updated_at'),
+        ]);
+
+        Schema::table('torrents', function (Blueprint $table): void {
+            $table->dropColumn('info_hash');
+            $table->renameColumn('info_hash2', 'info_hash');
+            $table->index('info_hash');
+        });
+    }
+};

--- a/resources/views/components/partials/_torrent-group-row.blade.php
+++ b/resources/views/components/partials/_torrent-group-row.blade.php
@@ -45,7 +45,7 @@
     @endif
     @if (config('torrent.magnet') == 1)
         <a
-            href="magnet:?dn={{ $torrent->name }}&xt=urn:btih:{{ $torrent->info_hash }}&as={{ route('torrent.download.rsskey', ['id' => $torrent->id, 'rsskey' => auth()->user()->rsskey ]) }}&tr={{ route('announce', ['passkey' => $user->passkey]) }}&xl={{ $torrent->size }}"
+            href="magnet:?dn={{ $torrent->name }}&xt=urn:btih:{{ bin2hex($torrent->info_hash) }}&as={{ route('torrent.download.rsskey', ['id' => $torrent->id, 'rsskey' => auth()->user()->rsskey ]) }}&tr={{ route('announce', ['passkey' => $user->passkey]) }}&xl={{ $torrent->size }}"
             title="{{ __('common.magnet') }}"
         >
             <i class="{{ config('other.font-awesome') }} fa-magnet"></i>

--- a/resources/views/components/torrent/row.blade.php
+++ b/resources/views/components/torrent/row.blade.php
@@ -144,7 +144,7 @@
             @if (config('torrent.magnet'))
                 <a
                     class="torrent-search--list__maget form__contained-icon-button form__contained-icon-button--filled"
-                    href="magnet:?dn={{ $torrent->name }}&xt=urn:btih:{{ $torrent->info_hash }}&as={{ route('torrent.download.rsskey', ['id' => $torrent->id, 'rsskey' => auth()->user()->rsskey ]) }}&tr={{ route('announce', ['passkey' => auth()->user()->passkey]) }}&xl={{ $torrent->size }}"
+                    href="magnet:?dn={{ $torrent->name }}&xt=urn:btih:{{ bin2hex($torrent->info_hash) }}&as={{ route('torrent.download.rsskey', ['id' => $torrent->id, 'rsskey' => auth()->user()->rsskey ]) }}&tr={{ route('announce', ['passkey' => auth()->user()->passkey]) }}&xl={{ $torrent->size }}"
                     download
                     title="{{ __('common.magnet') }}"
                 >

--- a/resources/views/livewire/graveyard-search.blade.php
+++ b/resources/views/livewire/graveyard-search.blade.php
@@ -273,7 +273,7 @@
                                 </a>
                             @endif
                             @if (config('torrent.magnet') == 1)
-                                <a href="magnet:?dn={{ $torrent->name }}&xt=urn:btih:{{ $torrent->info_hash }}&as={{ route('torrent.download.rsskey', ['id' => $torrent->id, 'rsskey' => $user->rsskey ]) }}&tr={{ route('announce', ['passkey' => $user->passkey]) }}&xl={{ $torrent->size }}">
+                                <a href="magnet:?dn={{ $torrent->name }}&xt=urn:btih:{{ bin2hex($torrent->info_hash) }}&as={{ route('torrent.download.rsskey', ['id' => $torrent->id, 'rsskey' => $user->rsskey ]) }}&tr={{ route('announce', ['passkey' => $user->passkey]) }}&xl={{ $torrent->size }}">
                                     <button class="btn btn-primary btn-circle" type="button" title="{{ __('common.magnet') }}">
                                         <i class="{{ config('other.font-awesome') }} fa-magnet"></i>
                                     </button>

--- a/resources/views/torrent/partials/buttons.blade.php
+++ b/resources/views/torrent/partials/buttons.blade.php
@@ -20,7 +20,7 @@
             @endif
         @else
             <a
-                href="magnet:?dn={{ $torrent->name }}&xt=urn:btih:{{ $torrent->info_hash }}&as={{ route('torrent.download.rsskey', ['id' => $torrent->id, 'rsskey' => $user->rsskey ]) }}&tr={{ route('announce', ['passkey' => $user->passkey]) }}&xl={{ $torrent->size }}"
+                href="magnet:?dn={{ $torrent->name }}&xt=urn:btih:{{ bin2hex($torrent->info_hash) }}&as={{ route('torrent.download.rsskey', ['id' => $torrent->id, 'rsskey' => $user->rsskey ]) }}&tr={{ route('announce', ['passkey' => $user->passkey]) }}&xl={{ $torrent->size }}"
                 class="form__button form__button--filled form__button--centered"
             >
                 <i class='{{ config("other.font-awesome") }} fa-magnet'></i> {{ __('common.magnet') }}

--- a/tests/Feature/Http/Controllers/AnnounceControllerTest.php
+++ b/tests/Feature/Http/Controllers/AnnounceControllerTest.php
@@ -27,7 +27,7 @@ class AnnounceControllerTest extends TestCase
         $peer_id = '19045931013802080695'; // 20 bytes
 
         Torrent::factory()->create([
-            'info_hash' => bin2hex($info_hash),
+            'info_hash' => $info_hash,
             'status'    => 1, // Approved
         ]);
 


### PR DESCRIPTION
Currently, querying the torrents table by info_hash is responsible for 49.7% of all database execution time for a large tracker. Let's take some steps to fix that. First we shall use the appropriate binary(20) column type instead of using what's essentially a VARCHAR(40) column type using ascii-encoded hex. In a future PR, we shall implement a "infohash2id" cache and query the torrents table solely by their id.