### PR TITLE
(Fix) Filled torrent name on request page

### DIFF
--- a/resources/views/requests/request.blade.php
+++ b/resources/views/requests/request.blade.php
@@ -169,9 +169,8 @@
                     <dd>
                         <a
                             href="{{ route('torrent', ['id' => $torrentRequest->torrent->id]) }}"
-                            title="{{ $torrentRequest->torrent->name }}"
                         >
-                            {{ $torrentRequest->name }}
+                            {{ $torrentRequest->torrent->name }}
                         </a>
                     </dd>
                 </dl>


### PR DESCRIPTION
We want to show the torrent's name that filled the request, not the name of the request.