### PR TITLE
(Fix) Chatbox fonts

### DIFF
--- a/resources/sass/chat/chatbox.scss
+++ b/resources/sass/chat/chatbox.scss
@@ -482,11 +482,11 @@
                         width: 100%;
                         max-width: 100%;
                         line-height: 130%;
-                        font-size: 14pt;
+                        font-size: 18px;
                         font-weight: 400;
 
                         .system {
-                            font-size: 12pt;
+                            font-size: 16px;
                             color: #939393;
                             padding: 0;
                             margin: 0;


### PR DESCRIPTION
Using pt units causes issues with windows not applying cleartype / subpixel anti-aliasing.