### PR TITLE
(Update) Remove bootstrap

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   "devDependencies": {
     "ajv": "^8.10.0",
     "axios": "^0.26.1",
-    "bootstrap-sass": "^3.4.3",
     "cross-env": "^7.0.3",
     "jquery": "^3.6.0",
     "laravel-echo": "^1.11.4",

--- a/resources/js/components/chat/Chatbox.vue
+++ b/resources/js/components/chat/Chatbox.vue
@@ -12,14 +12,14 @@
     <div
         :class="this.fullscreen == 1 ? `clearfix visible-sm-block panel-fullscreen` : `clearfix visible-sm-block`"
     ></div>
-    <div :class="this.fullscreen == 1 ? `panel panel-chat panel-fullscreen` : `panel panel-chat`">
-      <div class="panel-heading" id="frameHeader">
+    <section :class="this.fullscreen == 1 ? `panelV2 panel panel-chat panel-fullscreen` : `panelV2 panel panel-chat`">
+      <header class="panel__heading" id="frameHeader">
         <div class="button-holder no-space">
           <div class="button-left">
             <h4><i class="fas fa-comment-dots"></i> Chatbox v3.0</h4>
           </div>
           <div class="button-right">
-            <a href="" view="bot" @click.prevent="startBot()" class="btn btn-xs btn-warning">
+            <a href="" view="bot" @click.prevent="startBot()" class="form__button form__button--text">
               <i class="fa fa-robot"></i> {{ helpName }}
             </a>
             <a
@@ -27,7 +27,7 @@
                 view="list"
                 v-if="target < 1 && bot < 1 && tab != 'userlist'"
                 @click.prevent="changeTab('list', 'userlist')"
-                class="btn btn-xs btn-primary"
+                class="form__button form__button--text"
             >
               <i class="fa fa-users"></i> Users In {{ tab }}: {{ users.length }}
             </a>
@@ -35,30 +35,30 @@
                 href="#"
                 id="panel-fullscreen"
                 role="button"
-                :class="`btn btn-xs btn-success`"
+                :class="`form__button form__button--text`"
                 title="Toggle Fullscreen"
                 @click.prevent="changeFullscreen()"
             ><i
                 :class="
                                     this.fullscreen == 1
-                                        ? `glyphicon glyphicon-resize-small`
-                                        : `glyphicon glyphicon-resize-full`
+                                        ? `fas fa-compress`
+                                        : `fas fa-expand`
                                 "
             ></i>
             </a>
           </div>
         </div>
-      </div>
+      </header>
       <div class="panel-body" id="frameBody">
         <div id="frame" @mouseover="freezeChat()" @mouseout="unfreezeChat()">
           <div class="content no-space">
             <div class="button-holder nav nav-tabs mb-5" id="frameTabs">
               <div>
-                <ul role="tablist" class="nav nav-tabs no-border mb-0" v-if="boot == 1">
+                <ul role="tablist" class="panel__tabs no-border mb-0" v-if="boot == 1">
                   <li
                       v-for="echo in echoes"
                       v-if="echo.room && echo.room.name.length > 0"
-                      :class="tab != '' && tab === echo.room.name ? 'active' : null"
+                      :class="tab != '' && tab === echo.room.name ? 'panel__tab panel__tab--active' : 'panel__tab'"
                   >
                     <a
                         href=""
@@ -79,7 +79,7 @@
                   <li
                       v-for="echo in echoes"
                       v-if="echo.target && echo.target.id >= 3 && echo.target.username.length > 0"
-                      :class="target >= 3 && target === echo.target.id ? 'active' : null"
+                      :class="target >= 3 && target === echo.target.id ? 'panel__tab panel__tab--active' : 'panel__tab'"
                   >
                     <a
                         href=""
@@ -100,7 +100,7 @@
                   <li
                       v-for="echo in echoes"
                       v-if="echo.bot && echo.bot.id >= 1 && echo.bot.name.length > 0"
-                      :class="bot > 0 && bot === echo.bot.id ? 'active' : null"
+                      :class="bot > 0 && bot === echo.bot.id ? 'panel__tab panel__tab--active' : 'panel__tab'"
                   >
                     <a href="" role="tab" view="bot" @click.prevent="changeTab('bot', echo.bot.id)">
                       <i
@@ -174,7 +174,7 @@
         >
         </chat-form>
       </div>
-    </div>
+    </section>
   </div>
 </template>
 <style lang="scss" scoped>

--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -1,6 +1,3 @@
-// Web Font Components
-@import url('https://fonts.googleapis.com/css?family=Comfortaa:300,700|Ubuntu');
-
 // Vendor components
 @import '~bootstrap-sass/assets/stylesheets/bootstrap';
 @import 'vendor/font-awesome';

--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -60,6 +60,7 @@
 @import 'components/user-uploads';
 
 // Layout
+@import 'layout/footer';
 @import 'layout/header';
 @import 'layout/main';
 @import 'layout/secondary-nav';

--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -1,5 +1,4 @@
 // Vendor components
-@import '~bootstrap-sass/assets/stylesheets/bootstrap';
 @import 'vendor/font-awesome';
 @import '~sweetalert2/src/sweetalert2';
 @import 'vendor/virtual-select';

--- a/resources/sass/base/_typography.scss
+++ b/resources/sass/base/_typography.scss
@@ -1,3 +1,7 @@
+html {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
+}
+
 .fa:before,
 .fas:before {
     font-family: 'Font Awesome 5 Pro';

--- a/resources/sass/components/form/label.scss
+++ b/resources/sass/components/form/label.scss
@@ -13,7 +13,7 @@
     position: absolute;
     padding: 8px 4px 0 4px;
     display: inline-block;
-    top: 6px;
+    top: 3px;
     left: 8px;
     color: var(--label-fg);
     pointer-events: none;

--- a/resources/sass/components/form/select.scss
+++ b/resources/sass/components/form/select.scss
@@ -46,7 +46,7 @@
         padding: var(--select-padding-active);
 
         & + .form__label--floating {
-            top: -3px;
+            top: -5px;
             font-size: 11px;
             color: var(--label-fg-active);
             border-radius: 0;
@@ -57,7 +57,7 @@
     &:valid:not(.form__select--default),
     &:focus:placeholder-shown {
         & + .form__label--floating {
-            top: -3px;
+            top: -5px;
             font-size: 11px;
             border-radius: 0;
             padding: 0 4px;

--- a/resources/sass/components/form/text.scss
+++ b/resources/sass/components/form/text.scss
@@ -38,7 +38,7 @@
         padding: var(--input-text-padding-active);
 
         & + .form__label--floating {
-            top: -3px;
+            top: -5px;
             font-size: 11px;
             color: var(--label-fg-active);
             border-radius: 0;
@@ -50,7 +50,7 @@
     &:focus:placeholder-shown,
     &:read-only {
         & + .form__label--floating {
-            top: -3px;
+            top: -5px;
             font-size: 11px;
             border-radius: 0;
             padding: 0 4px;

--- a/resources/sass/components/form/textarea.scss
+++ b/resources/sass/components/form/textarea.scss
@@ -39,7 +39,7 @@
         height: 140px;
 
         & ~ .form__label--floating {
-            top: -3px;
+            top: -5px;
             font-size: 11px;
             color: var(--label-fg-active);
             border-radius: 0;
@@ -52,7 +52,7 @@
         height: 140px;
 
         & ~ .form__label--floating {
-            top: -3px;
+            top: -5px;
             font-size: 11px;
             border-radius: 0;
             padding: 0 4px;

--- a/resources/sass/layout/_footer.scss
+++ b/resources/sass/layout/_footer.scss
@@ -1,0 +1,33 @@
+html, body {
+    height: 100%;
+}
+
+.footer {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    position: sticky;
+    top: 100vh;
+    padding-top: 20px;
+}
+
+.footer__wrapper {
+    display: flex;
+    flex-wrap: wrap;
+    justify-items: center;
+    gap: 4rem;
+}
+
+.footer__section-title {
+    font-size: 22px;
+}
+
+.footer__section-list {
+    list-style-type: none;
+    padding-left: 6px;
+    font-size: 15px;
+}
+
+.footer__stats {
+    font-size: 14px;
+}

--- a/resources/sass/layout/_top_nav.scss
+++ b/resources/sass/layout/_top_nav.scss
@@ -62,10 +62,10 @@
         rgba(175, 99, 228, 1) 44%,
         rgba(141, 0, 255, 1) 86%
     );
-    font-weight: 900;
+    font-weight: 400;
     font-size: 2.5rem;
     text-shadow: rgba(52, 160, 230, 0.55) 0 0 1px;
-    font-family: Comfortaa, Helvetica Neue, Helvetica, Arial, sans-serif;
+    font-family: Helvetica Neue, Helvetica, Arial, sans-serif;
     text-transform: uppercase;
 }
 

--- a/resources/sass/main/_custom.scss
+++ b/resources/sass/main/_custom.scss
@@ -5202,11 +5202,6 @@ a.torrent-filename:visited {
     white-space: nowrap;
 }
 
-.footer,
-.footer-top {
-    padding: 20px 0;
-}
-
 .badge-float {
     border-radius: 5px !important;
 }
@@ -5235,20 +5230,6 @@ a.torrent-filename:visited {
 .embed-item {
     max-height: 100%;
     border: 0;
-}
-
-.footer {
-    background-color: #394245;
-}
-
-.footer-content {
-    padding: 20px 0;
-    color: #f0f0f0;
-}
-
-.subfooter {
-    padding: 10px 0;
-    font-size: 14px;
 }
 
 .separator {

--- a/resources/sass/main/_custom.scss
+++ b/resources/sass/main/_custom.scss
@@ -649,7 +649,6 @@ h3,
 h4,
 h5,
 h6 {
-    font-family: Comfortaa, 'Helvetica Neue', Helvetica, Arial, sans-serif;
     font-weight: 300;
     line-height: 1.1;
     color: inherit;

--- a/resources/views/livewire/person-search.blade.php
+++ b/resources/views/livewire/person-search.blade.php
@@ -18,19 +18,18 @@
         </div>
     </header>
     {{ $persons->links('partials.pagination') }}
-    <div class="panel__body">
+    <div class="panel__body" style="display: grid; grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); gap: 2rem;">
         @forelse ($persons as $person)
-            <div class="col-md-2 text-center">
-                <div class="thumbnail" style="min-height: 315px;">
-                    <a href="{{ route('mediahub.persons.show', ['id' => $person->id]) }}">
-                        <img alt="{{ $person->name }}"
-                             src="{{ isset($person->still) ? tmdb_image('cast_mid', $person->still) : 'https://via.placeholder.com/160x240' }}">
-                    </a>
-                    <div class="caption">
-                        <p class="text-bold">{{ $person->name }}</p>
-                    </div>
-                </div>
-            </div>
+            <figure style="display: flex; flex-direction: column; align-items: center">
+                <a href="{{ route('mediahub.persons.show', ['id' => $person->id]) }}">
+                    <img
+                        alt="{{ $person->name }}"
+                        src="{{ isset($person->still) ? tmdb_image('cast_mid', $person->still) : 'https://via.placeholder.com/160x240' }}"
+                        style="width: 140px; height: 140px; object-fit: cover; border-radius: 50%;"
+                    >
+                </a>
+                <figcaption>{{ $person->name }}</figcaption>
+            </figure>
         @empty
             No persons.
         @endforelse

--- a/resources/views/partials/footer.blade.php
+++ b/resources/views/partials/footer.blade.php
@@ -1,82 +1,98 @@
-@php $bg = rand(1, 13); $bgchange = $bg.".jpg" @endphp
-<br>
-<div id="l-footer" style="background-image: url('/img/footer/{{ $bgchange }}');">
-    <div class="container">
-        <div class="col-md-2 l-footer-section">
-            <h2 class="l-footer-section-title"><span class="text-bold">{{ config('other.title') }}</span></h2>
-            <footer>{{ config('other.meta_description') }}</footer>
-            <br>
+<footer class="footer">
+    <div class="footer__wrapper">
+        <section class="footer__section">
+            <h2 class="footer__section-title">
+                <b>{{ config('other.title') }}</b>
+            </h2>
+            <p>{{ config('other.meta_description') }}</p>
             <i class="{{ config('other.font-awesome') }} fa-tv-retro footer-icon" style="font-size: 90px;"></i>
-        </div>
-
-        <div class="col-md-2 l-footer-section">
-            <h2 class="l-footer-section-title">{{ __('common.account') }}</h2>
-            <ul>
+        </section>
+        <section class="footer__section">
+            <h2 class="footer__section-title">{{ __('common.account') }}</h2>
+            <ul class="footer__section-list">
                 <li>
-                    <a
-                            href="{{ route('users.show', ['username' => auth()->user()->username]) }}">{{ __('user.my-profile') }}</a>
+                    <a href="{{ route('users.show', ['username' => auth()->user()->username]) }}">{{ __('user.my-profile') }}</a>
                 </li>
                 <li>
-                    <a href="{{ route('logout') }}"
-                       onclick="event.preventDefault(); document.getElementById('logout-form').submit();">{{ __('common.logout') }}</a>
-                    <form id="logout-form" action="{{ route('logout') }}" method="POST" style="display: none;">@csrf
+                    <form action="{{ route('logout') }}" method="POST" style="display: contents;">
+                        @csrf
+                        <button style="display: contents">
+                            {{ __('common.logout') }}
+                        </button>
                     </form>
                 </li>
             </ul>
-        </div>
-
-        <div class="col-md-2 l-footer-section">
-            <h2 class="l-footer-section-title">{{ __('common.community') }}</h2>
-            <ul>
-                <li><a href="{{ route('forums.index') }}">{{ __('forum.forums') }}</a></li>
-                <li><a href="{{ route('articles.index') }}">{{ __('common.news') }}</a></li>
+        </section>
+        <section class="footer__section">
+            <h2 class="footer__section-title">{{ __('common.community') }}</h2>
+            <ul class="footer__section-list">
+                <li>
+                    <a href="{{ route('forums.index') }}">{{ __('forum.forums') }}</a>
+                </li>
+                <li>
+                    <a href="{{ route('articles.index') }}">{{ __('common.news') }}</a>
+                </li>
             </ul>
-        </div>
-
+        </section>
         @if ($footer_pages)
-            <div class="col-md-2 l-footer-section">
-                <h2 class="l-footer-section-title">{{ __('common.pages') }}</h2>
-                <ul>
+            <section class="footer__section">
+                <h2 class="footer__section-title">{{ __('common.pages') }}</h2>
+                <ul class="footer__section-list">
                     @foreach ($footer_pages as $page)
-                        <li><a href="{{ route('pages.show', ['id' => $page->id]) }}">{{ $page->name }}</a></li>
+                        <li>
+                            <a href="{{ route('pages.show', ['id' => $page->id]) }}">
+                                {{ $page->name }}
+                            </a>
+                        </li>
                     @endforeach
-                    <li><a href="{{ route('pages.index') }}">[View All]</a></li>
+                    <li>
+                        <a href="{{ route('pages.index') }}">[View All]</a>
+                    </li>
                 </ul>
-            </div>
+            </section>
         @endif
-
-        <div class="col-md-2 l-footer-section">
-            <h2 class="l-footer-section-title">{{ __('common.info') }}</h2>
-            <ul>
-                <li><a href="{{ route('staff') }}">{{ __('common.staff') }}</a></li>
-                <li><a href="{{ route('internal') }}">{{ __('common.internal') }}</a></li>
-                <li><a href="{{ route('client_blacklist') }}">{{ __('common.blacklist') }}</a></li>
-                <li><a href="{{ route('about') }}">{{ __('common.about') }}</a></li>
+        <section class="footer__section">
+            <h2 class="footer__section-title">{{ __('common.info') }}</h2>
+            <ul class="footer__section-list">
+                <li>
+                    <a href="{{ route('staff') }}">{{ __('common.staff') }}</a>
+                </li>
+                <li>
+                    <a href="{{ route('internal') }}">{{ __('common.internal') }}</a>
+                </li>
+                <li>
+                    <a href="{{ route('client_blacklist') }}">{{ __('common.blacklist') }}</a>
+                </li>
+                <li>
+                    <a href="{{ route('about') }}">{{ __('common.about') }}</a>
+                </li>
             </ul>
-        </div>
-
-        <div class="col-md-2 l-footer-section">
-            <h2 class="l-footer-section-title">{{ __('common.other') }}</h2>
-            <ul>
-                <li><a href="https://github.com/sponsors/HDVinnie" target="_blank"
-                       class="btn btn-xs btn-primary">{{ __('common.sponsor') }}</a></li>
-                <li><a href="https://github.com/HDInnovations/UNIT3D" target="_blank"
-                       class="btn btn-xs btn-primary">{{ __('common.powered-by') }}</a></li>
+        </section>
+        <section class="footer__section">
+            <h2 class="footer__section-title">{{ __('common.other') }}</h2>
+            <ul class="footer__section-list">
+                <li>
+                    <a
+                        href="https://github.com/sponsors/HDVinnie"
+                        target="_blank"
+                        class="form__button form__button--outlined"
+                    >
+                        {{ __('common.sponsor') }}
+                    </a>
+                </li>
+                <li>
+                    <a
+                        href="https://github.com/HDInnovations/UNIT3D"
+                        target="_blank"
+                        class="form__button form__button--outlined"
+                    >
+                        {{ __('common.powered-by') }}
+                    </a>
+                </li>
             </ul>
-        </div>
+        </section>
     </div>
-</div>
-
-<div class="subfooter text-center">
-    <div class="container">
-        <div class="subfooter-inner">
-            <div class="row">
-                <div class="col-md-12">
-                    <span class="text-bold">
-                        This page took {{ number_format(microtime(true) - (defined('LARAVEL_START') ? LARAVEL_START : request()->server('REQUEST_TIME_FLOAT')), 3) }} seconds to render and {{ number_format(memory_get_peak_usage(true) / 1024 / 1024, 2) }} MB of memory
-                    </span>
-                </div>
-            </div>
-        </div>
-    </div>
-</div>
+    <p class="footer__stats">
+        This page took {{ number_format(microtime(true) - (defined('LARAVEL_START') ? LARAVEL_START : request()->server('REQUEST_TIME_FLOAT')), 3) }} seconds to render and {{ number_format(memory_get_peak_usage(true) / 1024 / 1024, 2) }} MB of memory
+    </p>
+</footer>


### PR DESCRIPTION
After a year of moving the majority of styles to SASS, we can now finally remove our ancient version of bootstrap :partying_face:.

A few styles from mediahub are still in _custom.scss instead of grouped into components, but that will be cleaned up later.