### PR TITLE
(Fix) Torrent deletion message not allowing spaces

### DIFF
--- a/app/Http/Controllers/TorrentController.php
+++ b/app/Http/Controllers/TorrentController.php
@@ -253,7 +253,6 @@ class TorrentController extends Controller
         $request->validate([
             'message' => [
                 'required',
-                'alpha_dash',
                 'min:1',
             ],
         ]);


### PR DESCRIPTION
Validation wasn't working here before. Now that validation is working, we realize that `alpha_dash` prevents many useful deletion messages. Spaces should be allowed.