### PR TITLE
(Fix) Card genre link

### DIFF
--- a/resources/views/components/torrent/card.blade.php
+++ b/resources/views/components/torrent/card.blade.php
@@ -105,7 +105,7 @@
             <ul class="torrent-card__genres">
                 @foreach($meta->genres as $genre)
                     <li class="torrent-card__genre-item">
-                        <a class="torrent-card__genre" href="{{ route('torrents', ['view' => 'group', 'genres' => $genre->id]) }}">
+                        <a class="torrent-card__genre" href="{{ route('torrents', ['view' => 'group', 'genres' => [$genre->id]]) }}">
                             {{ $genre->name }}
                         </a>
                     </li>


### PR DESCRIPTION
The old generated link doesn't work since it uses `?genres=xxxx` instead of `?genres[0]=xxxx`