### PR TITLE
(Fix) Checkmarks go out of sync with livewire when clicking too fast

### DIFF
--- a/resources/views/livewire/similar-torrent.blade.php
+++ b/resources/views/livewire/similar-torrent.blade.php
@@ -55,7 +55,12 @@
                                 @if ($user->group->is_modo)
                                     <tr>
                                         <td colspan="0" rowspan="2" x-on:click.self="$el.firstElementChild.click()">
-                                            <input type="checkbox" value="{{ $torrent->id }}" wire:model="checked">
+                                            <input
+                                                id="torrent_checkbox_{{ $torrent->id }}"
+                                                type="checkbox"
+                                                value="{{ $torrent->id }}"
+                                                wire:model="checked"
+                                            >
                                         </td>
                                     </tr>
                                 @endif


### PR DESCRIPTION
The key for fixing seems to be either a unique `id` or `name` attribute.