### PR TITLE
(Fix) Chatbox styles windows

### DIFF
--- a/resources/sass/chat/chatbox.scss
+++ b/resources/sass/chat/chatbox.scss
@@ -483,6 +483,7 @@
                         max-width: 100%;
                         line-height: 130%;
                         font-size: 14pt;
+                        font-weight: 400;
 
                         .system {
                             font-size: 12pt;


### PR DESCRIPTION
With the bootstrap removal, some other custom CSS is now overwriting chatbox message font weight to 300. Let's explicitly define it to 400 (normal).