### PR TITLE
(Fix) BBCode quote border on certain themes

### DIFF
--- a/resources/sass/main/_custom.scss
+++ b/resources/sass/main/_custom.scss
@@ -35,7 +35,7 @@
     --bbcode-rendered-attention-subtle: #7289da;
     --bbcode-rendered-danger-fg: #ff141ccc;
     --bbcode-rendered-quote-bg: #6662;
-    --bbcode-rendered-quote-border: var(--color-green);
+    --bbcode-rendered-quote-border: #707070;
 
     --button-filled-bg: #5cb579 linear-gradient(to bottom right, #0ba360, #2bb673);
     --button-filled-border: none;


### PR DESCRIPTION
On light theme and cosmic void theme, the quote border color wasn't defined.