### PR TITLE
(Add) More precise timestamps to torrent peers and history

### DIFF
--- a/resources/views/torrent/history.blade.php
+++ b/resources/views/torrent/history.blade.php
@@ -88,8 +88,16 @@
                                     </span>
                                 </span>
                             </td>
-                            <td>{{ $history->created_at ? $history->created_at->diffForHumans() : 'N/A' }}</td>
-                            <td>{{ $history->updated_at ? $history->updated_at->diffForHumans() : 'N/A' }}</td>
+                            <td>
+                                <time datetime="{{ $history->created_at }}" title="{{ $history->created_at }}">
+                                    {{ $history->created_at ? $history->created_at->diffForHumans() : 'N/A' }}
+                                </time>
+                            </td>
+                            <td>
+                                <time datetime="{{ $history->updated_at }}" title="{{ $history->updated_at }}">
+                                    {{ $history->updated_at ? $history->updated_at->diffForHumans() : 'N/A' }}
+                                </time>
+                            </td>
                             @if ($history->seedtime < config('hitrun.seedtime'))
                                 <td class="text-red">{{ App\Helpers\StringHelper::timeElapsed($history->seedtime) }}</td>
                             @else

--- a/resources/views/torrent/peers.blade.php
+++ b/resources/views/torrent/peers.blade.php
@@ -79,8 +79,16 @@
                                 @endphp
                                 <td>@choice('user.client-connectable-state', $connectable)</td>
                             @endif
-                            <td>{{ $peer->created_at ? $peer->created_at->diffForHumans() : 'N/A' }}</td>
-                            <td>{{ $peer->updated_at ? $peer->updated_at->diffForHumans() : 'N/A' }}</td>
+                            <td>
+                                <time datetime="{{ $peer->created_at }}" title="{{ $peer->created_at }}">
+                                    {{ $peer->created_at ? $peer->created_at->diffForHumans() : 'N/A' }}
+                                </time>
+                            </td>
+                            <td>
+                                <time datetime="{{ $peer->updated_at }}" title="{{ $peer->updated_at }}">
+                                    {{ $peer->updated_at ? $peer->updated_at->diffForHumans() : 'N/A' }}
+                                </time>
+                            </td>
                             <td class="{{ $peer->seeder ? 'text-green' : 'text-red' }}">
                                 @if ($peer->seeder == 0)
                                     {{ __('torrent.leecher') }}


### PR DESCRIPTION
Adding it in the title tag shows the most accurate timestamp when hovered over.