### PR TITLE
(Fix) hiding whitespace surrounding bbcode block elements

### DIFF
--- a/app/Helpers/Bbcode.php
+++ b/app/Helpers/Bbcode.php
@@ -21,198 +21,231 @@ class Bbcode
             'closeBbcode' => '[/h1]',
             'openHtml'    => '<h1>',
             'closeHtml'   => '</h1>',
+            'block'       => true,
         ],
         'h2' => [
             'openBbcode'  => '/^\[h2\]/i',
             'closeBbcode' => '[/h2]',
             'openHtml'    => '<h2>',
             'closeHtml'   => '</h2>',
+            'block'       => true,
         ],
         'h3' => [
             'openBbcode'  => '/^\[h3\]/i',
             'closeBbcode' => '[/h3]',
             'openHtml'    => '<h3>',
             'closeHtml'   => '</h3>',
+            'block'       => true,
         ],
         'h4' => [
             'openBbcode'  => '/^\[h4\]/i',
             'closeBbcode' => '[/h4]',
             'openHtml'    => '<h4>',
             'closeHtml'   => '</h4>',
+            'block'       => true,
         ],
         'h5' => [
             'openBbcode'  => '/^\[h5\]/i',
             'closeBbcode' => '[/h5]',
             'openHtml'    => '<h5>',
             'closeHtml'   => '</h5>',
+            'block'       => true,
         ],
         'h6' => [
             'openBbcode'  => '/^\[h6\]/i',
             'closeBbcode' => '[/h6]',
             'openHtml'    => '<h6>',
             'closeHtml'   => '</h6>',
+            'block'       => true,
         ],
         'bold' => [
             'openBbcode'  => '/^\[b\]/i',
             'closeBbcode' => '[/b]',
             'openHtml'    => '<b>',
             'closeHtml'   => '</b>',
+            'block'       => false,
         ],
         'italic' => [
             'openBbcode'  => '/^\[i\]/i',
             'closeBbcode' => '[/i]',
             'openHtml'    => '<i>',
             'closeHtml'   => '</i>',
+            'block'       => false,
         ],
         'underline' => [
             'openBbcode'  => '/^\[u\]/i',
             'closeBbcode' => '[/u]',
             'openHtml'    => '<u>',
             'closeHtml'   => '</u>',
+            'block'       => false,
         ],
         'linethrough' => [
             'openBbcode'  => '/^\[s\]/i',
             'closeBbcode' => '[/s]',
             'openHtml'    => '<s>',
             'closeHtml'   => '</s>',
+            'block'       => false,
         ],
         'size' => [
             'openBbcode'  => '/^\[size=(\d+)\]/i',
             'closeBbcode' => '[/size]',
             'openHtml'    => '<span style="font-size: clamp(10px, $1, 100px);">',
             'closeHtml'   => '</span>',
+            'block'       => false,
         ],
         'font' => [
             'openBbcode'  => '/^\[font=([a-z0-9 ]+)\]/i',
             'closeBbcode' => '[/font]',
             'openHtml'    => '<span style="font-family: $1;">',
             'closeHtml'   => '</span>',
+            'block'       => false,
         ],
         'color' => [
             'openBbcode'  => '/^\[color=(\#[a-f0-9]{3,4}|\#[a-f0-9]{6}|\#[a-f0-9]{8}|[a-z]+)\]/i',
             'closeBbcode' => '[/color]',
             'openHtml'    => '<span style="color: $1;">',
             'closeHtml'   => '</span>',
+            'block'       => false,
         ],
         'center' => [
             'openBbcode'  => '/^\[center\]/i',
             'closeBbcode' => '[/center]',
             'openHtml'    => '<div style="text-align: center;">',
             'closeHtml'   => '</div>',
+            'block'       => true,
         ],
         'left' => [
             'openBbcode'  => '/^\[left\]/i',
             'closeBbcode' => '[/left]',
             'openHtml'    => '<div style="text-align: left;">',
             'closeHtml'   => '</div>',
+            'block'       => true,
         ],
         'right' => [
             'openBbcode'  => '/^\[right\]/i',
             'closeBbcode' => '[/right]',
             'openHtml'    => '<div style="text-align: right;">',
             'closeHtml'   => '</div>',
+            'block'       => true,
         ],
         'quote' => [
             'openBbcode'  => '/^\[quote\]/i',
             'closeBbcode' => '[/quote]',
             'openHtml'    => '<blockquote>',
             'closeHtml'   => '</blockquote>',
+            'block'       => true,
         ],
         'namedquote' => [
             'openBbcode'  => '/^\[quote=([^<>"]*?)\]/i',
             'closeBbcode' => '[/quote]',
             'openHtml'    => '<blockquote><i class="fas fa-quote-left"></i> <cite>Quoting $1:</cite><p>',
             'closeHtml'   => '</p></blockquote>',
+            'block'       => true,
         ],
         'namedlink' => [
             'openBbcode'  => '/^\[url=(.*?)\]/i',
             'closeBbcode' => '[/url]',
             'openHtml'    => '<a href="$1">',
             'closeHtml'   => '</a>',
+            'block'       => false,
         ],
         'orderedlistnumerical' => [
             'openBbcode'  => '/^\[list=1\]/i',
             'closeBbcode' => '[/list]',
             'openHtml'    => '<ol>',
             'closeHtml'   => '</ol>',
+            'block'       => true,
         ],
         'orderedlistalpha' => [
             'openBbcode'  => '/^\[list=a\]/i',
             'closeBbcode' => '[/list]',
             'openHtml'    => '<ol type="a">',
             'closeHtml'   => '</ol>',
+            'block'       => true,
         ],
         'unorderedlist' => [
             'openBbcode'  => '/^\[list\]/i',
             'closeBbcode' => '[/list]',
             'openHtml'    => '<ul>',
             'closeHtml'   => '</ul>',
+            'block'       => true,
         ],
         'code' => [
             'openBbcode'  => '/^\[code\]/i',
             'closeBbcode' => '[/code]',
             'openHtml'    => '<pre>',
             'closeHtml'   => '</pre>',
+            'block'       => true,
         ],
         'alert' => [
             'openBbcode'  => '/^\[alert\]/i',
             'closeBbcode' => '[/alert]',
             'openHtml'    => '<div class="bbcode-rendered__alert">',
             'closeHtml'   => '</div>',
+            'block'       => true,
         ],
         'note' => [
             'openBbcode'  => '/^\[note\]/i',
             'closeBbcode' => '[/note]',
             'openHtml'    => '<div class="bbcode-rendered__note">',
             'closeHtml'   => '</div>',
+            'block'       => true,
         ],
         'sub' => [
             'openBbcode'  => '/^\[sub\]/i',
             'closeBbcode' => '[/sub]',
             'openHtml'    => '<sub>',
             'closeHtml'   => '</sub>',
+            'block'       => false,
         ],
         'sup' => [
             'openBbcode'  => '/^\[sup\]/i',
             'closeBbcode' => '[/sup]',
             'openHtml'    => '<sup>',
             'closeHtml'   => '</sup>',
+            'block'       => false,
         ],
         'small' => [
             'openBbcode'  => '/^\[small\]/i',
             'closeBbcode' => '[/small]',
             'openHtml'    => '<small>',
             'closeHtml'   => '</small>',
+            'block'       => false,
         ],
         'table' => [
             'openBbcode'  => '/^\[table\]/i',
             'closeBbcode' => '[/table]',
             'openHtml'    => '<table>',
             'closeHtml'   => '</table>',
+            'block'       => true,
         ],
         'table-row' => [
             'openBbcode'  => '/^\[tr\]/i',
             'closeBbcode' => '[/tr]',
             'openHtml'    => '<tr>',
             'closeHtml'   => '</tr>',
+            'block'       => true,
         ],
         'table-data' => [
             'openBbcode'  => '/^\[td\]/i',
             'closeBbcode' => '[/td]',
             'openHtml'    => '<td>',
             'closeHtml'   => '</td>',
+            'block'       => true,
         ],
         'spoiler' => [
             'openBbcode'  => '/^\[spoiler\]/i',
             'closeBbcode' => '[/spoiler]',
             'openHtml'    => '<details><summary>Spoiler</summary><div style="text-align:left;">',
             'closeHtml'   => '</div></details>',
+            'block'       => false,
         ],
         'named-spoiler' => [
             'openBbcode'  => '/^\[spoiler=(.*?)\]/i',
             'closeBbcode' => '[/spoiler]',
             'openHtml'    => '<details><summary>$1</summary><div style="text-align:left;">',
             'closeHtml'   => '</div></details>',
+            'block'       => false,
         ],
     ];
 
@@ -310,6 +343,10 @@ class Bbcode
                 // otherwise return the expected element's to the stack
                 if (strcasecmp($tag, $el['closeBbcode']) === 0) {
                     $source = substr_replace($source, $el['closeHtml'], $index, \strlen($el['closeBbcode']));
+
+                    if ($el['block'] === true) {
+                        $this->handleBlockElementSpacing($source, $index, $index, $index + \strlen($el['closeHtml']) - 1);
+                    }
                 } else {
                     $openedElements[] = $name;
                 }
@@ -323,6 +360,11 @@ class Bbcode
                     if (preg_match($el['openBbcode'], $remainingText, $matches) === 1) {
                         $replacement = preg_replace($el['openBbcode'], $el['openHtml'], $matches[0]);
                         $source = substr_replace($source, $replacement, $index, \strlen($matches[0]));
+
+                        if ($el['block'] === true) {
+                            $this->handleBlockElementSpacing($source, $index, $index, $index + \strlen($replacement) - 1);
+                        }
+
                         $openedElements[] = $name;
 
                         break;
@@ -343,5 +385,58 @@ class Bbcode
         }
 
         return $source;
+    }
+
+    /**
+     * Remove line breaks immediately before and after tags for block elements.
+     *
+     * Useful so that you can write bbcode like the following without worrying about spacing:
+     *
+     * ```
+     * [list]
+     * [*]item 1
+     * [*]item 2
+     * [/list]
+     * ```
+     *
+     * @param  String $source        Reference to the source text content currently being converted from bbcode to html.
+     * @param  int    $index         Reference to the current index of `$source` that the parser must keep track of.
+     * @param  int    $tagStartIndex The index of the first character of the tag being parsed inside of `$source`. Should be the `[` character.
+     * @param  int    $tagStopIndex  The index of the last character of the tag being parsed inside of `$source`. Should be the `]` character.
+     * @return void
+     */
+    private function handleBlockElementSpacing(String &$source, int &$index, int $tagStartIndex, int $tagStopIndex): void
+    {
+        // Remove two line breaks (if they exist) instead of one, since a
+        // line break after a block element is positioned on the line after
+        // the block element, while a line break after a non-block element
+        // is positioned at the end of the same line of the non-block element.
+        // I.e. two line breaks after a block element provides the same amount
+        // of vertical space as one line break after a non-block element.
+        for ($i = 0; $i < 2; $i++) {
+            $bbcodeStopIndex = \strlen($source) - 1;
+
+            // Does there exist 2 characters after the tag and are they \r\n?
+            // Otherwise, does there exist 1 character after the tag and is it \n?
+            // In either case, remove those characters.
+            if ($tagStopIndex + 2 <= $bbcodeStopIndex && substr_compare($source, "\r\n", $tagStopIndex + 1, 2) === 0) {
+                $source = substr_replace($source, '', $tagStopIndex + 1, 2);
+            } elseif ($tagStopIndex + 1 <= $bbcodeStopIndex && $source[$tagStopIndex + 1] === "\n") {
+                $source = substr_replace($source, '', $tagStopIndex + 1, 1);
+            }
+        }
+
+        $bbcodeStopIndex = \strlen($source) - 1;
+
+        // Does there exist 2 characters before the tag and are they \r\n?
+        // Otherwise, does there exist 1 character before the tag and is it \n?
+        // In either case, remove those characters and adjust the current index appropriately.
+        if ($tagStartIndex >= 2 && substr_compare($source, "\r\n", $tagStartIndex - 2, 2) === 0) {
+            $source = substr_replace($source, '', $tagStartIndex - 2, 2);
+            $index -= 2;
+        } elseif ($tagStartIndex >= 1 && $source[$tagStartIndex - 1] === "\n") {
+            $source = substr_replace($source, '', $tagStartIndex - 1, 1);
+            $index -= 1;
+        }
     }
 }

--- a/resources/sass/components/_bbcode-rendered.scss
+++ b/resources/sass/components/_bbcode-rendered.scss
@@ -5,11 +5,6 @@
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
   color: var(--bbcode-rendered-fg-default);
-
-  br:first-child {
-    display: none;
-  }
-
   margin: 0;
   background-color: var(--bbcode-rendered-canvas-default);
 
@@ -344,14 +339,6 @@
     content: "";
   }
 
-  > *:first-child {
-    margin-top: 0 !important;
-  }
-
-  > *:last-child {
-    margin-bottom: 0 !important;
-  }
-
   a:not([href]) {
     color: inherit;
     text-decoration: none;
@@ -364,16 +351,8 @@
   dl,
   table,
   pre {
-    margin-top: 8px;
-    margin-bottom: 8px;
-  }
-
-  blockquote > :first-child {
-    margin-top: 0;
-  }
-
-  blockquote > :last-child {
-    margin-bottom: 0;
+    margin-top: 12px;
+    margin-bottom: 12px;
   }
 
   details {


### PR DESCRIPTION
The issue concerns writing BBCode such as:
```
[list]
[*]Item 1
[*]Item 2
[*]Item 3
[/list]
```
And not having an extra line break after each bullet point in the rendered HTML.

Originally, a very basic implementation was added to hide the first `<br>` via CSS, but this proved troublesome if a text node was the first element, which wouldn't be affected by CSS and caused issues as it hid the first line break after the first text node.

Now, we rely on the back end code to remove line breaks surround block level elements (as they're called in HTML) before they're presented to the user.