### PR TITLE
(Fix) User notes cancel button

### DIFF
--- a/app/Http/Livewire/UserNotes.php
+++ b/app/Http/Livewire/UserNotes.php
@@ -24,13 +24,20 @@ class UserNotes extends Component
 
     public User $user;
 
-    public string $message;
+    public string $message = '';
 
     public int $perPage = 25;
 
     public string $sortField = 'created_at';
 
     public string $sortDirection = 'desc';
+
+    protected $rules = [
+        'message' => [
+            'required',
+            'filled',
+        ],
+    ];
 
     final public function getNotesProperty(): \Illuminate\Contracts\Pagination\LengthAwarePaginator
     {
@@ -50,6 +57,8 @@ class UserNotes extends Component
     final public function store(): void
     {
         abort_unless(auth()->user()->group->is_modo, 403);
+
+        $this->validate();
 
         Note::create([
             'user_id'  => $this->user->id,

--- a/resources/views/livewire/user-notes.blade.php
+++ b/resources/views/livewire/user-notes.blade.php
@@ -16,8 +16,6 @@
                     <form
                         class="dialog__form"
                         x-on:click.outside="$refs.dialog.close()"
-                        wire:submit.prevent="store"
-                        x-on:submit="$refs.dialog.close()"
                     >
                         <p class="form__group">
                             <textarea
@@ -32,7 +30,11 @@
                             </label>
                         </p>
                         <p class="form__group">
-                            <button class="form__button form__button--filled">
+                            <button
+                                class="form__button form__button--filled"
+                                wire:click="store"
+                                x-on:click="$refs.dialog.close()"
+                            >
                                 {{ __('common.save') }}
                             </button>
                             <button formmethod="dialog" formnovalidate class="form__button form__button--outlined">


### PR DESCRIPTION
Previously, the cancel button was also sending the submit event. Now we listen on the save button directly to store the note. We also now validate the property before it's stored.