### PR TITLE
(Fix) Torrent mimetype validation

### DIFF
--- a/app/Http/Requests/StoreTorrentRequest.php
+++ b/app/Http/Requests/StoreTorrentRequest.php
@@ -45,7 +45,6 @@ class StoreTorrentRequest extends FormRequest
                 'required',
                 'file',
                 'mimes:torrent',
-                'mimetypes:application/x-bittorrent',
                 function (string $attribute, mixed $value, Closure $fail): void {
                     $decodedTorrent = TorrentTools::normalizeTorrent($value);
 


### PR DESCRIPTION
If a user has never installed a BitTorrent client, then their OS would have never registered the `application/x-bittorrent` mimetype. Upon upload, the browser does not sent this mimetype as a result, which causes the validation to fail.