### PR TITLE
(Fix) Parenthesis where there's not supposed to be one

### DIFF
--- a/resources/views/components/tv/card.blade.php
+++ b/resources/views/components/tv/card.blade.php
@@ -147,7 +147,7 @@
                 @foreach ($season['Episodes'] ?? [] as $episodeName => $episode)
                     <details
                         class="torrent-search--grouped__dropdown"
-                        @if ($loop->last && ! $season->has('Season Pack')))
+                        @if ($loop->last && ! $season->has('Season Pack'))
                             open
                         @endif
                     >


### PR DESCRIPTION
A user pointed this error out in the dev console.