### PR TITLE
(Fix) Allow reselection of "no distributor" and "no region"

### DIFF
--- a/resources/views/torrent/create.blade.php
+++ b/resources/views/torrent/create.blade.php
@@ -183,7 +183,7 @@
                                 x-model="distributor"
                                 x-bind:class="distributor === '' ? 'form__select--default' : ''"
                             >
-                                <option hidden="" disabled selected value=""></option>
+                                <option selected value=""></option>
                                 @foreach ($distributors as $distributor)
                                     <option value="{{ $distributor->id }}" @selected(old('distributor_id')==$distributor->id)>
                                         {{ $distributor->name }}
@@ -203,7 +203,7 @@
                                 x-model="region"
                                 x-bind:class="region === '' ? 'form__select--default' : ''"
                             >
-                                <option hidden disabled selected value=""></option>
+                                <option selected value=""></option>
                                 @foreach ($regions as $region)
                                     <option value="{{ $region->id }}" @selected(old('region_id')==$region->id)>
                                         {{ $region->name }}


### PR DESCRIPTION
The edit page allows selection of "No distributor" and "No region" so we should allow that on the upload page too. If we would rather instead explicitly enforce it, then the edit page should be updated instead.