### PR TITLE
(Fix) Set group, active, deleted_at, deleted_by when deleting a user

### DIFF
--- a/app/Http/Controllers/ForumCategoryController.php
+++ b/app/Http/Controllers/ForumCategoryController.php
@@ -14,7 +14,6 @@
 namespace App\Http\Controllers;
 
 use App\Models\Forum;
-use App\Models\Topic;
 
 /**
  * @see \Tests\Feature\Http\Controllers\ForumCategoryControllerTest

--- a/app/Http/Controllers/Staff/UserController.php
+++ b/app/Http/Controllers/Staff/UserController.php
@@ -115,6 +115,16 @@ class UserController extends Controller
 
         abort_if($user->group->is_modo || auth()->user()->id == $user->id, 403);
 
+        $user->can_upload = 0;
+        $user->can_download = 0;
+        $user->can_comment = 0;
+        $user->can_invite = 0;
+        $user->can_request = 0;
+        $user->can_chat = 0;
+        $user->group_id = UserGroups::PRUNED;
+        $user->deleted_by = auth()->user()->id;
+        $user->save();
+
         // Removes UserID from Torrents if any and replaces with System UserID (1)
         foreach (Torrent::withAnyStatus()->where('user_id', '=', $user->id)->get() as $tor) {
             $tor->user_id = 1;


### PR DESCRIPTION
If we delete a user (using the button on the profile page), it gets the "deleted_at" timestamp, but remains in his current group.
This PR adds the deleted_by ID, sets the user to inactive, and moves him into the pruned group.