### PR TITLE
(Fix) Chrome not wrapping code blocks

### DIFF
--- a/resources/sass/components/_bbcode-rendered.scss
+++ b/resources/sass/components/_bbcode-rendered.scss
@@ -532,6 +532,7 @@
     padding: 0;
     margin: 0;
     word-break: normal;
+    overflow-wrap: anywhere;
     white-space: pre-wrap;
     background: transparent;
     border: 0;
@@ -545,6 +546,8 @@
     overflow: visible;
     line-height: inherit;
     word-wrap: normal;
+    word-break: normal;
+    overflow-wrap: anywhere;
     background-color: transparent;
     border: 0;
   }
@@ -554,6 +557,7 @@
     line-height: inherit;
     word-wrap: normal;
     word-break: break-word;
+    overflow-wrap: anywhere;
     white-space: pre-wrap;
   }
 


### PR DESCRIPTION
We don't want to cut words off unless necessary to remain inside the box, however chrome didn't like the previous styles we used to implement this and caused the text to overflow outside the box.