### PR TITLE
(Update) Allow adding multiple torrents to a playlist

### DIFF
--- a/app/Http/Controllers/PlaylistTorrentController.php
+++ b/app/Http/Controllers/PlaylistTorrentController.php
@@ -13,11 +13,14 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Requests\MassUpsertPlaylistTorrentRequest;
 use App\Http\Requests\StorePlaylistTorrentRequest;
 use App\Models\Playlist;
 use App\Models\PlaylistTorrent;
 use Exception;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\Rule;
 
 /**
  * @see \Tests\Todo\Feature\Http\Controllers\PlaylistTorrentControllerTest
@@ -34,6 +37,34 @@ class PlaylistTorrentController extends Controller
         abort_unless($request->user()->id === $playlist->user_id, 403);
 
         PlaylistTorrent::create($request->validated());
+
+        return to_route('playlists.show', ['playlist' => $playlist])
+            ->withSuccess(trans('playlist.attached-success'));
+    }
+
+    /**
+     * Attach Torrents To A Playlist.
+     */
+    public function massUpsert(MassUpsertPlaylistTorrentRequest $request): \Illuminate\Http\RedirectResponse
+    {
+        $playlist = Playlist::findOrFail($request->integer('playlist_id'));
+
+        abort_unless($request->user()->id === $playlist->user_id, 403);
+
+        $playlistTorrents = $request->string('torrent_urls')
+            ->explode("\n")
+            ->map(fn ($url) => basename($url))
+            ->unique()
+            ->map(fn ($id) => ['playlist_id' => $playlist->id, 'torrent_id' => $id, 'tmdb_id' => 0])
+            ->toArray();
+
+        Validator::make($playlistTorrents, [
+            '*.torrent_id' => Rule::exists('torrents', 'id'),
+        ], [
+            '*.torrent_id.exists' => 'The torrent ID/URL ":input" entered was not found on site.'
+        ])->validate();
+
+        PlaylistTorrent::upsert($playlistTorrents, ['playlist_id', 'torrent_id', 'tmdb_id']);
 
         return to_route('playlists.show', ['playlist' => $playlist])
             ->withSuccess(trans('playlist.attached-success'));

--- a/app/Http/Requests/MassUpsertPlaylistTorrentRequest.php
+++ b/app/Http/Requests/MassUpsertPlaylistTorrentRequest.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * NOTICE OF LICENSE.
+ *
+ * UNIT3D Community Edition is open-sourced software licensed under the GNU Affero General Public License v3.0
+ * The details is bundled with this project in the file LICENSE.txt.
+ *
+ * @project    UNIT3D Community Edition
+ *
+ * @author     Roardom <roardom@protonmail.com>
+ * @license    https://www.gnu.org/licenses/agpl-3.0.en.html/ GNU Affero General Public License v3.0
+ */
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+
+/**
+ * @see \Tests\Todo\Unit\Http\Requests\VoteOnPollTest
+ */
+class MassUpsertPlaylistTorrentRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     */
+    public function rules(Request $request): array
+    {
+        return [
+            'playlist_id' => [
+                'required',
+                'numeric',
+                'integer',
+                Rule::exists('playlists', 'id'),
+            ],
+            'torrent_urls' => [
+                'required',
+                'max:65535',
+            ],
+        ];
+    }
+}

--- a/resources/views/playlist/show.blade.php
+++ b/resources/views/playlist/show.blade.php
@@ -28,22 +28,23 @@
                         <form
                             class="dialog__form"
                             method="POST"
-                            action="{{ route('playlist_torrents.store') }}"
+                            action="{{ route('playlist_torrents.massUpsert') }}"
                             x-on:click.outside="$refs.dialog.close()"
                         >
                             @csrf
+                            @method('PUT')
                             <p class="form__group">
                                 <input id="playlist_id" name="playlist_id" type="hidden" value="{{ $playlist->id }}">
                             </p>
                             <p class="form__group">
-                                <input
-                                    id="torrent_id"
-                                    class="form__text"
-                                    name="torrent_id"
+                                <textarea
+                                    id="torrent_urls"
+                                    class="form__textarea"
+                                    name="torrent_urls"
                                     type="text"
                                     required
-                                >
-                                <label class="form__label form__label--floating" for="torrent_id">Torrent ID</label>
+                                >{{ old('torrent_urls') }}</textarea>
+                                <label class="form__label form__label--floating" for="torrent_urls">Torrent IDs/URLs (One per line)</label>
                             </p>
                             <p class="form__group">
                                 <button class="form__button form__button--filled">

--- a/routes/web.php
+++ b/routes/web.php
@@ -245,6 +245,7 @@ Route::middleware('language')->group(function (): void {
         Route::prefix('playlist-torrents')->group(function (): void {
             Route::name('playlist_torrents.')->group(function (): void {
                 Route::post('/', [App\Http\Controllers\PlaylistTorrentController::class, 'store'])->name('store');
+                Route::put('/', [App\Http\Controllers\PlaylistTorrentController::class, 'massUpsert'])->name('massUpsert');
                 Route::delete('/{playlistTorrent}', [App\Http\Controllers\PlaylistTorrentController::class, 'destroy'])->name('destroy');
             });
         });


### PR DESCRIPTION
Instead of adding one torrent at a time through a text input, a textarea is offered instead where one id/url can be entered per line for convenience.