### PR TITLE
(Update) Optimize navbar

### DIFF
--- a/resources/views/partials/top_nav.blade.php
+++ b/resources/views/partials/top_nav.blade.php
@@ -249,16 +249,23 @@
                     {{ auth()->user()->getDownloaded() }}
                 </a>
             </li>
+            @php
+                $peer_counts = Cache::remember(
+                    'users:'.auth()->id().':peer_counts',
+                    60,
+                    fn () => DB::table('peers')->selectRaw('SUM(seeder = 0) as leeching, SUM(seeder = 1) as seeding')->where('user_id', '=', auth()->id())->first()
+                )
+            @endphp
             <li class="ratio-bar__seeding" title="{{ __('torrent.seeding') }}">
                 <a href="{{ route('users.peers.index', ['user' => auth()->user()]) }}">
                     <i class="{{ config('other.font-awesome') }} fa-upload"></i>
-                    {{ Cache::remember('users:'.auth()->id().':seeding_count', 60, fn () => DB::table('peers')->distinct()->where('user_id', '=', auth()->id())->where('seeder', '=', 1)->count('torrent_id')) }}
+                    {{ $peer_counts->seeding }}
                 </a>
             </li>
             <li class="ratio-bar__leeching" title="{{ __('torrent.leeching') }}">
                 <a href="{{ route('users.peers.index', ['user' => auth()->user(), 'seeding' => 'exclude']) }}">
                     <i class="{{ config('other.font-awesome') }} fa-download"></i>
-                    {{ Cache::remember('users:'.auth()->id().':leeching_count', 60, fn () => DB::table('peers')->distinct()->where('user_id', '=', auth()->id())->where('seeder', '=', 0)->count('torrent_id')) }}
+                    {{ $peer_counts->leeching }}
                 </a>
             </li>
             <li class="ratio-bar__buffer" title="{{ __('common.buffer') }}">


### PR DESCRIPTION
The performance of counting the peers of a user is more important than only counting one peer per torrent.

Related discussion: https://github.com/HDInnovations/UNIT3D-Community-Edition/pull/2700#issuecomment-1510379081