### PR TITLE
(Fix) floating labels relying on placeholder="" in chrome

### DIFF
--- a/resources/js/components/chat/ChatForm.vue
+++ b/resources/js/components/chat/ChatForm.vue
@@ -82,7 +82,7 @@
                 id="chat-message"
                 class="chatbox__textarea form__textarea"
                 name="message"
-                placeholder=""
+                placeholder=" "
                 send="true"
             ></textarea>
         <label class="form__label form__label--floating">Write your message...</label>

--- a/resources/sass/components/form/textarea.scss
+++ b/resources/sass/components/form/textarea.scss
@@ -2,7 +2,7 @@
  * Usage
  *
  * <p class="form__group">
- *     <textarea id="textarea" class="form__textarea" placeholder=""></textarea>
+ *     <textarea id="textarea" class="form__textarea" placeholder=" "></textarea>
  *     <label class="form__label form__label--floating" for="textarea"></label>
  *     @error('error')
  *         <span class="form__hint">{{ $error }}</span>

--- a/resources/views/Staff/application/show.blade.php
+++ b/resources/views/Staff/application/show.blade.php
@@ -127,7 +127,7 @@
                                     value="{{ $application->email }}"
                                 >
                                 <p class="form__group">
-                                    <textarea id="approve" class="form__textarea" name="approve" placeholder="">Application Approved!</textarea>
+                                    <textarea id="approve" class="form__textarea" name="approve" placeholder=" ">Application Approved!</textarea>
                                     <label class="form__label form__label--floating" for="approve">Invitation Message</label>
                                 </p>
                                 <p class="form__group">

--- a/resources/views/Staff/category/create.blade.php
+++ b/resources/views/Staff/category/create.blade.php
@@ -39,7 +39,7 @@
                         class="form__text"
                         type="text"
                         name="name"
-                        placeholder=""
+                        placeholder=" "
                     >
                     <label class="form__label form__label--floating" for="name">{{ __('common.name') }}<label>
                 </p>
@@ -49,7 +49,7 @@
                         class="form__text"
                         type="text"
                         name="position"
-                        placeholder=""
+                        placeholder=" "
                     >
                     <label class="form__label form__label--floating" for="positon">{{ __('common.position') }}</label>
                 </p>
@@ -59,7 +59,7 @@
                         class="form__text"
                         type="text"
                         name="icon"
-                        placeholder=""
+                        placeholder=" "
                     >
                     <label class="form__label form__label--floating" for="icon">{{ __('common.icon') }} (FontAwesome)</label>
                 </p>

--- a/resources/views/Staff/chat/bot/edit.blade.php
+++ b/resources/views/Staff/chat/bot/edit.blade.php
@@ -55,7 +55,7 @@
                         id="name"
                         class="form__text"
                         name="name"
-                        placeholder=""
+                        placeholder=" "
                         type="text"
                         value="{{ $bot->name }}"
                     >
@@ -68,7 +68,7 @@
                         inputmode="numeric"
                         name="position"
                         pattern="[0-9]*"
-                        placeholder=""
+                        placeholder=" "
                         type="text"
                         value="{{ $bot->position }}"
                     >
@@ -79,7 +79,7 @@
                         id="command"
                         class="form__text"
                         name="command"
-                        placeholder=""
+                        placeholder=" "
                         type="text"
                         value="{{ $bot->command }}"
                     >
@@ -90,7 +90,7 @@
                         id="info"
                         class="form__text"
                         name="info"
-                        placeholder=""
+                        placeholder=" "
                         type="text"
                         value="{{ $bot->info }}"
                     >
@@ -101,7 +101,7 @@
                         id="about"
                         class="form__text"
                         name="about"
-                        placeholder=""
+                        placeholder=" "
                         type="text"
                         value="{{ $bot->about }}"
                     >
@@ -112,7 +112,7 @@
                         id="emoji"
                         class="form__text"
                         name="emoji"
-                        placeholder=""
+                        placeholder=" "
                         type="text"
                         value="{{ $bot->emoji }}"
                     >
@@ -123,7 +123,7 @@
                         id="icon"
                         class="form__text"
                         name="icon"
-                        placeholder=""
+                        placeholder=" "
                         type="text"
                         value="{{ $bot->icon }}"
                     >
@@ -134,7 +134,7 @@
                         id="color"
                         class="form__text"
                         name="color"
-                        placeholder=""
+                        placeholder=" "
                         type="text"
                         value="{{ $bot->color }}"
                     >
@@ -145,7 +145,7 @@
                         id="help"
                         class="form__textarea"
                         name="help"
-                        placeholder=""
+                        placeholder=" "
                     >{{ $bot->help }}</textarea>
                     <label class="form__label form__label--floating" for="help">{{ __('bot.help') }}</label>
                 </p>

--- a/resources/views/Staff/forum/create.blade.php
+++ b/resources/views/Staff/forum/create.blade.php
@@ -44,7 +44,7 @@
                     <label class="form__label form__label--floating" for="name">Title</label>
                 </p>
                 <p class="form__group">
-                    <textarea id="description" class="form__textarea" name="description" placeholder=""></textarea>
+                    <textarea id="description" class="form__textarea" name="description" placeholder=" "></textarea>
                     <label class="form__label form__label--floating" for="description">Description</label>
                 </p>
                 <p class="form__group">
@@ -65,7 +65,7 @@
                         inputmode="numeric"
                         name="position"
                         pattern="[0-9]*"
-                        placeholder=""
+                        placeholder=" "
                         type="text"
                     >
                     <label class="form__label form__label--floating" for="position">{{ __('common.position') }}</label>

--- a/resources/views/Staff/forum/edit.blade.php
+++ b/resources/views/Staff/forum/edit.blade.php
@@ -79,7 +79,7 @@
                         inputmode="numeric"
                         name="position"
                         pattern="[0-9]*"
-                        placeholder=""
+                        placeholder=" "
                         type="text"
                         value="{{ $forum->position }}"
                         required

--- a/resources/views/Staff/group/create.blade.php
+++ b/resources/views/Staff/group/create.blade.php
@@ -29,7 +29,7 @@
                         class="form__text"
                         type="text"
                         name="name"
-                        placeholder=""
+                        placeholder=" "
                     />
                     <label class="form__label form__label--floating">
                         {{ __('common.name') }}
@@ -40,7 +40,7 @@
                         class="form__text"
                         type="text"
                         name="position"
-                        placeholder=""
+                        placeholder=" "
                     />
                     <label class="form__label form__label--floating">
                         {{ __('common.position') }}
@@ -51,7 +51,7 @@
                         class="form__text"
                         type="text"
                         name="level"
-                        placeholder=""
+                        placeholder=" "
                     />
                     <label class="form__label form__label--floating">
                         Level
@@ -62,7 +62,7 @@
                         class="form__text"
                         type="text"
                         name="download_slots"
-                        placeholder=""
+                        placeholder=" "
                     />
                     <label class="form__label form__label--floating">
                         DL Slots
@@ -73,7 +73,7 @@
                         class="form__text"
                         type="text"
                         name="color"
-                        placeholder=""
+                        placeholder=" "
                     />
                     <label class="form__label form__label--floating">
                         Color (e.g. #ff0000)
@@ -84,7 +84,7 @@
                         class="form__text"
                         type="text"
                         name="icon"
-                        placeholder=""
+                        placeholder=" "
                     />
                     <label class="form__label form__label--floating">
                         FontAwesome Icon (e.g. fas fa-user)

--- a/resources/views/Staff/group/edit.blade.php
+++ b/resources/views/Staff/group/edit.blade.php
@@ -32,7 +32,7 @@
                         class="form__text"
                         type="text"
                         name="name"
-                        placeholder=""
+                        placeholder=" "
                         value="{{ $group->name }}"
                     />
                     <label class="form__label form__label--floating">
@@ -44,7 +44,7 @@
                         class="form__text"
                         type="text"
                         name="position"
-                        placeholder=""
+                        placeholder=" "
                         value="{{ $group->position }}"
                     />
                     <label class="form__label form__label--floating">
@@ -56,7 +56,7 @@
                         class="form__text"
                         type="text"
                         name="level"
-                        placeholder=""
+                        placeholder=" "
                         value="{{ $group->level }}"
                     />
                     <label class="form__label form__label--floating">
@@ -68,7 +68,7 @@
                         class="form__text"
                         type="text"
                         name="download_slots"
-                        placeholder=""
+                        placeholder=" "
                         value="{{ $group->download_slots }}"
                     />
                     <label class="form__label form__label--floating">
@@ -80,7 +80,7 @@
                         class="form__text"
                         type="text"
                         name="color"
-                        placeholder=""
+                        placeholder=" "
                         value="{{ $group->color }}"
                     />
                     <label class="form__label form__label--floating">
@@ -92,7 +92,7 @@
                         class="form__text"
                         type="text"
                         name="icon"
-                        placeholder=""
+                        placeholder=" "
                         value="{{ $group->icon }}"
                     />
                     <label class="form__label form__label--floating">

--- a/resources/views/Staff/poll/create.blade.php
+++ b/resources/views/Staff/poll/create.blade.php
@@ -54,7 +54,7 @@
                             class="form__text"
                             name="options[]"
                             type="text"
-                            placeholder=""
+                            placeholder=" "
                         >
                         <label class="form__label form__label--floating" x-bind:for="'option' + option">
                             {{ __('poll.option') }}

--- a/resources/views/Staff/rss/create.blade.php
+++ b/resources/views/Staff/rss/create.blade.php
@@ -51,7 +51,7 @@
                     inputmode="numeric"
                     name="position"
                     pattern="[0-9]*"
-                    placeholder=""
+                    placeholder=" "
                     type="text"
                 >
                 <label class="form__label form__label--floating" for="position">
@@ -63,7 +63,7 @@
                     id="search"
                     class="form__text"
                     name="search"
-                    placeholder=""
+                    placeholder=" "
                     type="text"
                 >
                 <label class="form__label form__label--floating" for="search">
@@ -76,7 +76,7 @@
                     type="text"
                     class="form__text"
                     name="description"
-                    placeholder=""
+                    placeholder=" "
                 >
                 <label class="form__label form__label--floating" for="description">
                     {{ __('torrent.torrent') }} {{ __('torrent.description') }}
@@ -88,7 +88,7 @@
                     type="text"
                     class="form__text"
                     name="uploader"
-                    placeholder=""
+                    placeholder=" "
                 >
                 <label class="form__label form__label--floating" for="uploader">
                     {{ __('torrent.torrent') }} {{ __('torrent.uploader') }}
@@ -102,7 +102,7 @@
                         inputmode="numeric"
                         name="tmdb"
                         pattern="[0-9]*"
-                        placeholder=""
+                        placeholder=" "
                         type="text"
                     >
                     <label class="form__label form__label--floating" for="tmdb">
@@ -116,7 +116,7 @@
                         inputmode="numeric"
                         name="imdb"
                         pattern="[0-9]*"
-                        placeholder=""
+                        placeholder=" "
                         type="text"
                     >
                     <label class="form__label form__label--floating" for="imdb">
@@ -130,7 +130,7 @@
                         inputmode="numeric"
                         name="tvdb"
                         pattern="[0-9]*"
-                        placeholder=""
+                        placeholder=" "
                         type="text"
                     >
                     <label class="form__label form__label--floating" for="tvdb">
@@ -145,7 +145,7 @@
                         inputmode="numeric"
                         name="mal"
                         pattern="[0-9]*"
-                        placeholder=""
+                        placeholder=" "
                         type="text"
                     >
                     <label class="form__label form__label--floating" for="mal">

--- a/resources/views/Staff/rss/edit.blade.php
+++ b/resources/views/Staff/rss/edit.blade.php
@@ -53,7 +53,7 @@
                     inputmode="numeric"
                     name="position"
                     pattern="[0-9]*"
-                    placeholder=""
+                    placeholder=" "
                     type="text"
                     value="{{ $rss->position }}"
                 >
@@ -66,7 +66,7 @@
                     id="search"
                     class="form__text"
                     name="search"
-                    placeholder=""
+                    placeholder=" "
                     type="text"
                     value="{{ $rss->object_torrent->search }}"
                 >
@@ -80,7 +80,7 @@
                     type="text"
                     class="form__text"
                     name="description"
-                    placeholder=""
+                    placeholder=" "
                     value="{{ $rss->object_torrent->description }}"
                 >
                 <label class="form__label form__label--floating" for="description">
@@ -93,7 +93,7 @@
                     type="text"
                     class="form__text"
                     name="uploader"
-                    placeholder=""
+                    placeholder=" "
                     value="{{ $rss->object_torrent->uploader }}"
                 >
                 <label class="form__label form__label--floating" for="uploader">
@@ -108,7 +108,7 @@
                         inputmode="numeric"
                         name="tmdb"
                         pattern="[0-9]*"
-                        placeholder=""
+                        placeholder=" "
                         type="text"
                         value="{{ $rss->object_torrent->tmdb }}"
                     >
@@ -123,7 +123,7 @@
                         inputmode="numeric"
                         name="imdb"
                         pattern="[0-9]*"
-                        placeholder=""
+                        placeholder=" "
                         type="text"
                         value="{{ $rss->object_torrent->imdb }}"
                     >
@@ -138,7 +138,7 @@
                         inputmode="numeric"
                         name="tvdb"
                         pattern="[0-9]*"
-                        placeholder=""
+                        placeholder=" "
                         type="text"
                         value="{{ $rss->object_torrent->tvdb }}"
                     >
@@ -154,7 +154,7 @@
                         inputmode="numeric"
                         name="mal"
                         pattern="[0-9]*"
-                        placeholder=""
+                        placeholder=" "
                         type="text"
                         value="{{ $rss->object_torrent->mal }}"
                     >

--- a/resources/views/Staff/user/edit.blade.php
+++ b/resources/views/Staff/user/edit.blade.php
@@ -90,7 +90,7 @@
                         id="title"
                         class="form__text"
                         name="title"
-                        placeholder=""
+                        placeholder=" "
                         type="text"
                         value="{{ $user->title }}"
                     >

--- a/resources/views/auth/application/create.blade.php
+++ b/resources/views/auth/application/create.blade.php
@@ -76,7 +76,7 @@
                                         class="form__text"
                                         name="images[]"
                                         type="url"
-                                        placeholder=""
+                                        placeholder=" "
                                         required
                                     >
                                     <label
@@ -96,7 +96,7 @@
                                         class="form__text"
                                         name="links[]"
                                         type="url"
-                                        placeholder=""
+                                        placeholder=" "
                                     >
                                     <label
                                         class="form__label form__label--floating"

--- a/resources/views/contact/index.blade.php
+++ b/resources/views/contact/index.blade.php
@@ -32,7 +32,7 @@
                         id="contact-name"
                         class="form__text"
                         name="contact-name"
-                        placeholder=""
+                        placeholder=" "
                         required
                         type="text"
                         value="{{ auth()->user()->username }}"
@@ -46,7 +46,7 @@
                         id="email"
                         class="form__text"
                         name="email"
-                        placeholder=""
+                        placeholder=" "
                         required
                         type="email"
                         value="{{ auth()->user()->email }}"
@@ -60,7 +60,7 @@
                         id="message"
                         class="form__textarea"
                         name="message"
-                        placeholder=""
+                        placeholder=" "
                         required
                     ></textarea>
                     <label class="form__label form__label--floating" for="message">

--- a/resources/views/forum/topic/edit.blade.php
+++ b/resources/views/forum/topic/edit.blade.php
@@ -41,7 +41,7 @@
                         class="form__text"
                         maxlength="75"
                         name="name"
-                        placeholder=""
+                        placeholder=" "
                         required
                         type="text"
                         value="{{ $topic->name }}"

--- a/resources/views/livewire/bbcode-input.blade.php
+++ b/resources/views/livewire/bbcode-input.blade.php
@@ -199,7 +199,7 @@
                     id="bbcode-{{ $name }}"
                     name="{{ $name }}"
                     class="form__textarea bbcode-input__input"
-                    placeholder=""
+                    placeholder=" "
                     x-ref="bbcode"
                     wire:model.defer="contentBbcode"
                     @if ($isRequired)

--- a/resources/views/livewire/collection-search.blade.php
+++ b/resources/views/livewire/collection-search.blade.php
@@ -6,7 +6,7 @@
                 <div class="form__group">
                     <input
                         class="form__text"
-                        placeholder=""
+                        placeholder=" "
                         type="text"
                         wire:model.debounce.250ms="search"
                     />

--- a/resources/views/livewire/company-search.blade.php
+++ b/resources/views/livewire/company-search.blade.php
@@ -6,7 +6,7 @@
                 <div class="form__group">
                     <input
                         class="form__text"
-                        placeholder=""
+                        placeholder=" "
                         type="text"
                         wire:model.debounce.250ms="search"
                     />

--- a/resources/views/livewire/forum-category-topic-search.blade.php
+++ b/resources/views/livewire/forum-category-topic-search.blade.php
@@ -30,7 +30,7 @@
                             class="form__text"
                             type="text"
                             wire:model="search"
-                            placeholder=""
+                            placeholder=" "
                         />
                         <label for="search" class="form__label form__label--floating">
                             {{ __('common.search') }}

--- a/resources/views/livewire/forum-topic-search.blade.php
+++ b/resources/views/livewire/forum-topic-search.blade.php
@@ -76,7 +76,7 @@
                             class="form__text"
                             type="text"
                             wire:model="search"
-                            placeholder=""
+                            placeholder=" "
                         />
                         <label for="search" class="form__label form__label--floating">
                             {{ __('common.search') }}

--- a/resources/views/livewire/network-search.blade.php
+++ b/resources/views/livewire/network-search.blade.php
@@ -6,7 +6,7 @@
                 <div class="form__group">
                     <input
                         class="form__text"
-                        placeholder=""
+                        placeholder=" "
                         type="text"
                         wire:model.debounce.250ms="search"
                     />

--- a/resources/views/livewire/note-search.blade.php
+++ b/resources/views/livewire/note-search.blade.php
@@ -26,7 +26,7 @@
                             class="form__text"
                             type="text"
                             wire:model="search"
-                            placeholder=""
+                            placeholder=" "
                     />
                     <label class="form__label form__label--floating">
                         Message

--- a/resources/views/livewire/password-strength.blade.php
+++ b/resources/views/livewire/password-strength.blade.php
@@ -6,7 +6,7 @@
                 autocomplete="new-password"
                 minlength="12"
                 name="new_password"
-                placeholder=""
+                placeholder=" "
                 required
                 type="password"
                 value="{{ old('new_password') }}"
@@ -21,7 +21,7 @@
                 autocomplete="new-password"
                 minlength="12"
                 name="new_password_confirmation"
-                placeholder=""
+                placeholder=" "
                 required
                 type="password"
                 value="{{ old('new_password') }}"

--- a/resources/views/livewire/peer-search.blade.php
+++ b/resources/views/livewire/peer-search.blade.php
@@ -7,23 +7,23 @@
             <form class="form">
                 <div class="form__group--short-horizontal">
                     <p class="form__group">
-                        <input wire:model="torrent" class="form__text" placeholder="">
+                        <input wire:model="torrent" class="form__text" placeholder=" ">
                         <label class="form__label form__label--floating">Torrent Name</label>
                     </p>
                     <p class="form__group">
-                        <input wire:model="ip" class="form__text" placeholder="">
+                        <input wire:model="ip" class="form__text" placeholder=" ">
                         <label class="form__label form__label--floating">IP Address</label>
                     </p>
                     <p class="form__group">
-                        <input wire:model="port" class="form__text" placeholder="">
+                        <input wire:model="port" class="form__text" placeholder=" ">
                         <label class="form__label form__label--floating">Port</label>
                     </p>
                     <p class="form__group">
-                        <input wire:model="agent" class="form__text" placeholder="">
+                        <input wire:model="agent" class="form__text" placeholder=" ">
                         <label class="form__label form__label--floating">Agent</label>
                     </p>
                     <p class="form__group">
-                        <select wire:model="connectivity" class="form__select" placeholder="">
+                        <select wire:model="connectivity" class="form__select" placeholder=" ">
                             <option value="any">Any</option>
                             <option value="connectable">Connectable</option>
                             <option value="unconnectable">Unconnectable</option>
@@ -31,7 +31,7 @@
                         <label class="form__label form__label--floating">Connectivity</label>
                     </p>
                     <p class="form__group">
-                        <select wire:model="groupBy" class="form__select" placeholder="">
+                        <select wire:model="groupBy" class="form__select" placeholder=" ">
                             <option value="none">None</option>
                             <option value="user_session">User Session</option>
                             <option value="user_ip">User IP</option>

--- a/resources/views/livewire/person-search.blade.php
+++ b/resources/views/livewire/person-search.blade.php
@@ -6,7 +6,7 @@
                 <div class="form__group">
                     <input
                         class="form__text"
-                        placeholder=""
+                        placeholder=" "
                         type="text"
                         wire:model.debounce.250ms="search"
                     />

--- a/resources/views/livewire/post-search.blade.php
+++ b/resources/views/livewire/post-search.blade.php
@@ -9,7 +9,7 @@
                         class="form__text"
                         type="text"
                         wire:model="search"
-                        placeholder=""
+                        placeholder=" "
                     />
                     <label for="search" class="form__label form__label--floating">
                         {{ __('common.search') }}

--- a/resources/views/livewire/subtitle-search.blade.php
+++ b/resources/views/livewire/subtitle-search.blade.php
@@ -106,7 +106,7 @@
                             wire:model="search"
                             type="search"
                             class="form__text"
-                            placeholder=""
+                            placeholder=" "
                         >
                         <label for="search" class="form__label form__label--floating">
                             {{ __('torrent.name') }}

--- a/resources/views/livewire/ticket-search.blade.php
+++ b/resources/views/livewire/ticket-search.blade.php
@@ -39,7 +39,7 @@
                         class="form__text"
                         type="text"
                         wire:model="search"
-                        placeholder=""
+                        placeholder=" "
                     />
                     <label class="form__label form__label--floating">
                         {{ __('ticket.subject') }}

--- a/resources/views/livewire/topic-post-search.blade.php
+++ b/resources/views/livewire/topic-post-search.blade.php
@@ -9,7 +9,7 @@
                         class="form__text"
                         type="text"
                         wire:model="search"
-                        placeholder=""
+                        placeholder=" "
                     />
                     <label for="search" class="form__label form__label--floating">
                         {{ __('common.search') }}

--- a/resources/views/livewire/topic-search.blade.php
+++ b/resources/views/livewire/topic-search.blade.php
@@ -30,7 +30,7 @@
                             class="form__text"
                             type="text"
                             wire:model="search"
-                            placeholder=""
+                            placeholder=" "
                         />
                         <label for="search" class="form__label form__label--floating">
                             {{ __('common.search') }}

--- a/resources/views/livewire/torrent-request-search.blade.php
+++ b/resources/views/livewire/torrent-request-search.blade.php
@@ -119,32 +119,32 @@
                                 wire:model="name"
                                 type="search"
                                 class="form__text"
-                                placeholder=""
+                                placeholder=" "
                             />
                             <label class="form__label form__label--floating">
                                 {{ __('common.name') }}
                             </label>
                         </p>
                         <p class="form__group">
-                            <input wire:model="requestor" class="form__text" placeholder="">
+                            <input wire:model="requestor" class="form__text" placeholder=" ">
                             <label class="form__label form__label--floating">{{ __('common.author') }}</label>
                         </p>
                     </div>
                     <div class="form__group--short-horizontal">
                         <p class="form__group">
-                            <input wire:model="tmdbId" class="form__text" placeholder="">
+                            <input wire:model="tmdbId" class="form__text" placeholder=" ">
                             <label class="form__label form__label--floating">TMDb ID</label>
                         </p>
                         <p class="form__group">
-                            <input wire:model="imdbId" class="form__text" placeholder="">
+                            <input wire:model="imdbId" class="form__text" placeholder=" ">
                             <label class="form__label form__label--floating">IMDb ID</label>
                         </p>
                         <p class="form__group">
-                            <input wire:model="tvdbId" class="form__text" placeholder="">
+                            <input wire:model="tvdbId" class="form__text" placeholder=" ">
                             <label class="form__label form__label--floating">TVDb ID</label>
                         </p>
                         <p class="form__group">
-                            <input wire:model="malId" class="form__text" placeholder="">
+                            <input wire:model="malId" class="form__text" placeholder=" ">
                             <label class="form__label form__label--floating">MAL ID</label>
                         </p>
                     </div>

--- a/resources/views/livewire/torrent-search.blade.php
+++ b/resources/views/livewire/torrent-search.blade.php
@@ -15,44 +15,44 @@
         <div class="panel__body" style="padding: 5px;">
             <div class="form__group--horizontal">
                 <p class="form__group">
-                    <input wire:model="name" class="form__text" placeholder="" autofocus>
+                    <input wire:model="name" class="form__text" placeholder=" " autofocus>
                     <label class="form__label form__label--floating">{{ __('torrent.name') }}</label>
                 </p>
             </div>
             <form class="form" x-cloak x-show="open">
                 <div class="form__group--short-horizontal">
                     <p class="form__group">
-                        <input wire:model="description" class="form__text" placeholder="">
+                        <input wire:model="description" class="form__text" placeholder=" ">
                         <label class="form__label form__label--floating">{{ __('torrent.description') }}</label>
                     </p>
                     <p class="form__group">
-                        <input wire:model="mediainfo" class="form__text" placeholder="">
+                        <input wire:model="mediainfo" class="form__text" placeholder=" ">
                         <label class="form__label form__label--floating">{{ __('torrent.media-info') }}</label>
                     </p>
                     <p class="form__group">
-                        <input wire:model="keywords" class="form__text" placeholder="">
+                        <input wire:model="keywords" class="form__text" placeholder=" ">
                         <label class="form__label form__label--floating">{{ __('torrent.keywords') }}</label>
                     </p>
                     <p class="form__group">
-                        <input wire:model="uploader" class="form__text" placeholder="">
+                        <input wire:model="uploader" class="form__text" placeholder=" ">
                         <label class="form__label form__label--floating">{{ __('torrent.uploader') }}</label>
                     </p>
                 </div>
                 <div class="form__group--short-horizontal">
                     <p class="form__group">
-                        <input wire:model="startYear" class="form__text" placeholder="">
+                        <input wire:model="startYear" class="form__text" placeholder=" ">
                         <label class="form__label form__label--floating">{{ __('torrent.start-year') }}</label>
                     </p>
                     <p class="form__group">
-                        <input wire:model="endYear" class="form__text" placeholder="">
+                        <input wire:model="endYear" class="form__text" placeholder=" ">
                         <label class="form__label form__label--floating">{{ __('torrent.end-year') }}</label>
                     </p>
                     <p class="form__group">
-                        <input wire:model="playlistId" class="form__text" placeholder="">
+                        <input wire:model="playlistId" class="form__text" placeholder=" ">
                         <label class="form__label form__label--floating">Playlist ID</label>
                     </p>
                     <p class="form__group">
-                        <input wire:model="collectionId" class="form__text" placeholder="">
+                        <input wire:model="collectionId" class="form__text" placeholder=" ">
                         <label class="form__label form__label--floating">Collection ID</label>
                     </p>
                 </div>
@@ -66,29 +66,29 @@
                         <div id="distributors" wire:ignore></div>
                     </div>
                     <p class="form__group">
-                        <input wire:model="companyId" class="form__text" placeholder="">
+                        <input wire:model="companyId" class="form__text" placeholder=" ">
                         <label class="form__label form__label--floating">Company ID</label>
                     </p>
                     <p class="form__group">
-                        <input wire:model="networkId" class="form__text" placeholder="">
+                        <input wire:model="networkId" class="form__text" placeholder=" ">
                         <label class="form__label form__label--floating">Network ID</label>
                     </p>
                 </div>
                 <div class="form__group--short-horizontal">
                     <p class="form__group">
-                        <input wire:model="tmdbId" class="form__text" placeholder="">
+                        <input wire:model="tmdbId" class="form__text" placeholder=" ">
                         <label class="form__label form__label--floating">TMDb ID</label>
                     </p>
                     <p class="form__group">
-                        <input wire:model="imdbId" class="form__text" placeholder="">
+                        <input wire:model="imdbId" class="form__text" placeholder=" ">
                         <label class="form__label form__label--floating">IMDb ID</label>
                     </p>
                     <p class="form__group">
-                        <input wire:model="tvdbId" class="form__text" placeholder="">
+                        <input wire:model="tvdbId" class="form__text" placeholder=" ">
                         <label class="form__label form__label--floating">TVDb ID</label>
                     </p>
                     <p class="form__group">
-                        <input wire:model="malId" class="form__text" placeholder="">
+                        <input wire:model="malId" class="form__text" placeholder=" ">
                         <label class="form__label form__label--floating">MAL ID</label>
                     </p>
                 </div>

--- a/resources/views/livewire/tv-search.blade.php
+++ b/resources/views/livewire/tv-search.blade.php
@@ -6,7 +6,7 @@
                 <div class="form__group">
                     <input
                         class="form__text"
-                        placeholder=""
+                        placeholder=" "
                         type="text"
                         wire:model.debounce.250ms="search"
                     />

--- a/resources/views/livewire/user-active.blade.php
+++ b/resources/views/livewire/user-active.blade.php
@@ -4,7 +4,7 @@
         <div class="panel__body">
             <form class="form">
                 <p class="form__group">
-                    <input wire:model="name" class="form__text" placeholder="" autofocus="">
+                    <input wire:model="name" class="form__text" placeholder=" " autofocus="">
                     <label class="form__label form__label--floating">{{ __('torrent.name') }}</label>
                 </p>
                 <p class="form__group">

--- a/resources/views/livewire/user-notes.blade.php
+++ b/resources/views/livewire/user-notes.blade.php
@@ -24,7 +24,7 @@
                                 id="message"
                                 class="form__textarea"
                                 name="message"
-                                placeholder=""
+                                placeholder=" "
                                 wire:model.defer="message"
                             ></textarea>
                             <label class="form__label form__label--floating" for="message">

--- a/resources/views/livewire/user-resurrections.blade.php
+++ b/resources/views/livewire/user-resurrections.blade.php
@@ -5,7 +5,7 @@
             <form class="form">
                 <div class="form__group">
                     <p class="form__group">
-                        <input wire:model="name" class="form__text" placeholder="" autofocus="">
+                        <input wire:model="name" class="form__text" placeholder=" " autofocus="">
                         <label class="form__label form__label--floating">{{ __('torrent.name') }}</label>
                     </p>
                 </div>

--- a/resources/views/livewire/user-search.blade.php
+++ b/resources/views/livewire/user-search.blade.php
@@ -39,7 +39,7 @@
                         class="form__text"
                         type="text"
                         wire:model="search"
-                        placeholder=""
+                        placeholder=" "
                     />
                     <label class="form__label form__label--floating">
                         {{ __('user.search') }}

--- a/resources/views/livewire/user-torrents.blade.php
+++ b/resources/views/livewire/user-torrents.blade.php
@@ -4,7 +4,7 @@
         <div class="panel__body">
             <div class="form__group--horizontal">
                 <p class="form__group">
-                    <input wire:model="name" class="form__text" placeholder="" autofocus="">
+                    <input wire:model="name" class="form__text" placeholder=" " autofocus="">
                     <label class="form__label form__label--floating">{{ __('torrent.name') }}</label>
                 </p>
             </div>

--- a/resources/views/livewire/user-uploads.blade.php
+++ b/resources/views/livewire/user-uploads.blade.php
@@ -4,7 +4,7 @@
         <div class="panel__body">
             <div class="form__group--horizontal">
                 <p class="form__group">
-                    <input wire:model="name" class="form__text" placeholder="" autofocus="">
+                    <input wire:model="name" class="form__text" placeholder=" " autofocus="">
                     <label class="form__label form__label--floating">{{ __('torrent.name') }}</label>
                 </p>
             </div>

--- a/resources/views/livewire/watchlist-search.blade.php
+++ b/resources/views/livewire/watchlist-search.blade.php
@@ -26,7 +26,7 @@
                         class="form__text"
                         type="text"
                         wire:model="search"
-                        placeholder=""
+                        placeholder=" "
                     />
                     <label class="form__label form__label--floating" for="search">
                         Search by message

--- a/resources/views/playlist/create.blade.php
+++ b/resources/views/playlist/create.blade.php
@@ -38,7 +38,7 @@
                         class="form__text"
                         type="text"
                         name="name"
-                        placeholder=""
+                        placeholder=" "
                         required
                         value="{{ old('name') }}"
                     >

--- a/resources/views/playlist/edit.blade.php
+++ b/resources/views/playlist/edit.blade.php
@@ -44,7 +44,7 @@
                         class="form__text"
                         type="text"
                         name="name"
-                        placeholder=""
+                        placeholder=" "
                         required
                         value="{{ $playlist->name }}"
                     >

--- a/resources/views/requests/create.blade.php
+++ b/resources/views/requests/create.blade.php
@@ -129,7 +129,7 @@
                                 inputmode="numeric"
                                 name="tvdb"
                                 pattern="[0-9]*"
-                                placeholder=""
+                                placeholder=" "
                                 type="text"
                                 value="{{ $tvdb ?: old('tvdb') }}"
                             >
@@ -143,7 +143,7 @@
                                 inputmode="numeric"
                                 name="mal"
                                 pattern="[0-9]*"
-                                placeholder=""
+                                placeholder=" "
                                 type="text"
                                 value="{{ $mal ?: old('mal') }}"
                             >

--- a/resources/views/requests/edit.blade.php
+++ b/resources/views/requests/edit.blade.php
@@ -143,7 +143,7 @@
                                 inputmode="numeric"
                                 name="tvdb"
                                 pattern="[0-9]*"
-                                placeholder=""
+                                placeholder=" "
                                 type="text"
                                 value="{{ $torrentRequest->tvdb ?: (old('tvdb') ?? '0') }}"
                             >
@@ -157,7 +157,7 @@
                                 inputmode="numeric"
                                 name="mal"
                                 pattern="[0-9]*"
-                                placeholder=""
+                                placeholder=" "
                                 type="text"
                                 value="{{ $torrentRequest->mal ?: (old('mal') ?? '0') }}"
                             >
@@ -170,7 +170,7 @@
                                 inputmode="numeric"
                                 name="igdb"
                                 pattern="[0-9]*"
-                                placeholder=""
+                                placeholder=" "
                                 type="text"
                                 value="{{ $torrentRequest->igdb ?: (old('igdb') ?? '0') }}"
                             >

--- a/resources/views/requests/partials/fulfill.blade.php
+++ b/resources/views/requests/partials/fulfill.blade.php
@@ -19,7 +19,7 @@
                     id="torrent_id"
                     class="form__text"
                     name="torrent_id"
-                    placeholder=""
+                    placeholder=" "
                     type="text"
                 >
                 <label for="torrent_id" class="form__label form__label--floating">

--- a/resources/views/requests/partials/report.blade.php
+++ b/resources/views/requests/partials/report.blade.php
@@ -19,7 +19,7 @@
                     id="message"
                     class="form__text"
                     name="message"
-                    placeholder=""
+                    placeholder=" "
                     type="text"
                 ></textarea>
                 <label for="message" class="form__label form__label--floating">

--- a/resources/views/requests/partials/vote.blade.php
+++ b/resources/views/requests/partials/vote.blade.php
@@ -21,7 +21,7 @@
                     inputmode="numeric"
                     name="bonus_value"
                     pattern="[0-9]*?[1-9][0-9]{2,}"
-                    placeholder=""
+                    placeholder=" "
                     type="text"
                 >
                 <label for="bonus_value" class="form__label form__label--floating">

--- a/resources/views/rss/create.blade.php
+++ b/resources/views/rss/create.blade.php
@@ -44,7 +44,7 @@
                     id="search"
                     class="form__text"
                     name="search"
-                    placeholder=""
+                    placeholder=" "
                     type="text"
                 >
                 <label class="form__label form__label--floating" for="search">
@@ -57,7 +57,7 @@
                     type="text"
                     class="form__text"
                     name="description"
-                    placeholder=""
+                    placeholder=" "
                 >
                 <label class="form__label form__label--floating" for="description">
                     {{ __('torrent.torrent') }} {{ __('torrent.description') }}
@@ -69,7 +69,7 @@
                     type="text"
                     class="form__text"
                     name="uploader"
-                    placeholder=""
+                    placeholder=" "
                 >
                 <label class="form__label form__label--floating" for="uploader">
                     {{ __('torrent.torrent') }} {{ __('torrent.uploader') }}
@@ -83,7 +83,7 @@
                         inputmode="numeric"
                         name="tmdb"
                         pattern="[0-9]*"
-                        placeholder=""
+                        placeholder=" "
                         type="text"
                     >
                     <label class="form__label form__label--floating" for="tmdb">
@@ -97,7 +97,7 @@
                         inputmode="numeric"
                         name="imdb"
                         pattern="[0-9]*"
-                        placeholder=""
+                        placeholder=" "
                         type="text"
                     >
                     <label class="form__label form__label--floating" for="imdb">
@@ -111,7 +111,7 @@
                         inputmode="numeric"
                         name="tvdb"
                         pattern="[0-9]*"
-                        placeholder=""
+                        placeholder=" "
                         type="text"
                     >
                     <label class="form__label form__label--floating" for="tvdb">
@@ -126,7 +126,7 @@
                         inputmode="numeric"
                         name="mal"
                         pattern="[0-9]*"
-                        placeholder=""
+                        placeholder=" "
                         type="text"
                     >
                     <label class="form__label form__label--floating" for="mal">

--- a/resources/views/rss/edit.blade.php
+++ b/resources/views/rss/edit.blade.php
@@ -51,7 +51,7 @@
                     id="search"
                     class="form__text"
                     name="search"
-                    placeholder=""
+                    placeholder=" "
                     type="text"
                     value="{{ $rss->object_torrent->search }}"
                 >
@@ -65,7 +65,7 @@
                     type="text"
                     class="form__text"
                     name="description"
-                    placeholder=""
+                    placeholder=" "
                     value="{{ $rss->object_torrent->description }}"
                 >
                 <label class="form__label form__label--floating" for="description">
@@ -78,7 +78,7 @@
                     type="text"
                     class="form__text"
                     name="uploader"
-                    placeholder=""
+                    placeholder=" "
                     value="{{ $rss->object_torrent->uploader }}"
                 >
                 <label class="form__label form__label--floating" for="uploader">
@@ -93,7 +93,7 @@
                         inputmode="numeric"
                         name="tmdb"
                         pattern="[0-9]*"
-                        placeholder=""
+                        placeholder=" "
                         type="text"
                         value="{{ $rss->object_torrent->tmdb }}"
                     >
@@ -108,7 +108,7 @@
                         inputmode="numeric"
                         name="imdb"
                         pattern="[0-9]*"
-                        placeholder=""
+                        placeholder=" "
                         type="text"
                         value="{{ $rss->object_torrent->imdb }}"
                     >
@@ -123,7 +123,7 @@
                         inputmode="numeric"
                         name="tvdb"
                         pattern="[0-9]*"
-                        placeholder=""
+                        placeholder=" "
                         type="text"
                         value="{{ $rss->object_torrent->tvdb }}"
                     >
@@ -139,7 +139,7 @@
                         inputmode="numeric"
                         name="mal"
                         pattern="[0-9]*"
-                        placeholder=""
+                        placeholder=" "
                         type="text"
                         value="{{ $rss->object_torrent->mal }}"
                     >

--- a/resources/views/subtitle/create.blade.php
+++ b/resources/views/subtitle/create.blade.php
@@ -70,7 +70,7 @@
                         name="note"
                         id="note"
                         class="form__text"
-                        placeholder=""
+                        placeholder=" "
                     >
                     <label class="form__label form__label--floating" for="note">
                         {{ __('subtitle.note') }} ({{ __('subtitle.note-help') }})

--- a/resources/views/torrent/create.blade.php
+++ b/resources/views/torrent/create.blade.php
@@ -302,7 +302,7 @@
                                 x-bind:value="(cats[cat].type === 'movie' || cats[cat].type === 'tv') ? '{{ $mal ?: old('mal') }}' : '0'"
                                 x-bind:required="cats[cat].type === 'movie' || cats[cat].type === 'tv'"
                                 class="form__text"
-                                placeholder=""
+                                placeholder=" "
                             >
                             <label class="form__label form__label--floating" for="automal">MAL ID ({{ __('torrent.required-anime') }})</label>
                         </p>
@@ -327,7 +327,7 @@
                             id="autokeywords"
                             class="form__text"
                             value="{{ old('keywords') }}"
-                            placeholder=""
+                            placeholder=" "
                         >
                         <label class="form__label form__label--floating" for="autokeywords">
                             {{ __('torrent.keywords') }} (<i>{{ __('torrent.keywords-example') }}</i>)
@@ -339,7 +339,7 @@
                             id="upload-form-mediainfo"
                             name="mediainfo"
                             class="form__textarea"
-                            placeholder=""
+                            placeholder=" "
                         >{{ old('mediainfo') }}</textarea>
                         <label class="form__label form__label--floating" for="upload-form-mediainfo">
                             {{ __('torrent.media-info-parser') }}
@@ -350,7 +350,7 @@
                             id="upload-form-bdinfo"
                             name="bdinfo"
                             class="form__textarea"
-                            placeholder=""
+                            placeholder=" "
                         >{{ old('bdinfo') }}</textarea>
                         <label class="form__label form__label--floating" for="upload-form-bdinfo">
                             BDInfo (Quick Summary)

--- a/resources/views/torrent/edit.blade.php
+++ b/resources/views/torrent/edit.blade.php
@@ -314,7 +314,7 @@
                         class="form__text"
                         name="keywords"
                         type="text"
-                        placeholder=""
+                        placeholder=" "
                         value="{{ old('keywords') ?? $keywords->implode(', ') }}"
                     >
                     <label class="form__label form__label--floating" for="keywords">
@@ -332,7 +332,7 @@
                         id="description"
                         class="form__textarea"
                         name="mediainfo"
-                        placeholder=""
+                        placeholder=" "
                     >{{ old('mediainfo') ?? $torrent->mediainfo }}</textarea>
                     <label class="form__label form__label--floating" for="description">
                         {{ __('torrent.media-info') }}
@@ -344,7 +344,7 @@
                         id="bdinfo"
                         class="form__textarea"
                         name="bdinfo"
-                        placeholder=""
+                        placeholder=" "
                     >{{ old('bdinfo') ?? $torrent->bdinfo }}</textarea>
                     <label class="form__label form__label--floating" for="description">
                         BDInfo (Quick Summary)

--- a/resources/views/torrent/partials/buttons.blade.php
+++ b/resources/views/torrent/partials/buttons.blade.php
@@ -117,7 +117,7 @@
                         class="form__text"
                         list="torrent_quick_tips"
                         name="tip"
-                        placeholder=""
+                        placeholder=" "
                         type="text"
                         pattern="[0-9]*"
                         inputmode="numeric"

--- a/resources/views/user/general_setting/edit.blade.php
+++ b/resources/views/user/general_setting/edit.blade.php
@@ -67,7 +67,7 @@
                             id="custom_css"
                             class="form__text"
                             name="custom_css"
-                            placeholder=""
+                            placeholder=" "
                             type="url"
                             value="{{ $user->custom_css }}"
                         >
@@ -80,7 +80,7 @@
                             id="standalone_css"
                             class="form__text"
                             name="standalone_css"
-                            placeholder=""
+                            placeholder=" "
                             type="url"
                             value="{{ $user->standalone_css }}"
                         >

--- a/resources/views/user/gift/create.blade.php
+++ b/resources/views/user/gift/create.blade.php
@@ -38,7 +38,7 @@
                         id="users"
                         class="form__text"
                         name="to_username"
-                        placeholder=""
+                        placeholder=" "
                         required
                         type="text"
                     >
@@ -53,7 +53,7 @@
                         inputmode="numeric"
                         name="bonus_points"
                         pattern="[0-9]*"
-                        placeholder=""
+                        placeholder=" "
                         required
                         type="text"
                     >
@@ -66,7 +66,7 @@
                         id="bonus_message"
                         class="form__textarea"
                         name="bonus_message"
-                        placeholder=""
+                        placeholder=" "
                         required
                     ></textarea>
                     <label class="form__label form__label--floating" for="bonus_message">

--- a/resources/views/user/invite/create.blade.php
+++ b/resources/views/user/invite/create.blade.php
@@ -50,7 +50,7 @@
                             class="form__text"
                             type="email"
                             name="email"
-                            placeholder=""
+                            placeholder=" "
                         >
                         <label class="form__label form__label--floating" for="email">{{ __('common.email') }}</label>
                     </p>

--- a/resources/views/user/password/edit.blade.php
+++ b/resources/views/user/password/edit.blade.php
@@ -44,7 +44,7 @@
                             class="form__text"
                             autocomplete="current-password"
                             name="current_password"
-                            placeholder=""
+                            placeholder=" "
                             required
                             type="password"
                         >

--- a/resources/views/user/profile/edit.blade.php
+++ b/resources/views/user/profile/edit.blade.php
@@ -45,7 +45,7 @@
                         id="title"
                         class="form__text"
                         name="title"
-                        placeholder=""
+                        placeholder=" "
                         type="text"
                         value="{{ $user->title }}"
                     >

--- a/resources/views/user/profile/show.blade.php
+++ b/resources/views/user/profile/show.blade.php
@@ -628,7 +628,7 @@
                                             type="text"
                                             pattern="[0-9]*"
                                             inputmode="numeric"
-                                            placeholder=""
+                                            placeholder=" "
                                         />
                                         <label class="form__label form__label--floating">
                                             {{ __('bon.amount') }}
@@ -638,7 +638,7 @@
                                             id="bonus_message"
                                             class="form__textarea"
                                             name="bonus_message"
-                                            placeholder=""
+                                            placeholder=" "
                                         ></textarea>
                                         <label class="form__label form__label--floating" for="bonus__message">
                                             {{ __('pm.message') }}


### PR DESCRIPTION
Form input labels rely on the :place-holder-shown css property to float the label whenever the placeholder disappears (i.e. any time there's text inside) that way a user can click outside of the form input and the label will stay floating. Unfortunately, it seems that because only `placeholder=""` is used with the placeholder attribute being empty, Chrome interprets this as no place-holder being shown even if no text has been entered in the form input, triggering the label to float automatically. To fix this, we must add a space to every placeholder attribute (`placeholder=" "`)