### PR TITLE
(Update) Optimize process tv and process movie jobs

### DIFF
--- a/app/Jobs/ProcessMovieJob.php
+++ b/app/Jobs/ProcessMovieJob.php
@@ -16,6 +16,7 @@ namespace App\Jobs;
 use App\Enums\Occupations;
 use App\Models\Collection;
 use App\Models\Company;
+use App\Models\Credit;
 use App\Models\Genre;
 use App\Models\Movie;
 use App\Models\Person;
@@ -45,48 +46,69 @@ class ProcessMovieJob implements ShouldQueue
     public function handle(): void
     {
         $tmdb = new TMDB();
+        $movie = Movie::find((int) $this->movie['id']);
+
+        // Genres
+
+        $genres = [];
+        $genre_ids = [];
 
         foreach ($this->movie['genres'] as $genre) {
-            if (isset($genre['name'])) {
-                Genre::updateOrCreate(['id' => $genre['id']], $genre)->movie()->syncWithoutDetaching([$this->movie['id']]);
-            }
+            $genre_ids[] = $genre['id'];
+            $genres[] = [
+                'id'   => $genre['id'],
+                'name' => $genre['name']
+            ];
         }
 
-        foreach ($this->movie['production_companies'] as $productionCompany) {
-            $client = new Client\Company($productionCompany['id']);
-            $productionCompany = $client->getData();
+        Genre::upsert($genres, 'id');
+        $movie->genres()->sync(array_unique($genre_ids));
 
-            if (isset($productionCompany['name'])) {
-                $productionCompanyArray = [
-                    'description'    => $productionCompany['description'] ?? null,
-                    'headquarters'   => $productionCompany['headquarters'] ?? null,
-                    'homepage'       => $productionCompany['homepage'] ?? null,
-                    'logo'           => $tmdb->image('logo', $productionCompany),
-                    'name'           => $productionCompany['name'] ?? null,
-                    'origin_country' => $productionCompany['origin_country'],
-                ];
-                Company::updateOrCreate(['id' => $productionCompany['id']], $productionCompanyArray)->movie()->syncWithoutDetaching([$this->movie['id']]);
-            }
+        // Companies
+
+        $companies = [];
+        $company_ids = [];
+
+        foreach ($this->movie['production_companies'] ?? [] as $company) {
+            $company = (new Client\Company($company['id']))->getData();
+
+            $company_ids[] = $company['id'];
+            $companies[] = [
+                'id'             => $company['id'],
+                'description'    => $company['description'] ?? null,
+                'headquarters'   => $company['headquarters'] ?? null,
+                'homepage'       => $company['homepage'] ?? null,
+                'logo'           => $tmdb->image('logo', $company),
+                'name'           => $company['name'] ?? null,
+                'origin_country' => $company['origin_country'],
+            ];
         }
+
+        Company::upsert($companies, 'id');
+        $movie->companies()->sync(array_unique($company_ids));
+
+        // Collection
 
         if (isset($this->movie['belongs_to_collection']['id'])) {
-            $client = new Client\Collection($this->movie['belongs_to_collection']['id']);
-            $belongsToCollection = $client->getData();
+            $collection = (new Client\Collection($this->movie['belongs_to_collection']['id']))->getData();
 
-            if (isset($belongsToCollection['name'])) {
-                $titleSort = addslashes(str_replace(['The ', 'An ', 'A ', '"'], [''], $belongsToCollection['name']));
+            $titleSort = addslashes(str_replace(['The ', 'An ', 'A ', '"'], [''], $collection['name']));
 
-                $belongsToCollectionArray = [
-                    'name'      => $belongsToCollection['name'] ?? null,
-                    'name_sort' => $titleSort,
-                    'parts'     => is_countable($belongsToCollection['parts']) ? \count($belongsToCollection['parts']) : 0,
-                    'overview'  => $belongsToCollection['overview'] ?? null,
-                    'poster'    => $tmdb->image('poster', $belongsToCollection),
-                    'backdrop'  => $tmdb->image('backdrop', $belongsToCollection),
-                ];
-                Collection::updateOrCreate(['id' => $belongsToCollection['id']], $belongsToCollectionArray)->movie()->syncWithoutDetaching([$this->movie['id']]);
-            }
+            $collection = [
+                'id'        => $collection['id'],
+                'name'      => $collection['name'] ?? null,
+                'name_sort' => $titleSort,
+                'parts'     => is_countable($collection['parts']) ? \count($collection['parts']) : 0,
+                'overview'  => $collection['overview'] ?? null,
+                'poster'    => $tmdb->image('poster', $collection),
+                'backdrop'  => $tmdb->image('backdrop', $collection),
+            ];
+
+            Collection::upsert($collection, 'id');
+            $movie->collection()->sync([$collection['id']]);
         }
+
+        // People
 
         $people_ids = [];
         $credits = [];
@@ -110,6 +132,7 @@ class ProcessMovieJob implements ShouldQueue
                     'movie_id'      => $this->movie['id'],
                     'person_id'     => $person['id'],
                     'occupation_id' => $job->value,
+                    'character'     => null,
                     'order'         => null
                 ];
                 $people_ids[] = $person['id'];
@@ -119,23 +142,31 @@ class ProcessMovieJob implements ShouldQueue
         $people = [];
 
         foreach (array_unique($people_ids) as $person_id) {
-            $client = new Client\Person($person_id);
-            $person = $client->getData();
+            $person = (new Client\Person($person_id))->getData();
             $people[] = $tmdb->person_array($person);
         }
 
         Person::upsert($people, 'id');
-        Movie::find($this->movie['id'])->people()->sync($credits);
+        Credit::upsert($credits, ['person_id', 'movie_id', 'tv_id', 'occupation_id', 'character']);
 
-        if (isset($this->movie['recommendations'])) {
-            foreach ($this->movie['recommendations']['results'] as $recommendation) {
-                if (Movie::where('id', '=', $recommendation['id'])->exists()) {
-                    Recommendation::updateOrCreate(
-                        ['recommendation_movie_id' => $recommendation['id'], 'movie_id' => $this->movie['id']],
-                        ['title' => $recommendation['title'], 'vote_average' => $recommendation['vote_average'], 'poster' => $tmdb->image('poster', $recommendation), 'release_date' => $recommendation['release_date']]
-                    );
-                }
+        // Recommendations
+
+        $movie_ids = Movie::select('id')->findMany(array_column($this->movie['recommendations']['results'] ?? [], 'id'))->pluck('id');
+        $recommendations = [];
+
+        foreach ($this->movie['recommendations']['results'] ?? [] as $recommendation) {
+            if ($movie_ids->contains($recommendation['id'])) {
+                $recommendations[] = [
+                    'recommendation_movie_id' => $recommendation['id'],
+                    'movie_id'                => $this->movie['id'],
+                    'title'                   => $recommendation['title'],
+                    'vote_average'            => $recommendation['vote_average'],
+                    'poster'                  => $tmdb->image('poster', $recommendation),
+                    'release_date'            => $recommendation['release_date'],
+                ];
             }
         }
+
+        Recommendation::upsert($recommendations, ['recommendation_movie_id', 'movie_id']);
     }
 }

--- a/app/Jobs/ProcessTvJob.php
+++ b/app/Jobs/ProcessTvJob.php
@@ -16,6 +16,7 @@ namespace App\Jobs;
 
 use App\Enums\Occupations;
 use App\Models\Company;
+use App\Models\Credit;
 use App\Models\Episode;
 use App\Models\Genre;
 use App\Models\Network;
@@ -49,51 +50,79 @@ class ProcessTvJob implements ShouldQueue
     public function handle(): void
     {
         $tmdb = new TMDB();
+        $tv = Tv::find((int) $this->tv['id']);
 
-        foreach ($this->tv['production_companies'] as $productionCompany) {
-            if (isset($productionCompany['name'])) {
-                $productionCompanyArray = [
-                    'description'    => $tmdb->ifExists('description', $productionCompany),
-                    'name'           => $productionCompany['name'],
-                    'headquarters'   => $tmdb->ifExists('headquarters', $productionCompany),
-                    'homepage'       => $tmdb->ifExists('homepage', $productionCompany),
-                    'logo'           => $tmdb->image('logo', $productionCompany),
-                    'origin_country' => $tmdb->ifExists('origin_country', $productionCompany),
-                ];
-                Company::updateOrCreate(['id' => $productionCompany['id']], $productionCompanyArray)->tv()->syncWithoutDetaching([$this->tv['id']]);
-            }
+        // Companies
+
+        $companies = [];
+        $company_ids = [];
+
+        foreach ($this->tv['production_companies'] ?? [] as $company) {
+            $companies[] = [
+                'id'             => $company['id'],
+                'description'    => $tmdb->ifExists('description', $company),
+                'name'           => $company['name'],
+                'headquarters'   => $tmdb->ifExists('headquarters', $company),
+                'homepage'       => $tmdb->ifExists('homepage', $company),
+                'logo'           => $tmdb->image('logo', $company),
+                'origin_country' => $tmdb->ifExists('origin_country', $company),
+            ];
+            $company_ids[] = $company['id'];
         }
 
-        foreach ($this->tv['networks'] as $network) {
-            $client = new Client\Network($network['id']);
-            $network = $client->getData();
+        Company::upsert($companies, 'id');
+        $tv->companies()->sync(array_unique($company_ids));
 
-            if (isset($network['name'])) {
+        // Networks
+
+        $networks = [];
+        $network_ids = [];
+
+        foreach ($this->tv['networks'] ?? [] as $network) {
+            $network = (new Client\Network($network['id']))->getData();
+
+            if (isset($network['id'], $network['name'])) {
                 if (isset($network['images']['logos'][0]) && \array_key_exists('file_path', $network['images']['logos'][0])) {
                     $logo = 'https://image.tmdb.org/t/p/original'.$network['images']['logos'][0]['file_path'];
                 } else {
                     $logo = null;
                 }
 
-                $networkArray = [
+                $networks[] = [
+                    'id'             => $network['id'],
                     'headquarters'   => $tmdb->ifExists('headquarters', $network),
                     'homepage'       => $tmdb->ifExists('homepage', $network),
                     'logo'           => $logo,
                     'name'           => $network['name'],
                     'origin_country' => $network['origin_country'],
                 ];
-                Network::updateOrCreate(['id' => $network['id']], $networkArray)->tv()->syncWithoutDetaching([$this->id]);
+                $network_ids[] = $network['id'];
             }
         }
+
+        Network::upsert($networks, 'id');
+        $tv->networks()->sync(array_unique($network_ids));
+
+        // Genres
+
+        $genres = [];
+        $genre_ids = [];
 
         foreach ($this->tv['genres'] as $genre) {
-            if (isset($genre['name'])) {
-                Genre::updateOrCreate(['id' => $genre['id']], $genre)->tv()->syncWithoutDetaching([$this->id]);
-            }
+            $genres[] = [
+                'id'   => $genre['id'],
+                'name' => $genre['name']
+            ];
+            $genre_ids[] = $genre['id'];
         }
 
-        $people_ids = [];
+        Genre::upsert($genres, 'id');
+        $tv->genres()->sync(array_unique($genre_ids));
+
+        // People
+
         $credits = [];
+        $people_ids = [];
 
         foreach ($this->tv['aggregate_credits']['cast'] ?? [] as $person) {
             foreach ($person['roles'] as $role) {
@@ -117,6 +146,7 @@ class ProcessTvJob implements ShouldQueue
                         'tv_id'         => $this->tv['id'],
                         'person_id'     => $person['id'],
                         'occupation_id' => $occupation->value,
+                        'character'     => null,
                         'order'         => null,
                     ];
                     $people_ids[] = $person['id'];
@@ -129,6 +159,7 @@ class ProcessTvJob implements ShouldQueue
                 'tv_id'         => $this->tv['id'],
                 'person_id'     => $person['id'],
                 'occupation_id' => Occupations::CREATOR->value,
+                'character'     => null,
                 'order'         => null,
             ];
             $people_ids[] = $person['id'];
@@ -137,64 +168,70 @@ class ProcessTvJob implements ShouldQueue
         $people = [];
 
         foreach (array_unique($people_ids) as $person_id) {
-            $client = new Client\Person($person_id);
-            $person = $client->getData();
+            $person = (new Client\Person($person_id))->getData();
             $people[] = $tmdb->person_array($person);
         }
 
         Person::upsert($people, 'id');
-        Tv::find($this->tv['id'])->people()->sync($credits);
+        Credit::upsert($credits, ['person_id', 'movie_id', 'tv_id', 'occupation_id', 'character']);
+
+        // Seasons and episodes
+
+        $seasons = [];
+        $episodes = [];
 
         foreach ($this->tv['seasons'] as $season) {
-            $client = new Client\Season($this->id, sprintf('%02d', $season['season_number']));
-            $season = $client->getData();
+            $season = (new Client\Season($this->id, $season['season_number']))->getData();
 
-            if (isset($season['season_number'])) {
-                $seasonArray = [
-                    'air_date'      => $tmdb->ifExists('air_date', $season),
-                    'poster'        => $tmdb->image('poster', $season),
-                    'name'          => $tmdb->ifExists('name', $season),
-                    'overview'      => $tmdb->ifExists('overview', $season),
-                    'season_number' => sprintf('%02d', $season['season_number']),
-                    'tv_id'         => $this->id,
+            $seasons[] = [
+                'id'            => $season['id'],
+                'air_date'      => $tmdb->ifExists('air_date', $season),
+                'poster'        => $tmdb->image('poster', $season),
+                'name'          => $tmdb->ifExists('name', $season),
+                'overview'      => $tmdb->ifExists('overview', $season),
+                'season_number' => $tmdb->ifExists('season_number', $season),
+                'tv_id'         => $this->id,
+            ];
+
+            foreach ($season['episodes'] as $episode) {
+                $episodes[] = [
+                    'id'              => $episode['id'],
+                    'tv_id'           => $this->id,
+                    'air_date'        => $tmdb->ifExists('air_date', $episode),
+                    'name'            => Str::limit($tmdb->ifExists('name', $episode), 200),
+                    'episode_number'  => $episode['episode_number'],
+                    'overview'        => $tmdb->ifExists('overview', $episode),
+                    'still'           => $tmdb->image('still', $episode),
+                    'production_code' => $episode['production_code'],
+                    'season_number'   => $episode['season_number'],
+                    'vote_average'    => $episode['vote_average'],
+                    'vote_count'      => $episode['vote_count'],
+                    'season_id'       => $season['id'],
                 ];
-
-                Season::updateOrCreate(['id' => $season['id']], $seasonArray)->tv();
-
-                foreach ($season['episodes'] as $episode) {
-                    $client = new Client\Episode($this->id, sprintf('%02d', $season['season_number']), $episode['episode_number']);
-                    $episode = $client->getData();
-
-                    if (isset($episode['episode_number'])) {
-                        $episodeArray = [
-                            'tv_id'           => $this->id,
-                            'air_date'        => $tmdb->ifExists('air_date', $episode),
-                            'name'            => Str::limit($tmdb->ifExists('name', $episode), 200),
-                            'episode_number'  => sprintf('%02d', $episode['episode_number']),
-                            'overview'        => $tmdb->ifExists('overview', $episode),
-                            'still'           => $tmdb->image('still', $episode),
-                            'production_code' => $episode['production_code'],
-                            'season_number'   => sprintf('%02d', $episode['season_number']),
-                            'vote_average'    => $episode['vote_average'],
-                            'vote_count'      => $episode['vote_count'],
-                            'season_id'       => $season['id'],
-                        ];
-
-                        Episode::updateOrCreate(['id' => $episode['id']], $episodeArray)->season();
-                    }
-                }
             }
         }
 
-        if (isset($this->tv['recommendations'])) {
-            foreach ($this->tv['recommendations']['results'] as $recommendation) {
-                if (Tv::where('id', '=', $recommendation['id'])->exists()) {
-                    Recommendation::updateOrCreate(
-                        ['recommendation_tv_id' => $recommendation['id'], 'tv_id' => $this->tv['id']],
-                        ['title' => $recommendation['name'], 'vote_average' => $recommendation['vote_average'], 'poster' => $tmdb->image('poster', $recommendation), 'first_air_date' => $recommendation['first_air_date']]
-                    );
-                }
+        Season::upsert($seasons, ['tv_id', 'season_number']);
+        Episode::upsert($episodes, 'id');
+
+        // Recommendations
+
+        $tv_ids = Tv::select('id')->findMany(array_column($this->tv['recommendations']['results'] ?? [], 'id'))->pluck('id');
+        $recommendations = [];
+
+        foreach ($this->tv['recommendations']['results'] ?? [] as $recommendation) {
+            if ($tv_ids->contains($recommendation['id'])) {
+                $recommendations[] = [
+                    'recommendation_tv_id' => $recommendation['id'],
+                    'tv_id'                => $this->tv['id'],
+                    'title'                => $recommendation['name'],
+                    'vote_average'         => $recommendation['vote_average'],
+                    'poster'               => $tmdb->image('poster', $recommendation),
+                    'first_air_date'       => $recommendation['first_air_date'],
+                ];
             }
         }
+
+        Recommendation::upsert($recommendations, ['recommendation_tv_id', 'tv_id']);
     }
 }


### PR DESCRIPTION
- Use upserts.
- Now that we use `aggregate_credits`, we no longer need to fetch the people on each episode, therefore we can use the episode object returned from the `season` api call instead of fetching each episode.
- Find all existing movie/tv ids for recommendations at once instead of checking if each exists individually.

Future improvements:
- Use Laravel HTTP Pools: https://laravel.com/docs/10.x/http-client#concurrent-requests