### PR TITLE
(Fix) PM mass action routes

### DIFF
--- a/resources/views/user/received-private-message/index.blade.php
+++ b/resources/views/user/received-private-message/index.blade.php
@@ -108,6 +108,7 @@
             <form action="{{ route('users.received_messages.mass_update', ['user' => $user]) }}" method="POST">
                 <p class="form__group form__group--horizontal">
                     @csrf
+                    @method('PATCH')
                     <button class="form__button form__button--filled form__button--centered">
                         <i class="{{ config('other.font-awesome') }} fa-eye"></i>
                         {{ __('pm.mark-all-read') }}

--- a/routes/web.php
+++ b/routes/web.php
@@ -449,8 +449,8 @@ Route::middleware('language')->group(function (): void {
             Route::get('/{receivedPrivateMessage}', [App\Http\Controllers\User\ReceivedPrivateMessageController::class, 'show'])->name('show');
             Route::patch('/{receivedPrivateMessage}', [App\Http\Controllers\User\ReceivedPrivateMessageController::class, 'update'])->name('update');
             Route::delete('/{receivedPrivateMessage}', [App\Http\Controllers\User\ReceivedPrivateMessageController::class, 'destroy'])->name('destroy');
-            Route::post('/mass-update', [App\Http\Controllers\User\ReceivedPrivateMessageController::class, 'massUpdate'])->name('mass_update');
-            Route::delete('/mass-delete', [App\Http\Controllers\User\ReceivedPrivateMessageController::class, 'massDestroy'])->name('mass_destroy');
+            Route::patch('/', [App\Http\Controllers\User\ReceivedPrivateMessageController::class, 'massUpdate'])->name('mass_update');
+            Route::delete('/', [App\Http\Controllers\User\ReceivedPrivateMessageController::class, 'massDestroy'])->name('mass_destroy');
         });
 
         // Outbox


### PR DESCRIPTION
The mass actions either need to be defined before the individual actions in the route file, or use a route path that doesn't conflict with the individual action routes. The second option was chosen here.