### PR TITLE
(Fix) Comment children avatars

### DIFF
--- a/app/Http/Livewire/Comments.php
+++ b/app/Http/Livewire/Comments.php
@@ -178,7 +178,7 @@ class Comments extends Component
     {
         return $this->model
             ->comments()
-            ->with(['user:id,username,group_id,image', 'user.group', 'children.user:id,username,group_id', 'children.user.group', 'children.children'])
+            ->with(['user:id,username,group_id,image', 'user.group', 'children.user:id,username,group_id,image', 'children.user.group'])
             ->parent()
             ->latest()
             ->paginate($this->perPage);


### PR DESCRIPTION
Also remove unnecessary query: comments can only be replied to once, so children of children of comments don't exist.