### PR TITLE
(Bug) Fix torrent free removal

### DIFF
--- a/app/Http/Controllers/TorrentBuffController.php
+++ b/app/Http/Controllers/TorrentBuffController.php
@@ -96,7 +96,7 @@ class TorrentBuffController extends Controller
         $torrentFlAmount = $request->input('freeleech');
 
         $v = validator($request->input(), [
-            'freeleech' => 'numeric|not_in:0',
+            'freeleech' => 'numeric|min:0|max:100',
         ]);
 
         if ($v->fails()) {


### PR DESCRIPTION
Since the view for Freeleech (option "No" equals value 0) uses 0, this must be a valid option in the TorrentBuffController.