### PR TITLE
(Bug) Fix Usericon spacing in forum posts

### DIFF
--- a/resources/views/components/forum/post.blade.php
+++ b/resources/views/components/forum/post.blade.php
@@ -133,7 +133,7 @@
             :anon="false"
             :user="$post->user"
         >
-            <x-slot:appended-icons>
+            <x-slot:appendedIcons>
                 @if ($post->user->isOnline())
                     <i class="{{ config('other.font-awesome') }} fa-circle text-green" title="Online"></i>
                 @else


### PR DESCRIPTION
This will ensure that username icons, such as isOnline & personal message, are the same style as on user profile blades. Also, fixed the spacing and padding on forum posts for those two icons.