### PR TITLE
(Fix) BBCode preview styles

### DIFF
--- a/resources/views/livewire/bbcode-input.blade.php
+++ b/resources/views/livewire/bbcode-input.blade.php
@@ -189,9 +189,9 @@
     </menu>
     <div class="bbcode-input__tab-pane">
         @if ($isPreviewEnabled)
-            <p class="bbcode-input__preview bbcode-rendered">
+            <div class="bbcode-input__preview bbcode-rendered">
                 @joypixels($contentHtml)
-            </p>
+            </div>
             <input type="hidden" name="{{ $name }}" wire:model.defer="contentBbcode">
         @else
             <p class="form__group">


### PR DESCRIPTION
BBCode preview can contain elements which can't be contained in a p tag. In these cases, browsers move the contents outside of the p tag to which they no longer get styled by the bbcode-rendered class.