### PR TITLE
Add huntr.dev to SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,11 +14,6 @@
 
 ## Reporting a Vulnerability
 
-If you discover any security related issues, please email hdinnovations@protonmail.com instead of using the issue tracker.
-
-
-# Reporting a Vulnerability
-
 If you discover a security vulnerability in unit3d-community-edition please disclose it via [our huntr page](https://huntr.dev/repos/hdinnovations/unit3d-community-edition/). Information about bounties, CVEs, response times and past reports are all there..
 
 Thank you for improving the security of unit3d-community-edition.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,3 +15,10 @@
 ## Reporting a Vulnerability
 
 If you discover any security related issues, please email hdinnovations@protonmail.com instead of using the issue tracker.
+
+
+# Reporting a Vulnerability
+
+If you discover a security vulnerability in unit3d-community-edition please disclose it via [our huntr page](https://huntr.dev/repos/hdinnovations/unit3d-community-edition/). Information about bounties, CVEs, response times and past reports are all there..
+
+Thank you for improving the security of unit3d-community-edition.


### PR DESCRIPTION
As requested through the platform by @hdvinnie, this will point your security policy to [huntr.dev](https://huntr.dev/repos/hdinnovations/unit3d-community-edition})