### PR TITLE
(Fix) Post username overflowing container

### DIFF
--- a/resources/sass/components/forum/_post.scss
+++ b/resources/sass/components/forum/_post.scss
@@ -27,7 +27,7 @@
         'aside header'
         'aside content'
         'aside footer';
-    grid-template-columns: 153px minmax(0, 1fr);
+    grid-template-columns: minmax(153px, min-content) minmax(0, 1fr);
     grid-template-rows: auto 1fr auto;
     border-radius: 5px;
     box-shadow: var(--post-shadow);


### PR DESCRIPTION
Make sure the post is at least 153px wide and at most the width of the username.

If the width of the username is less than 153px, then the max is ignored: https://developer.mozilla.org/en-US/docs/Web/CSS/minmax