### PR TITLE
(Fix) Don't sort pinned topics first in index

### DIFF
--- a/app/Http/Livewire/TopicSearch.php
+++ b/app/Http/Livewire/TopicSearch.php
@@ -71,7 +71,6 @@ class TopicSearch extends Component
                     ->where('forum_id', '=', $this->forumId)
                     ->orWhereIn('forum_id', Forum::where('parent_id', '=', $this->forumId)->select('id'))
             ))
-            ->orderByDesc('pinned')
             ->orderBy($this->sortField, $this->sortDirection)
             ->paginate(25);
     }


### PR DESCRIPTION
There's too many of them to be useful in a global index across all forums