### PR TITLE
(Fix) Only show groups permitted by the user's rank

### DIFF
--- a/app/Http/Controllers/Staff/UserController.php
+++ b/app/Http/Controllers/Staff/UserController.php
@@ -51,11 +51,13 @@ class UserController extends Controller
     /**
      * User Edit Form.
      */
-    public function edit(User $user): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
+    public function edit(Request $request, User $user): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
     {
+        $group = $request->user()->group;
+
         return view('Staff.user.edit', [
             'user'      => $user,
-            'groups'    => Group::all(),
+            'groups'    => Group::when(! $group->is_owner, fn ($query) => $query->where('level', '<=', $group->level))->get(),
             'internals' => Internal::all(),
         ]);
     }


### PR DESCRIPTION
On the user edit form, all groups are shown in the group edit selection regardless of if the currently authenticated user is allowed to edit a user to the selected group. This PR changes it so only the groups that the authenticated user are allowed to edit users to are shown in the edit form.