### PR TITLE
(Fix) Store peer unconnectable state

### DIFF
--- a/app/Models/Peer.php
+++ b/app/Models/Peer.php
@@ -83,6 +83,8 @@ class Peer extends Model
                 if (\is_resource($con)) {
                     fclose($con);
                 }
+            } else {
+                $this->connectable = $cache === null ? 0 : unserialize($cache);
             }
         }
     }


### PR DESCRIPTION
Every time this function is called, we're already updating the `updated_at` timestamp to the current time, so it's a relatively insignificant change to add another field to the update clause at the same time.