### PR TITLE
(Fix) Forum topic reply count

### DIFF
--- a/resources/views/forum/topic/show.blade.php
+++ b/resources/views/forum/topic/show.blade.php
@@ -64,7 +64,7 @@
             <dt>{{ __('forum.created-at') }}</dt>
             <dd>{{ date('M d Y H:m', strtotime($topic->created_at)) }}</dd>
             <dt>{{ __('forum.replies') }}</dt>
-            <dd>{{ $topic->num_post }}</dd>
+            <dd>{{ $topic->num_post - 1 }}</dd>
             <dt>{{ __('forum.views') }}</dt>
             <dd>{{ $topic->views }}</dd>
         </dl>


### PR DESCRIPTION
Replies are all the posts excluding the first post, and the first post should not be included in the count.