### PR TITLE
(Update) Warning system

### DIFF
--- a/resources/views/user/profile/partials/warnings.blade.php
+++ b/resources/views/user/profile/partials/warnings.blade.php
@@ -1,4 +1,4 @@
-<section class="panelV2" x-data="{ tab: 'undeleted'}"">
+<section class="panelV2" x-data="{ tab: 'automated'}">
     <header class="panel__header">
         <h2 class="panel__heading">{{ __('user.warnings') }}</h2>
         <div class="panel__actions">
@@ -68,10 +68,18 @@
         <li
             class="panel__tab"
             role="tab"
-            x-bind:class="tab === 'undeleted' && 'panel__tab--active'"
-            x-on:click="tab = 'undeleted'"
+            x-bind:class="tab === 'automated' && 'panel__tab--active'"
+            x-on:click="tab = 'automated'"
         >
-            {{ __('user.warnings') }} ({{ $user->active_warnings_count ?? 0 }})
+            Automated ({{ $user->auto_warnings_count ?? 0 }})
+        </li>
+        <li
+            class="panel__tab"
+            role="tab"
+            x-bind:class="tab === 'manual' && 'panel__tab--active'"
+            x-on:click="tab = 'manual'"
+        >
+            Manual ({{ $user->manual_warnings_count ?? 0 }})
         </li>
         <li
             class="panel__tab"
@@ -79,10 +87,10 @@
             x-bind:class="tab === 'deleted' && 'panel__tab--active'"
             x-on:click="tab = 'deleted'"
         >
-            {{ __('user.soft-deleted-warnings') }} ({{ $user->soft_deleted_warnings_count ?? 0 }})
+            Soft Deleted ({{ $user->soft_deleted_warnings_count ?? 0 }})
         </li>
     </menu>
-    <div class="data-table-wrapper" x-show="tab === 'undeleted'">
+    <div class="data-table-wrapper" x-show="tab === 'automated'">
         <table class="data-table">
             <thead>
                 <tr>
@@ -96,7 +104,7 @@
                 </tr>
             </thead>
             <tbody>
-                @forelse ($warnings as $warning)
+                @forelse ($autoWarnings as $warning)
                     <tr>
                         <td>
                             <x-user_tag :user="$warning->staffuser" :anon="false" />
@@ -166,8 +174,84 @@
                 @endforelse
             </tbody>
         </table>
-        {{ $warnings->links('partials.pagination') }}
+        {{ $autoWarnings->links('partials.pagination') }}
     </div>
+    <div class="data-table-wrapper" x-show="tab === 'manual'">
+        <table class="data-table">
+            <thead>
+            <tr>
+                <th>{{ __('user.warned-by') }}</th>
+                <th>{{ __('common.reason') }}</th>
+                <th>{{ __('user.created-on') }}</th>
+                <th>{{ __('user.expires-on') }}</th>
+                <th>{{ __('user.active') }}</th>
+                <th>{{ __('common.actions') }}</th>
+            </tr>
+            </thead>
+        <tbody>
+        @forelse ($manualWarnings as $warning)
+            <tr>
+                <td>
+                    <x-user_tag :user="$warning->staffuser" :anon="false" />
+                </td>
+                <td>{{ $warning->reason }}</td>
+                <td>
+                    <time datetime="{{ $warning->created_at }}" title="{{ $warning->created_at }}">
+                        {{ $warning->created_at }}
+                    </time>
+                </td>
+                <td>
+                    <time datetime="{{ $warning->expires_on }}" title="{{ $warning->expires_on }}">
+                        {{ $warning->expires_on }}
+                    </time>
+                </td>
+                <td>
+                    @if ($warning->active)
+                        <i class="{{ config('other.font-awesome') }} fa-check text-green"></i>
+                    @else
+                        <i class="{{ config('other.font-awesome') }} fa-times text-red"></i>
+                    @endif
+                </td>
+                <td>
+                    <menu class="data-table__actions">
+                        <li class="data-table__action">
+                            <form
+                                    action="{{ route('deleteWarning', ['id' => $warning->id]) }}"
+                                    method="POST"
+                                    x-data
+                            >
+                                @csrf
+                                @method('DELETE')
+                                <button
+                                        x-on:click.prevent="Swal.fire({
+                                                title: 'Are you sure?',
+                                                text: `Are you sure you want to delete this warning: ${atob('{{ base64_encode($warning->reason) }}')}?`,
+                                                icon: 'warning',
+                                                showConfirmButton: true,
+                                                showCancelButton: true,
+                                            }).then((result) => {
+                                                if (result.isConfirmed) {
+                                                    $root.submit();
+                                                }
+                                            })"
+                                        class="form__button form__button--text"
+                                >
+                                    {{ __('common.delete') }}
+                                </button>
+                            </form>
+                        </li>
+                    </menu>
+                </td>
+            </tr>
+        @empty
+            <tr>
+                <td colspan="7">{{ __('user.no-warning') }}</td>
+            </tr>
+        @endforelse
+        </tbody>
+    </table>
+    {{ $manualWarnings->links('partials.pagination') }}
+</div>
     <div class="data-table-wrapper" x-show="tab === 'deleted'" x-cloak>
         <table class="data-table">
             <thead>

--- a/resources/views/user/profile/show.blade.php
+++ b/resources/views/user/profile/show.blade.php
@@ -285,7 +285,7 @@
         @if (auth()->user()->group->is_modo)
             @livewire('user-notes', ['user' => $user])
             @include('user.profile.partials.bans', ['bans' => $user->userban])
-            @include('user.profile.partials.warnings', ['warnings' => $warnings])
+            @include('user.profile.partials.warnings')
             <section class="panelV2">
                 <header class="panel__header">
                     <h2 class="panel__heading">Watchlist</h2>


### PR DESCRIPTION
- bump pagination to 10
- The warnings panel is now split by warning types. Automated (Torrents), Manual (Staff) and Soft Deleted (whether manual or automated). The counts in tabs are total whether active or not. The Active warning count and total hit run count are in top right of profile.