### PR TITLE
(Fix) Duplicate credit insertion

### DIFF
--- a/app/Jobs/ProcessMovieJob.php
+++ b/app/Jobs/ProcessMovieJob.php
@@ -147,6 +147,7 @@ class ProcessMovieJob implements ShouldQueue
         }
 
         Person::upsert($people, 'id');
+        Credit::where('movie_id', '=', $this->movie['id'])->delete();
         Credit::upsert($credits, ['person_id', 'movie_id', 'tv_id', 'occupation_id', 'character']);
 
         // Recommendations

--- a/app/Jobs/ProcessTvJob.php
+++ b/app/Jobs/ProcessTvJob.php
@@ -173,6 +173,7 @@ class ProcessTvJob implements ShouldQueue
         }
 
         Person::upsert($people, 'id');
+        Credit::where('tv_id', '=', $this->tv['id'])->delete();
         Credit::upsert($credits, ['person_id', 'movie_id', 'tv_id', 'occupation_id', 'character']);
 
         // Seasons and episodes


### PR DESCRIPTION
The unique index on the credits table doesn't work because some of the columns are nullable. Let's just delete all entries first then re-insert.