### PR TITLE
(Fix) Multiple bbcode editors on same page

### DIFF
--- a/resources/views/livewire/bbcode-input.blade.php
+++ b/resources/views/livewire/bbcode-input.blade.php
@@ -25,10 +25,10 @@
     }"
 >
     <p class="bbcode-input__tabs">
-        <input class="bbcode-input__tab-input" type="radio" id="bbcode-preview-disabled" name="isPreviewEnabled" value="0" wire:model="isPreviewEnabled" />
-        <label class="bbcode-input__tab-label" for="bbcode-preview-disabled">Write</label>
-        <input class="bbcode-input__tab-input" type="radio" id="bbcode-preview-enabled" name="isPreviewEnabled" value="1" wire:model="isPreviewEnabled" />
-        <label class="bbcode-input__tab-label" for="bbcode-preview-enabled">{{ __('common.preview') }}</label>
+        <input class="bbcode-input__tab-input" type="radio" id="{{ $name }}-bbcode-preview-disabled" name="isPreviewEnabled" value="0" wire:model="isPreviewEnabled" />
+        <label class="bbcode-input__tab-label" for="{{ $name }}-bbcode-preview-disabled">Write</label>
+        <input class="bbcode-input__tab-input" type="radio" id="{{ $name }}-bbcode-preview-enabled" name="isPreviewEnabled" value="1" wire:model="isPreviewEnabled" />
+        <label class="bbcode-input__tab-label" for="{{ $name }}-bbcode-preview-enabled">{{ __('common.preview') }}</label>
     </p>
     <p class="bbcode-input__icon-bar-toggle">
         <button type="button" class="form__button form__button--text" x-on:click="showButtons = ! showButtons">BBCode</button>


### PR DESCRIPTION
Otherwise only the first bbcode editor responds. I believe the only page currently with multiple bbcode editors is the profile edit page that's used to edit both the user's `about` as well as their forum signature.