### PR TITLE
(Update) use peer id for client blacklist instead of user agent

### DIFF
--- a/app/Http/Controllers/AnnounceController.php
+++ b/app/Http/Controllers/AnnounceController.php
@@ -184,10 +184,14 @@ final class AnnounceController extends Controller
         }
 
         // Block Blacklisted Clients
-        $clientBlacklist = cache()->rememberForever('client_blacklist', fn () => BlacklistClient::pluck('name')->toArray());
+        $blacklistedPeerIdPrefixes = cache()->rememberForever('client_blacklist', fn () => BlacklistClient::pluck('peer_id_prefix')->toArray());
 
-        if (\in_array($userAgent, $clientBlacklist)) {
-            throw new TrackerException(128, [':ua' => $request->header('User-Agent')]);
+        $peerId = $request->query->get('peer_id');
+
+        foreach ($blacklistedPeerIdPrefixes as $blacklistedPeerIdPrefix) {
+            if (str_starts_with($peerId, $blacklistedPeerIdPrefix)) {
+                throw new TrackerException(128, [':ua' => $request->header('User-Agent')]);
+            }
         }
     }
 

--- a/app/Http/Requests/Staff/StoreBlacklistClientRequest.php
+++ b/app/Http/Requests/Staff/StoreBlacklistClientRequest.php
@@ -38,6 +38,11 @@ class StoreBlacklistClientRequest extends FormRequest
                 'string',
                 'unique:blacklist_clients',
             ],
+            'peer_id_prefix' => [
+                'required',
+                'string',
+                'unique:blacklist_clients',
+            ],
             'reason' => [
                 'sometimes',
                 'string',

--- a/app/Http/Requests/Staff/UpdateBlacklistClientRequest.php
+++ b/app/Http/Requests/Staff/UpdateBlacklistClientRequest.php
@@ -38,6 +38,11 @@ class UpdateBlacklistClientRequest extends FormRequest
                 'string',
                 'max:255',
             ],
+            'peer_id_prefix' => [
+                'required',
+                'string',
+                'unique:blacklist_clients',
+            ],
             'reason' => [
                 'required',
                 'string',

--- a/database/factories/BlacklistClientFactory.php
+++ b/database/factories/BlacklistClientFactory.php
@@ -29,8 +29,9 @@ class BlacklistClientFactory extends Factory
     public function definition(): array
     {
         return [
-            'name'   => $this->faker->unique()->name(),
-            'reason' => $this->faker->text(),
+            'name'           => $this->faker->unique()->name(),
+            'reason'         => $this->faker->text(),
+            'peer_id_prefix' => $this->faker->unique()->text(5),
         ];
     }
 }

--- a/database/migrations/2023_12_30_092415_add_peer_id_prefix_to_blacklist_client.php
+++ b/database/migrations/2023_12_30_092415_add_peer_id_prefix_to_blacklist_client.php
@@ -1,0 +1,14 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::table('blacklist_clients', function (Blueprint $table): void {
+            $table->string('peer_id_prefix');
+        });
+    }
+};

--- a/resources/views/Staff/blacklist/clients/create.blade.php
+++ b/resources/views/Staff/blacklist/clients/create.blade.php
@@ -45,6 +45,19 @@
                 </p>
                 <p class="form__group">
                     <input
+                        id="peer_id_prefix"
+                        class="form__text"
+                        name="peer_id_prefix"
+                        required
+                        type="text"
+                        value="{{ old('peer_id_prefix') }}"
+                    />
+                    <label class="form__label form__label--floating" for="peer_id_prefix">
+                        Peer ID Prefix
+                    </label>
+                </p>
+                <p class="form__group">
+                    <input
                         id="reason"
                         class="form__text"
                         name="reason"

--- a/resources/views/Staff/blacklist/clients/edit.blade.php
+++ b/resources/views/Staff/blacklist/clients/edit.blade.php
@@ -46,6 +46,19 @@
                 </p>
                 <p class="form__group">
                     <input
+                        id="peer_id_prefix"
+                        class="form__text"
+                        name="peer_id_prefix"
+                        required
+                        type="text"
+                        value="{{ $client->peer_id_prefix }}"
+                    />
+                    <label class="form__label form__label--floating" for="peer_id_prefix">
+                        Peer ID Prefix
+                    </label>
+                </p>
+                <p class="form__group">
+                    <input
                         id="reason"
                         class="form__text"
                         name="reason"

--- a/resources/views/Staff/blacklist/clients/index.blade.php
+++ b/resources/views/Staff/blacklist/clients/index.blade.php
@@ -14,7 +14,7 @@
         <header class="panel__header">
             <h2 class="panel__heading">Blacklisted Clients</h2>
             <div class="panel__actions">
-                <div class="panel_action">
+                <div class="panel__action">
                     <a
                         href="{{ route('staff.blacklisted_clients.create') }}"
                         class="form__button form__button--text"
@@ -28,7 +28,7 @@
             <table class="data-table">
                 <thead>
                     <tr>
-                        <th>{{ __('common.name') }}</th>
+                        <th>Peer ID prefix</th>
                         <th>{{ __('common.reason') }}</th>
                         <th>{{ __('common.actions') }}</th>
                     </tr>

--- a/resources/views/page/blacklist/client.blade.php
+++ b/resources/views/page/blacklist/client.blade.php
@@ -13,9 +13,16 @@
         <h2 class="panel__heading">{{ __('page.blacklist-clients') }}</h2>
         <div class="data-table-wrapper">
             <table class="data-table">
+                <thead>
+                    <tr>
+                        <th>Client Name</th>
+                        <th>Reason</th>
+                    </tr>
+                </thead>
                 @foreach ($clients as $client)
                     <tr>
                         <td>{{ $client->name }}</td>
+                        <td>{{ $client->reason }}</td>
                     </tr>
                 @endforeach
             </table>

--- a/tests/Feature/Http/Controllers/Staff/BlacklistClientControllerTest.php
+++ b/tests/Feature/Http/Controllers/Staff/BlacklistClientControllerTest.php
@@ -71,8 +71,9 @@ test('store validates with a form request', function (): void {
 
 test('store returns an ok response', function (): void {
     $response = $this->actingAs($this->staffUser)->post(route('staff.blacklisted_clients.store'), [
-        'name'   => 'Test Name',
-        'reason' => 'Test Reason',
+        'name'           => 'Test Name',
+        'reason'         => 'Test Reason',
+        'peer_id_prefix' => 'Test Peer ID Prefix',
     ]);
     $response->assertRedirect(route('staff.blacklisted_clients.index'));
     $response->assertSessionHas('success', 'Blacklisted Client Stored Successfully!');
@@ -90,8 +91,9 @@ test('update returns an ok response', function (): void {
     $blacklistClient = BlacklistClient::factory()->create();
 
     $response = $this->actingAs($this->staffUser)->patch(route('staff.blacklisted_clients.update', [$blacklistClient]), [
-        'name'   => 'Test Name Updated',
-        'reason' => 'Test Reason Updated',
+        'name'           => 'Test Name Updated',
+        'reason'         => 'Test Reason Updated',
+        'peer_id_prefix' => 'Test Peer ID Prefix Updated',
     ]);
     $response->assertRedirect(route('staff.blacklisted_clients.index'));
     $response->assertSessionHas('success', 'Blacklisted Client Was Updated Successfully!');


### PR DESCRIPTION
Maybe should just check both and add an extra column in the db.