### PR TITLE
(Add) Refresh torrent metadata button

### DIFF
--- a/app/Http/Controllers/SimilarTorrentController.php
+++ b/app/Http/Controllers/SimilarTorrentController.php
@@ -17,6 +17,7 @@ use App\Models\Category;
 use App\Models\Movie;
 use App\Models\Torrent;
 use App\Models\Tv;
+use App\Services\Tmdb\TMDBScraper;
 use MarcReichel\IGDBLaravel\Models\Game;
 use MarcReichel\IGDBLaravel\Models\PlatformLogo;
 
@@ -99,5 +100,26 @@ class SimilarTorrentController extends Controller
             'tmdb'               => $tmdb ?? null,
             'igdb'               => $igdb ?? null,
         ]);
+    }
+
+    public function update(Category $category, int $tmdbId)
+    {
+        if ($tmdbId !== 0) {
+            $tmdbScraper = new TMDBScraper();
+
+            switch (true) {
+                case $category->movie_meta:
+                    $tmdbScraper->movie($tmdbId);
+
+                    break;
+                case $category->tv_meta:
+                    $tmdbScraper->tv($tmdbId);
+
+                    break;
+            }
+        }
+
+        return to_route('torrents.similar', ['category_id' => $category->id, 'tmdb' => $tmdbId])
+            ->withSuccess('Metadata update queued successfully');
     }
 }

--- a/resources/sass/components/_meta.scss
+++ b/resources/sass/components/_meta.scss
@@ -158,27 +158,38 @@
     padding: 0;
 }
 
-.meta__dropdown > li:first-child > a {
+.meta__dropdown > li > form {
+    display: contents;
+}
+
+.meta__dropdown > li:first-child > a,
+.meta__dropdown > li:first-child > form > button {
     border-radius: 6px 6px 0 0;
 }
 
-.meta__dropdown > li:last-child > a {
+.meta__dropdown > li:last-child > a,
+.meta__dropdown > li:last-child > form > button {
     border-radius: 0 0 6px 6px;
 }
 
-.meta__dropdown > li:only-child > a {
+.meta__dropdown > li:only-child > a,
+.meta__dropdown > li:only-child > form > button {
     border-radius: 6px;
 }
 
-.meta__dropdown > li > a {
+.meta__dropdown > li > a,
+.meta__dropdown > li > form > button {
     padding: 18px 18px 18px 28px;
     min-width: 180px;
     display: block;
     color: var(--meta-dropdown-fg);
+    background: transparent;
     font-size: 14px;
+    text-align: left;
 }
 
-.meta__dropdown > li > a:hover {
+.meta__dropdown > li > a:hover,
+.meta__dropdown > li > form > button:hover {
     background: var(--meta-dropdown-hover-bg);
     color: var(--meta-dropdown-hover-fg);
 }

--- a/resources/views/torrent/partials/movie_meta.blade.php
+++ b/resources/views/torrent/partials/movie_meta.blade.php
@@ -44,6 +44,18 @@
                     Request similar
                 </a>
             </li>
+            @if ($meta?->id && auth()->user()->group->is_modo)
+                <li>
+                    <form
+                        action="{{ route('torrents.similar.update', ['category' => $category, 'tmdbId' => $meta->id]) }}"
+                        method="post"
+                    >
+                        @csrf
+                        @method('PATCH')
+                        <button>Update Metadata</button>
+                    </form>
+                </li>
+            @endif
         </ul>
     </div>
     <ul class="meta__ids">

--- a/resources/views/torrent/partials/tv_meta.blade.php
+++ b/resources/views/torrent/partials/tv_meta.blade.php
@@ -44,6 +44,18 @@
                     Request similar
                 </a>
             </li>
+            @if ($meta?->id && auth()->user()->group->is_modo)
+                <li>
+                    <form
+                        action="{{ route('torrents.similar.update', ['category' => $category, 'tmdbId' => $meta->id]) }}"
+                        method="post"
+                    >
+                        @csrf
+                        @method('PATCH')
+                        <button>Update Metadata</button>
+                    </form>
+                </li>
+            @endif
         </ul>
     </div>
     <ul class="meta__ids">

--- a/routes/web.php
+++ b/routes/web.php
@@ -206,6 +206,7 @@ Route::middleware('language')->group(function (): void {
             Route::get('/download/{id}', [App\Http\Controllers\TorrentDownloadController::class, 'store'])->name('download');
             Route::post('/{id}/reseed', [App\Http\Controllers\ReseedController::class, 'store'])->name('reseed');
             Route::get('/similar/{category_id}.{tmdb}', [App\Http\Controllers\SimilarTorrentController::class, 'show'])->name('torrents.similar');
+            Route::patch('/similar/{category}.{tmdbId}', [App\Http\Controllers\SimilarTorrentController::class, 'update'])->name('torrents.similar.update')->middleware('modo');
         });
 
         Route::prefix('torrent')->group(function (): void {


### PR DESCRIPTION
Provides the ability to site moderators to refresh movie/tv metadata easily. Any torrent uploader can already do this by editing their torrent and resubmitting without changing anything.