### PR TITLE
(Fix) Browsing to page 2 of inbox search results

### DIFF
--- a/resources/views/user/pm/index.blade.php
+++ b/resources/views/user/pm/index.blade.php
@@ -25,9 +25,7 @@
                 <form
                     class="panel__action"
                     action="{{ route('searchPMInbox') }}"
-                    method="POST"
                 >
-                    @csrf
                     <p class="form__group">
                         <input
                             id="search"

--- a/resources/views/user/pm/outbox.blade.php
+++ b/resources/views/user/pm/outbox.blade.php
@@ -25,9 +25,7 @@
                 <form
                     class="panel__action"
                     action="{{ route('searchPMOutbox') }}"
-                    method="POST"
                 >
-                    @csrf
                     <p class="form__group">
                         <input
                             id="search"

--- a/routes/web.php
+++ b/routes/web.php
@@ -530,8 +530,8 @@ Route::group(['middleware' => 'language'], function (): void {
 
         // Private Messages
         Route::group(['prefix' => 'mail'], function (): void {
-            Route::post('/searchPMInbox', [App\Http\Controllers\User\PrivateMessageController::class, 'searchPMInbox'])->name('searchPMInbox');
-            Route::post('/searchPMOutbox', [App\Http\Controllers\User\PrivateMessageController::class, 'searchPMOutbox'])->name('searchPMOutbox');
+            Route::get('/searchPMInbox', [App\Http\Controllers\User\PrivateMessageController::class, 'searchPMInbox'])->name('searchPMInbox');
+            Route::get('/searchPMOutbox', [App\Http\Controllers\User\PrivateMessageController::class, 'searchPMOutbox'])->name('searchPMOutbox');
             Route::get('/inbox', [App\Http\Controllers\User\PrivateMessageController::class, 'getPrivateMessages'])->name('inbox');
             Route::get('/message/{id}', [App\Http\Controllers\User\PrivateMessageController::class, 'getPrivateMessageById'])->name('message');
             Route::get('/outbox', [App\Http\Controllers\User\PrivateMessageController::class, 'getPrivateMessagesSent'])->name('outbox');


### PR DESCRIPTION
The paginate() function only works with GET requests. POST is only required for database changes, and these functions only read the database, so they can be converted to GET. Partially reverts #427.