### PR TITLE
(Update) Accessors/mutators

### DIFF
--- a/app/Models/Article.php
+++ b/app/Models/Article.php
@@ -13,6 +13,7 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use App\Helpers\Bbcode;
 use App\Helpers\Linkify;
 use App\Traits\Auditable;
@@ -76,12 +77,11 @@ class Article extends Model
         return $trimmedText;
     }
 
-    /**
-     * Set The Articles Content After Its Been Purified.
-     */
-    public function setContentAttribute(?string $value): void
+    protected function content(): Attribute
     {
-        $this->attributes['content'] = htmlspecialchars((new AntiXSS())->xss_clean($value), ENT_NOQUOTES);
+        return new Attribute(
+            set: fn ($value) => htmlspecialchars((new AntiXSS())->xss_clean($value), ENT_NOQUOTES),
+        );
     }
 
     /**

--- a/app/Models/Message.php
+++ b/app/Models/Message.php
@@ -13,6 +13,7 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use App\Helpers\Bbcode;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -67,12 +68,11 @@ class Message extends Model
         return $this->belongsTo(Chatroom::class);
     }
 
-    /**
-     * Set The Chat Message After Its Been Purified.
-     */
-    public function setMessageAttribute(string $value): void
+    protected function message(): Attribute
     {
-        $this->attributes['message'] = htmlspecialchars((new AntiXSS())->xss_clean($value), ENT_NOQUOTES);
+        return new Attribute(
+            set: fn ($value) => htmlspecialchars((new AntiXSS())->xss_clean($value), ENT_NOQUOTES),
+        );
     }
 
     /**

--- a/app/Models/Page.php
+++ b/app/Models/Page.php
@@ -13,6 +13,7 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use App\Helpers\Bbcode;
 use App\Helpers\MarkdownExtra;
 use App\Traits\Auditable;
@@ -31,12 +32,11 @@ class Page extends Model
      */
     protected $guarded = ['id', 'created_at', 'updated_at'];
 
-    /**
-     * Set The Pages Content After Its Been Purified.
-     */
-    public function setContentAttribute(?string $value): void
+    protected function content(): Attribute
     {
-        $this->attributes['content'] = $value;
+        return new Attribute(
+            set: fn ($value) => $value,
+        );
     }
 
     /**

--- a/app/Models/Playlist.php
+++ b/app/Models/Playlist.php
@@ -13,6 +13,7 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use App\Helpers\Bbcode;
 use App\Helpers\Linkify;
 use App\Traits\Auditable;
@@ -49,12 +50,11 @@ class Playlist extends Model
         return $this->morphMany(Comment::class, 'commentable');
     }
 
-    /**
-     * Set The Playlists Description After It's Been Purified.
-     */
-    public function setDescriptionAttribute(?string $value): void
+    protected function description(): Attribute
     {
-        $this->attributes['description'] = htmlspecialchars((new AntiXSS())->xss_clean($value), ENT_NOQUOTES);
+        return new Attribute(
+            set: fn ($value) => htmlspecialchars((new AntiXSS())->xss_clean($value), ENT_NOQUOTES),
+        );
     }
 
     /**

--- a/app/Models/Poll.php
+++ b/app/Models/Poll.php
@@ -13,6 +13,7 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use App\Traits\Auditable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -59,12 +60,11 @@ class Poll extends Model
         return $this->hasMany(Voter::class);
     }
 
-    /**
-     * Set The Poll's Title.
-     */
-    public function setTitleAttribute($title): void
+    protected function title(): Attribute
     {
-        $this->attributes['title'] = $title;
+        return new Attribute(
+            set: fn ($value) => $value,
+        );
     }
 
     /**

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -13,6 +13,7 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use App\Helpers\Bbcode;
 use App\Helpers\Linkify;
 use App\Traits\Auditable;
@@ -90,12 +91,11 @@ class Post extends Model
         return $this->hasMany(Topic::class, 'first_post_user_id', 'user_id');
     }
 
-    /**
-     * Set The Posts Content After Its Been Purified.
-     */
-    public function setContentAttribute(?string $value): void
+    protected function content(): Attribute
     {
-        $this->attributes['content'] = htmlspecialchars((new AntiXSS())->xss_clean($value), ENT_NOQUOTES);
+        return new Attribute(
+            set: fn ($value) => htmlspecialchars((new AntiXSS())->xss_clean($value), ENT_NOQUOTES),
+        );
     }
 
     /**

--- a/app/Models/PrivateMessage.php
+++ b/app/Models/PrivateMessage.php
@@ -13,6 +13,7 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use App\Helpers\Bbcode;
 use App\Helpers\Linkify;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -52,12 +53,11 @@ class PrivateMessage extends Model
         ]);
     }
 
-    /**
-     * Set The PM Message After Its Been Purified.
-     */
-    public function setMessageAttribute(string $value): void
+    protected function message(): Attribute
     {
-        $this->attributes['message'] = htmlspecialchars((new AntiXSS())->xss_clean($value), ENT_NOQUOTES);
+        return new Attribute(
+            set: fn ($value) => htmlspecialchars((new AntiXSS())->xss_clean($value), ENT_NOQUOTES),
+        );
     }
 
     /**

--- a/app/Models/Rss.php
+++ b/app/Models/Rss.php
@@ -13,6 +13,7 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use App\Traits\Auditable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -77,49 +78,24 @@ class Rss extends Model
         return $this->belongsTo(User::class, 'staff_id');
     }
 
-    /**
-     * Get the RSS feeds JSON Torrent as object.
-     */
-    public function getObjectTorrentAttribute(): stdClass|bool
+    protected function objectTorrent(): Attribute
     {
-        // Went with attribute to avoid () calls in views. Uniform ->object_torrent vs ->json_torrent.
-        if ($this->json_torrent) {
-            $expected = $this->expected_fields;
-
-            return (object) array_merge($expected, $this->json_torrent);
-        }
-
-        return false;
+        return new Attribute(
+            get: function ($value) {
+                // Went with attribute to avoid () calls in views. Uniform ->object_torrent vs ->json_torrent.
+                if ($this->json_torrent) {
+                    $expected = $this->expected_fields;
+                    return (object) array_merge($expected, $this->json_torrent);
+                }
+                return false;
+            },
+        );
     }
 
-    /**
-     * Get the RSS feeds expected fields for form validation.
-     */
-    public function getExpectedFieldsAttribute(): array
+    protected function expectedFields(): Attribute
     {
-        // Just Torrents for now... extendable to check on feed type in future.
-        return [
-            'search'          => null,
-            'description'     => null,
-            'uploader'        => null,
-            'imdb'            => null,
-            'mal'             => null,
-            'categories'      => null,
-            'types'           => null,
-            'resolutions'     => null,
-            'genres'          => null,
-            'freeleech'       => null,
-            'doubleupload'    => null,
-            'featured'        => null,
-            'stream'          => null,
-            'highspeed'       => null,
-            'sd'              => null,
-            'internal'        => null,
-            'personalrelease' => null,
-            'bookmark'        => null,
-            'alive'           => null,
-            'dying'           => null,
-            'dead'            => null,
-        ];
+        return new Attribute(
+            get: fn ($value) => ['search' => null, 'description' => null, 'uploader' => null, 'imdb' => null, 'mal' => null, 'categories' => null, 'types' => null, 'resolutions' => null, 'genres' => null, 'freeleech' => null, 'doubleupload' => null, 'featured' => null, 'stream' => null, 'highspeed' => null, 'sd' => null, 'internal' => null, 'personalrelease' => null, 'bookmark' => null, 'alive' => null, 'dying' => null, 'dead' => null],
+        );
     }
 }

--- a/app/Models/Rss.php
+++ b/app/Models/Rss.php
@@ -18,7 +18,6 @@ use App\Traits\Auditable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
-use stdClass;
 
 class Rss extends Model
 {

--- a/app/Models/TicketAttachment.php
+++ b/app/Models/TicketAttachment.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use App\Traits\Auditable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -15,9 +16,11 @@ class TicketAttachment extends Model
         'full_disk_path',
     ];
 
-    public function getFullDiskPathAttribute(): string
+    protected function fullDiskPath(): Attribute
     {
-        return $this->disk_path.''.$this->file_name;
+        return new Attribute(
+            get: fn ($value) => $this->disk_path . '' . $this->file_name,
+        );
     }
 
     /**

--- a/app/Models/TicketAttachment.php
+++ b/app/Models/TicketAttachment.php
@@ -19,7 +19,7 @@ class TicketAttachment extends Model
     protected function fullDiskPath(): Attribute
     {
         return new Attribute(
-            get: fn ($value) => $this->disk_path . '' . $this->file_name,
+            get: fn ($value) => $this->disk_path.''.$this->file_name,
         );
     }
 

--- a/app/Models/Torrent.php
+++ b/app/Models/Torrent.php
@@ -13,6 +13,7 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use App\Helpers\Bbcode;
 use App\Helpers\Linkify;
 use App\Helpers\MediaInfo;
@@ -233,12 +234,11 @@ class Torrent extends Model
         return $this->hasMany(Bookmark::class);
     }
 
-    /**
-     * Set The Torrents Description After Its Been Purified.
-     */
-    public function setDescriptionAttribute(?string $value): void
+    protected function description(): Attribute
     {
-        $this->attributes['description'] = htmlspecialchars((new AntiXSS())->xss_clean($value), ENT_NOQUOTES);
+        return new Attribute(
+            set: fn ($value) => htmlspecialchars((new AntiXSS())->xss_clean($value), ENT_NOQUOTES),
+        );
     }
 
     /**
@@ -251,12 +251,13 @@ class Torrent extends Model
         return (new Linkify())->linky($bbcode->parse($this->description));
     }
 
-    /**
-     * Set The Torrents MediaInfo After Its Been Purified.
-     */
-    public function setMediaInfoAttribute(?string $value): void
+    protected function mediaInfo(): Attribute
     {
-        $this->attributes['mediainfo'] = $value;
+        return new Attribute(
+            set: fn ($value) => [
+                'mediainfo' => $value,
+            ],
+        );
     }
 
     /**

--- a/app/Models/TorrentRequest.php
+++ b/app/Models/TorrentRequest.php
@@ -13,6 +13,7 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use App\Helpers\Bbcode;
 use App\Helpers\Linkify;
 use App\Notifications\NewComment;
@@ -130,12 +131,11 @@ class TorrentRequest extends Model
         return $this->hasMany(TorrentRequestBounty::class, 'requests_id', 'id');
     }
 
-    /**
-     * Set The Requests Description After Its Been Purified.
-     */
-    public function setDescriptionAttribute(?string $value): void
+    protected function description(): Attribute
     {
-        $this->attributes['description'] = htmlspecialchars((new AntiXSS())->xss_clean($value), ENT_NOQUOTES);
+        return new Attribute(
+            set: fn ($value) => htmlspecialchars((new AntiXSS())->xss_clean($value), ENT_NOQUOTES),
+        );
     }
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -13,6 +13,7 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use App\Helpers\Bbcode;
 use App\Helpers\Linkify;
 use App\Helpers\StringHelper;
@@ -752,12 +753,11 @@ class User extends Authenticatable
         return StringHelper::formatBytes($bytes);
     }
 
-    /**
-     * Set The Users Signature After Its Been Purified.
-     */
-    public function setSignatureAttribute(?string $value): void
+    protected function signature(): Attribute
     {
-        $this->attributes['signature'] = htmlspecialchars((new AntiXSS())->xss_clean($value), ENT_NOQUOTES);
+        return new Attribute(
+            set: fn ($value) => htmlspecialchars((new AntiXSS())->xss_clean($value), ENT_NOQUOTES),
+        );
     }
 
     /**
@@ -770,12 +770,11 @@ class User extends Authenticatable
         return (new Linkify())->linky($bbcode->parse($this->signature));
     }
 
-    /**
-     * Set The Users About Me After Its Been Purified.
-     */
-    public function setAboutAttribute(?string $value): void
+    protected function about(): Attribute
     {
-        $this->attributes['about'] = htmlspecialchars((new AntiXSS())->xss_clean($value), ENT_NOQUOTES);
+        return new Attribute(
+            set: fn ($value) => htmlspecialchars((new AntiXSS())->xss_clean($value), ENT_NOQUOTES),
+        );
     }
 
     /**

--- a/app/Models/UserNotification.php
+++ b/app/Models/UserNotification.php
@@ -13,6 +13,7 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
@@ -54,20 +55,18 @@ class UserNotification extends Model
         ]);
     }
 
-    /**
-     * Get the Expected groups for form validation.
-     */
-    public function getExpectedGroupsAttribute(): array
+    protected function expectedGroups(): Attribute
     {
-        return [];
+        return new Attribute(
+            get: fn ($value) => [],
+        );
     }
 
-    /**
-     * Get the Expected fields for form validation.
-     */
-    public function getExpectedFieldsAttribute(): array
+    protected function expectedFields(): Attribute
     {
-        return [];
+        return new Attribute(
+            get: fn ($value) => [],
+        );
     }
 
     /**

--- a/app/Models/UserPrivacy.php
+++ b/app/Models/UserPrivacy.php
@@ -13,6 +13,7 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
@@ -64,20 +65,18 @@ class UserPrivacy extends Model
         ]);
     }
 
-    /**
-     * Get the Expected groups for form validation.
-     */
-    public function getExpectedGroupsAttribute(): array
+    protected function expectedGroups(): Attribute
     {
-        return [];
+        return new Attribute(
+            get: fn ($value) => [],
+        );
     }
 
-    /**
-     * Get the Expected fields for form validation.
-     */
-    public function getExpectedFieldsAttribute(): array
+    protected function expectedFields(): Attribute
     {
-        return [];
+        return new Attribute(
+            get: fn ($value) => [],
+        );
     }
 
     /**


### PR DESCRIPTION
- Starting with Laravel 8, you may define an accessor and mutator using a single, non-prefixed method which returns an Illuminate\Database\Eloquent\Casts\Attribute.