### PR TITLE
(Fix) Request alignment due to unneeded html block

### DIFF
--- a/resources/views/requests/create.blade.php
+++ b/resources/views/requests/create.blade.php
@@ -105,7 +105,6 @@
                                 value="{{ $tmdb ?: old('tmdb') }}"
                             >
                             <label class="form__label form__label--floating" for="autotmdb">TMDB ID</label>
-                            <output name="apimatch" id="apimatch" for="torrent"></output>
                         </p>
                         <p class="form__group">
                             <input type="hidden" name="imdb" value="0" />


### PR DESCRIPTION
Copied from the torrent upload page where the html is used to display the movie/tv title and year from tmdb after autodetecting from uploaded torrent name. But that's not used for requests, and keeping it causes the boxes to not line up, so it should be removed.