### PR TITLE
(Update) Only update the torrents table a max of once per announce

### DIFF
--- a/app/Jobs/ProcessAnnounce.php
+++ b/app/Jobs/ProcessAnnounce.php
@@ -199,7 +199,7 @@ class ProcessAnnounce implements ShouldQueue
                 // End User Update
 
                 // Torrent Completed Update
-                $this->torrent->increment('times_completed');
+                $this->torrent->times_completed += 1;
                 break;
 
             case 'stopped':


### PR DESCRIPTION
Just update it a single time at the end of the job.