### PR TITLE
(Fix) Featured buttons and animation

### DIFF
--- a/resources/views/blocks/featured.blade.php
+++ b/resources/views/blocks/featured.blade.php
@@ -8,7 +8,7 @@
             <ul
                 class="featured-carousel"
                 x-ref="featured"
-                {{-- x-init="setInterval(function () {$el.parentNode.matches(':hover') ? null : (($el.scrollLeft == $el.scrollWidth - $el.offsetWidth - 16) ? $el.scrollLeft = 0 : $el.scrollLeft += (($el.children[0].offsetWidth + 16) / 2 + 1)) }, 5000)" --}}
+                 x-init="setInterval(function () {$el.parentNode.matches(':hover') ? null : (($el.scrollLeft == $el.scrollWidth - $el.offsetWidth - 16) ? $el.scrollLeft = 0 : $el.scrollLeft += (($el.children[0].offsetWidth + 16) / 2 + 2)) }, 5000)"
             >
                 @foreach ($featured as $feature)
                     @if ($feature->torrent === null || ! $feature->torrent->isApproved())
@@ -40,10 +40,10 @@
                 @endforeach
             </ul>
             <nav class="featured-carousel__nav">
-                <button class="featured-carousel__previous" x-on:click="$refs.featured.scrollLeft == 0 ? $refs.featured.scrollLeft = $refs.featured.scrollWidth : $refs.featured.scrollLeft -= (($refs.featured.children[0].offsetWidth + 16) / 2 + 1)">
+                <button class="featured-carousel__previous" x-on:click="$refs.featured.scrollLeft == 16 ? $refs.featured.scrollLeft = $refs.featured.scrollWidth : $refs.featured.scrollLeft -= (($refs.featured.children[0].offsetWidth + 16) / 2 + 2)">
                     <i class="{{ \config('other.font-awesome') }} fa-angle-left"></i>
                 </button>
-                <button class="featured-carousel__next" x-on:click="$refs.featured.scrollLeft == ($refs.featured.scrollWidth - $refs.featured.offsetWidth) ? $refs.featured.scrollLeft = 0 : $refs.featured.scrollLeft += (($refs.featured.children[0].offsetWidth + 16) / 2 + 1)">
+                <button class="featured-carousel__next" x-on:click="$refs.featured.scrollLeft == ($refs.featured.scrollWidth - $refs.featured.offsetWidth - 16) ? $refs.featured.scrollLeft = 0 : $refs.featured.scrollLeft += (($refs.featured.children[0].offsetWidth + 16) / 2 + 2)">
                     <i class="{{ \config('other.font-awesome') }} fa-angle-right"></i>
                 </button>
             </nav>


### PR DESCRIPTION
The code for having the carousel rotate was unintentionally commented out.

Additionally, there seems to be a rounding error somewhere when there are 6 or more featured torrents where scrolling one pixel past halfway through the next card isn't enough to get it to scroll the rest of the way on its own using css scroll behavior. So that's now been updated to 2 pixels which seems to work with 6 featured torrents.

Finally, the card gap (currently set to 16 px) wasn't accounted for in the wrap around for when the last card is reached. Now it is.