### PR TITLE
(Fix) Updating group should allow slots to be nullable

### DIFF
--- a/app/Http/Requests/Staff/StoreGroupRequest.php
+++ b/app/Http/Requests/Staff/StoreGroupRequest.php
@@ -35,7 +35,7 @@ class StoreGroupRequest extends FormRequest
             'name'             => 'required|string|unique:groups',
             'position'         => 'required|integer',
             'level'            => 'required|integer',
-            'download_slots'   => 'integer',
+            'download_slots'   => 'nullable|integer',
             'color'            => 'required',
             'icon'             => 'required',
             'effect'           => 'sometimes',

--- a/app/Http/Requests/Staff/UpdateGroupRequest.php
+++ b/app/Http/Requests/Staff/UpdateGroupRequest.php
@@ -35,7 +35,7 @@ class UpdateGroupRequest extends FormRequest
             'name'             => 'required|string',
             'position'         => 'required|integer',
             'level'            => 'required|integer',
-            'download_slots'   => 'integer',
+            'download_slots'   => 'nullable|integer',
             'color'            => 'required',
             'icon'             => 'required',
             'effect'           => 'sometimes',


### PR DESCRIPTION
If the field isn't filled out, that means it will be null which signifies the the group has no slots, i.e. the slots are unlimited.