### PR TITLE
(Update) Various database performance improvements

### DIFF
--- a/app/Http/Controllers/PageController.php
+++ b/app/Http/Controllers/PageController.php
@@ -50,7 +50,7 @@ class PageController extends Controller
     {
         return view('page.staff', [
             'staff' => Group::query()
-                ->with('users:id,username,group_id,title')
+                ->with('users.group')
                 ->where('is_modo', '=', 1)
                 ->orWhere('is_admin', '=', 1)
                 ->get()
@@ -65,7 +65,7 @@ class PageController extends Controller
     {
         return view('page.internal', [
             'internals' => Internal::query()
-                ->with('users')
+                ->with('users.group')
                 ->orderBy('name')
                 ->get(),
         ]);

--- a/app/Http/Controllers/Staff/ApplicationController.php
+++ b/app/Http/Controllers/Staff/ApplicationController.php
@@ -37,7 +37,7 @@ class ApplicationController extends Controller
     {
         return view('Staff.application.index', [
             'applications' => Application::withoutGlobalScope(ApprovedScope::class)
-                ->with(['user', 'moderated', 'imageProofs', 'urlProofs'])
+                ->with(['user.group', 'moderated.group', 'imageProofs', 'urlProofs'])
                 ->latest()
                 ->paginate(25),
         ]);

--- a/app/Http/Controllers/Staff/ArticleController.php
+++ b/app/Http/Controllers/Staff/ArticleController.php
@@ -31,7 +31,10 @@ class ArticleController extends Controller
     public function index(): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
     {
         return view('Staff.article.index', [
-            'articles' => $articles = Article::latest()->paginate(25),
+            'articles' => Article::latest()
+                ->with('user:id,username')
+                ->withCount('comments')
+                ->paginate(25),
         ]);
     }
 

--- a/app/Http/Controllers/Staff/BanController.php
+++ b/app/Http/Controllers/Staff/BanController.php
@@ -33,7 +33,7 @@ class BanController extends Controller
     public function index(): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
     {
         return view('Staff.ban.index', [
-            'bans' => Ban::latest()->paginate(25),
+            'bans' => Ban::latest()->with('banneduser.group', 'staffuser.group')->paginate(25),
         ]);
     }
 

--- a/app/Http/Controllers/Staff/ForumController.php
+++ b/app/Http/Controllers/Staff/ForumController.php
@@ -33,7 +33,10 @@ class ForumController extends Controller
     public function index(): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
     {
         return view('Staff.forum.index', [
-            'categories' => Forum::orderBy('position')->where('parent_id', '=', 0)->get(),
+            'categories' => Forum::orderBy('position')
+                ->where('parent_id', '=', 0)
+                ->with(['forums' => fn ($query) => $query->orderBy('position')])
+                ->get(),
         ]);
     }
 
@@ -105,7 +108,7 @@ class ForumController extends Controller
         return view('Staff.forum.edit', [
             'categories' => Forum::where('parent_id', '=', 0)->get(),
             'groups'     => Group::all(),
-            'forum'      => $forum,
+            'forum'      => $forum->load('permissions'),
         ]);
     }
 
@@ -162,7 +165,7 @@ class ForumController extends Controller
         if ($forum->parent_id == 0) {
             $category = $forum;
 
-            foreach ($category->getForumsInCategory() as $forum) {
+            foreach ($category->forums as $forum) {
                 $forum->permissions()->delete();
                 $forum->posts()->delete();
                 $forum->topics()->delete();

--- a/app/Http/Controllers/Staff/HomeController.php
+++ b/app/Http/Controllers/Staff/HomeController.php
@@ -70,19 +70,15 @@ class HomeController extends Controller
                     ->selectRaw('count(case when seeder = 1 then 1 end) as seeders')
                     ->first();
             }),
-            'reports' => DB::table('reports')
-                ->selectRaw('count(case when solved = 0 then 1 end) as unsolved')
-                ->first(),
-            'apps' => DB::table('applications')
-                ->selectRaw('count(case when status = 0 then 1 end) as pending')
-                ->first(),
-            'certificate'      => $certificate,
-            'uptime'           => $systemInformation->uptime(),
-            'ram'              => $systemInformation->memory(),
-            'disk'             => $systemInformation->disk(),
-            'avg'              => $systemInformation->avg(),
-            'basic'            => $systemInformation->basic(),
-            'file_permissions' => $systemInformation->directoryPermissions(),
+            'unsolvedReportsCount'     => DB::table('reports')->where('solved', '=', false)->count(),
+            'pendingApplicationsCount' => DB::table('applications')->where('status', '=', 0)->count(),
+            'certificate'              => $certificate,
+            'uptime'                   => $systemInformation->uptime(),
+            'ram'                      => $systemInformation->memory(),
+            'disk'                     => $systemInformation->disk(),
+            'avg'                      => $systemInformation->avg(),
+            'basic'                    => $systemInformation->basic(),
+            'file_permissions'         => $systemInformation->directoryPermissions(),
         ]);
     }
 }

--- a/app/Http/Controllers/Staff/ModerationController.php
+++ b/app/Http/Controllers/Staff/ModerationController.php
@@ -42,15 +42,15 @@ class ModerationController extends Controller
         return view('Staff.moderation.index', [
             'current' => now(),
             'pending' => Torrent::withoutGlobalScope(ApprovedScope::class)
-                ->with(['user:id,username,group_id', 'user.group', 'category', 'type'])
+                ->with(['user.group', 'category', 'type', 'resolution', 'category'])
                 ->where('status', '=', Torrent::PENDING)
                 ->get(),
             'postponed' => Torrent::withoutGlobalScope(ApprovedScope::class)
-                ->with(['user:id,username,group_id', 'user.group', 'category', 'type'])
+                ->with(['user.group', 'moderated.group', 'category', 'type', 'resolution', 'category'])
                 ->where('status', '=', Torrent::POSTPONED)
                 ->get(),
             'rejected' => Torrent::withoutGlobalScope(ApprovedScope::class)
-                ->with(['user:id,username,group_id', 'user.group', 'category', 'type'])
+                ->with(['user.group', 'moderated.group', 'category', 'type', 'resolution', 'category'])
                 ->where('status', '=', Torrent::REJECTED)
                 ->get(),
         ]);

--- a/app/Http/Controllers/Staff/ReportController.php
+++ b/app/Http/Controllers/Staff/ReportController.php
@@ -29,7 +29,10 @@ class ReportController extends Controller
     public function index(): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
     {
         return view('Staff.report.index', [
-            'reports' => Report::orderBy('solved')->latest()->paginate(25)
+            'reports' => Report::orderBy('solved')
+                ->with('reported.group', 'reporter.group', 'staff.group')
+                ->latest()
+                ->paginate(25)
         ]);
     }
 

--- a/app/Http/Controllers/Staff/SeedboxController.php
+++ b/app/Http/Controllers/Staff/SeedboxController.php
@@ -28,7 +28,7 @@ class SeedboxController extends Controller
     public function index(): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
     {
         return view('Staff.seedbox.index', [
-            'seedboxes' => Seedbox::with('user')->latest()->paginate(50),
+            'seedboxes' => Seedbox::with('user.group')->latest()->paginate(50),
         ]);
     }
 

--- a/app/Http/Controllers/StatsController.php
+++ b/app/Http/Controllers/StatsController.php
@@ -53,23 +53,20 @@ class StatsController extends Controller
         // Total SD Count
         $numSd = cache()->remember('num_sd', $this->carbon, fn () => Torrent::where('sd', '=', 1)->count());
 
-        // Total Seeders
-        $numSeeders = cache()->remember('num_seeders', $this->carbon, fn () => Peer::where('seeder', '=', 1)->count());
+        // Generally sites have more seeders than leechers, so it ends up being faster (by approximately 50%) to compute these stats instead of computing them individually
+        $leecherCount = cache()->remember('peer_seeder_count', $this->carbon, fn () => Peer::where('seeder', '=', false)->count());
+        $peerCount = cache()->remember('peer_count', $this->carbon, fn () => Peer::count());
 
-        // Total Leechers
-        $numLeechers = cache()->remember('num_leechers', $this->carbon, fn () => Peer::where('seeder', '=', 0)->count());
-
-        //Total Upload Traffic Without Double Upload
-        $actualUpload = cache()->remember('actual_upload', $this->carbon, fn () => History::sum('actual_uploaded'));
-
-        //Total Upload Traffic With Double Upload
-        $creditedUpload = cache()->remember('credited_upload', $this->carbon, fn () => History::sum('uploaded'));
-
-        //Total Download Traffic Without Freeleech
-        $actualDownload = cache()->remember('actual_download', $this->carbon, fn () => History::sum('actual_downloaded'));
-
-        //Total Download Traffic With Freeleech
-        $creditedDownload = cache()->remember('credited_download', $this->carbon, fn () => History::sum('downloaded'));
+        $historyStats = cache()->remember(
+            'history_stats',
+            $this->carbon,
+            fn () => History::query()
+                ->selectRaw('SUM(actual_uploaded) as actual_upload')
+                ->selectRaw('SUM(uploaded) as credited_upload')
+                ->selectRaw('SUM(actual_downloaded) as actual_download')
+                ->selectRaw('SUM(downloaded) as credited_download')
+                ->first()
+        );
 
         $bannedGroup = cache()->rememberForever('banned_group', fn () => Group::where('slug', '=', 'banned')->pluck('id'));
         $validatingGroup = cache()->rememberForever('validating_group', fn () => Group::where('slug', '=', 'validating')->pluck('id'));
@@ -107,15 +104,15 @@ class StatsController extends Controller
             'num_hd'            => $numTorrent - $numSd,
             'num_sd'            => $numSd,
             'torrent_size'      => cache()->remember('torrent_size', $this->carbon, fn () => Torrent::sum('size')),
-            'num_seeders'       => $numSeeders,
-            'num_leechers'      => $numLeechers,
-            'num_peers'         => $numSeeders + $numLeechers,
-            'actual_upload'     => $actualUpload,
-            'actual_download'   => $actualDownload,
-            'actual_up_down'    => $actualUpload + $actualDownload,
-            'credited_upload'   => $creditedUpload,
-            'credited_download' => $creditedDownload,
-            'credited_up_down'  => $creditedUpload + $creditedDownload,
+            'num_seeders'       => $peerCount - $leecherCount,
+            'num_leechers'      => $leecherCount,
+            'num_peers'         => $peerCount,
+            'actual_upload'     => $historyStats->actual_upload,
+            'actual_download'   => $historyStats->actual_download,
+            'actual_up_down'    => $historyStats->actual_upload + $historyStats->actual_download,
+            'credited_upload'   => $historyStats->credited_upload,
+            'credited_download' => $historyStats->credited_download,
+            'credited_up_down'  => $historyStats->credited_upload + $historyStats->credited_download,
         ]);
     }
 

--- a/app/Http/Controllers/User/FollowController.php
+++ b/app/Http/Controllers/User/FollowController.php
@@ -30,7 +30,7 @@ class FollowController extends Controller
     public function index(User $user): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
     {
         return view('user.follower.index', [
-            'followers' => $user->followers()->orderByPivot('created_at', 'desc')->paginate(25),
+            'followers' => $user->followers()->with('group')->orderByPivot('created_at', 'desc')->paginate(25),
             'user'      => $user,
         ]);
     }

--- a/app/Http/Controllers/User/FollowingController.php
+++ b/app/Http/Controllers/User/FollowingController.php
@@ -24,7 +24,7 @@ class FollowingController extends Controller
     public function index(User $user): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
     {
         return view('user.following.index', [
-            'followings' => $user->following()->orderByPivot('created_at', 'desc')->paginate(25),
+            'followings' => $user->following()->with('group')->orderByPivot('created_at', 'desc')->paginate(25),
             'user'       => $user,
         ]);
     }

--- a/app/Http/Controllers/User/InviteController.php
+++ b/app/Http/Controllers/User/InviteController.php
@@ -38,7 +38,7 @@ class InviteController extends Controller
 
         return view('user.invite.index', [
             'user'    => $user,
-            'invites' => $user->sentInvite()->withTrashed()->with(['sender', 'receiver'])->latest()->paginate(25),
+            'invites' => $user->sentInvite()->withTrashed()->with(['sender.group', 'receiver.group'])->latest()->paginate(25),
         ]);
     }
 

--- a/app/Http/Controllers/User/ReceivedPrivateMessageController.php
+++ b/app/Http/Controllers/User/ReceivedPrivateMessageController.php
@@ -35,6 +35,8 @@ class ReceivedPrivateMessageController extends Controller
             'user' => $user,
             'pms'  => $user
                 ->receivedPrivateMessages()
+                ->select('id', 'sender_id', 'subject', 'created_at')
+                ->with('sender.group')
                 ->when(
                     $request->has('subject'),
                     fn ($query) => $query->where('subject', 'like', '%'.$request->string('subject').'%')

--- a/app/Http/Controllers/User/SentPrivateMessageController.php
+++ b/app/Http/Controllers/User/SentPrivateMessageController.php
@@ -35,6 +35,8 @@ class SentPrivateMessageController extends Controller
             'user' => $user,
             'pms'  => $user
                 ->sentPrivateMessages()
+                ->with('receiver.group')
+                ->select('id', 'receiver_id', 'subject', 'created_at')
                 ->when(
                     $request->has('subject'),
                     fn ($query) => $query->where('subject', 'like', '%'.$request->string('subject').'%')

--- a/app/Http/Controllers/User/TipController.php
+++ b/app/Http/Controllers/User/TipController.php
@@ -38,7 +38,7 @@ class TipController extends Controller
 
         return view('user.tip.index', [
             'user' => $user,
-            'tips' => BonTransactions::with(['senderObj', 'receiverObj', 'torrent'])
+            'tips' => BonTransactions::with(['senderObj.group', 'receiverObj.group', 'torrent'])
                 ->where(fn ($query) => $query->where('sender', '=', $user->id)->orwhere('receiver', '=', $user->id))
                 ->where('name', '=', 'tip')
                 ->latest('date_actioned')

--- a/app/Http/Controllers/User/TopicController.php
+++ b/app/Http/Controllers/User/TopicController.php
@@ -26,7 +26,7 @@ class TopicController extends Controller
         return view('user.topic.index', [
             'user'   => $user,
             'topics' => $user->topics()
-                ->with(['user', 'latestPoster'])
+                ->with(['user.group', 'latestPoster', 'forum:id,name'])
                 ->whereRelation('forumPermissions', [['show_forum', '=', 1], ['group_id', '=', auth()->user()->group_id]])
                 ->latest()
                 ->paginate(25),

--- a/app/Http/Livewire/CollectionSearch.php
+++ b/app/Http/Livewire/CollectionSearch.php
@@ -21,7 +21,7 @@ class CollectionSearch extends Component
 {
     use WithPagination;
 
-    public $search;
+    public $search = '';
 
     final public function updatedPage(): void
     {
@@ -37,7 +37,7 @@ class CollectionSearch extends Component
     {
         return Collection::withCount('movie')
             ->with('movie')
-            ->where('name', 'LIKE', '%'.$this->search.'%')
+            ->when($this->search !== '', fn ($query) => $query->where('name', 'LIKE', '%'.$this->search.'%'))
             ->oldest('name')
             ->paginate(25);
     }

--- a/app/Http/Livewire/CompanySearch.php
+++ b/app/Http/Livewire/CompanySearch.php
@@ -21,7 +21,7 @@ class CompanySearch extends Component
 {
     use WithPagination;
 
-    public $search;
+    public $search = '';
 
     final public function updatedPage(): void
     {
@@ -36,7 +36,7 @@ class CompanySearch extends Component
     final public function getCompaniesProperty(): \Illuminate\Contracts\Pagination\LengthAwarePaginator
     {
         return Company::withCount('tv', 'movie')
-            ->where('name', 'LIKE', '%'.$this->search.'%')
+            ->when($this->search !== '', fn ($query) => $query->where('name', 'LIKE', '%'.$this->search.'%'))
             ->oldest('name')
             ->paginate(30);
     }

--- a/app/Http/Livewire/FailedLoginSearch.php
+++ b/app/Http/Livewire/FailedLoginSearch.php
@@ -48,7 +48,7 @@ class FailedLoginSearch extends Component
     final public function getFailedLoginsProperty(): \Illuminate\Contracts\Pagination\LengthAwarePaginator
     {
         return FailedLoginAttempt::query()
-            ->with('user')
+            ->with('user.group')
             ->when($this->username, fn ($query) => $query->where('username', 'LIKE', $this->username.'%'))
             ->when($this->userId, fn ($query) => $query->where('user_id', '=', $this->userId))
             ->when($this->ipAddress, fn ($query) => $query->where('ip_address', 'LIKE', $this->ipAddress.'%'))

--- a/app/Http/Livewire/InviteLogSearch.php
+++ b/app/Http/Livewire/InviteLogSearch.php
@@ -53,7 +53,7 @@ class InviteLogSearch extends Component
     final public function getInvitesProperty(): \Illuminate\Contracts\Pagination\LengthAwarePaginator
     {
         return Invite::withTrashed()
-            ->with(['sender', 'receiver'])
+            ->with(['sender.group', 'receiver.group'])
             ->when($this->sender, fn ($query) => $query->whereIn('user_id', User::select('id')->where('username', '=', $this->sender)))
             ->when($this->email, fn ($query) => $query->where('email', 'LIKE', '%'.$this->email.'%'))
             ->when($this->code, fn ($query) => $query->where('code', 'LIKE', '%'.$this->code.'%'))

--- a/app/Http/Livewire/NetworkSearch.php
+++ b/app/Http/Livewire/NetworkSearch.php
@@ -21,7 +21,7 @@ class NetworkSearch extends Component
 {
     use WithPagination;
 
-    public $search;
+    public $search = '';
 
     final public function updatedPage(): void
     {
@@ -36,7 +36,7 @@ class NetworkSearch extends Component
     final public function getNetworksProperty(): \Illuminate\Contracts\Pagination\LengthAwarePaginator
     {
         return Network::withCount('tv')
-            ->where('name', 'LIKE', '%'.$this->search.'%')
+            ->when($this->search !== '', fn ($query) => $query->where('name', 'LIKE', '%'.$this->search.'%'))
             ->oldest('name')
             ->paginate(30);
     }

--- a/app/Http/Livewire/NoteSearch.php
+++ b/app/Http/Livewire/NoteSearch.php
@@ -33,7 +33,7 @@ class NoteSearch extends Component
     final public function getNotesProperty(): \Illuminate\Contracts\Pagination\LengthAwarePaginator
     {
         return Note::query()
-            ->with(['noteduser', 'staffuser'])
+            ->with(['noteduser.group', 'staffuser.group'])
             ->when($this->search, fn ($query) => $query->where('message', 'LIKE', '%'.$this->search.'%'))
             ->latest()
             ->paginate($this->perPage);

--- a/app/Http/Livewire/PersonSearch.php
+++ b/app/Http/Livewire/PersonSearch.php
@@ -21,7 +21,7 @@ class PersonSearch extends Component
 {
     use WithPagination;
 
-    public $search;
+    public $search = '';
 
     final public function updatedPage(): void
     {
@@ -36,7 +36,8 @@ class PersonSearch extends Component
     final public function getPersonsProperty(): \Illuminate\Contracts\Pagination\LengthAwarePaginator
     {
         return Person::select(['id', 'still', 'name'])
-            ->whereNotNull('still')->where('name', 'LIKE', '%'.$this->search.'%')
+            ->whereNotNull('still')
+            ->when($this->search !== '', fn ($query) => $query->where('name', 'LIKE', '%'.$this->search.'%'))
             ->oldest('name')
             ->paginate(30);
     }

--- a/app/Http/Livewire/SubtitleSearch.php
+++ b/app/Http/Livewire/SubtitleSearch.php
@@ -46,7 +46,7 @@ class SubtitleSearch extends Component
 
     final public function getSubtitlesProperty(): \Illuminate\Contracts\Pagination\LengthAwarePaginator
     {
-        return Subtitle::with(['user', 'torrent', 'language'])
+        return Subtitle::with(['user.group', 'torrent.category', 'language'])
             ->when($this->search, fn ($query) => $query->where('title', 'like', '%'.$this->search.'%'))
             ->when($this->categories, function ($query) {
                 $torrents = Torrent::whereIntegerInRaw('category_id', $this->categories)->pluck('id');

--- a/app/Http/Livewire/TicketSearch.php
+++ b/app/Http/Livewire/TicketSearch.php
@@ -69,7 +69,7 @@ class TicketSearch extends Component
     {
         if ($this->user->group->is_modo) {
             return Ticket::query()
-                ->with(['user', 'category', 'priority'])
+                ->with(['user.group', 'staff.group', 'category', 'priority'])
                 ->when($this->show === false, fn ($query) => $query->whereNull('closed_at'))
                 ->when($this->show, fn ($query) => $query->whereNotNull('closed_at'))
                 ->when($this->search, fn ($query) => $query->where('subject', 'LIKE', '%'.$this->search.'%'))
@@ -78,7 +78,7 @@ class TicketSearch extends Component
         }
 
         return Ticket::query()
-            ->with(['user', 'category', 'priority'])
+            ->with(['user.group', 'staff.group', 'category', 'priority'])
             ->where('user_id', '=', $this->user->id)
             ->when($this->show === false, fn ($query) => $query->whereNull('closed_at'))
             ->when($this->show, fn ($query) => $query->whereNotNull('closed_at'))

--- a/app/Http/Livewire/Top10.php
+++ b/app/Http/Livewire/Top10.php
@@ -24,7 +24,7 @@ class Top10 extends Component
     {
         $matches = Cache::remember('top10DayMatches', 3_600, fn () => DB::select('SELECT torrent_id, count(*) FROM history WHERE completed_at >= DATE_ADD(CURRENT_TIMESTAMP, INTERVAL -1 DAY) GROUP BY torrent_id ORDER BY count(*) DESC LIMIT 10'));
 
-        return Cache::remember('top10DayTorrents', 3_600, fn () => Torrent::with(['user:id,username,group_id', 'category', 'type', 'resolution'])
+        return Cache::remember('top10DayTorrents', 3_600, fn () => Torrent::with(['user:id,username,group_id' => ['group:id,name,color,icon,effect'], 'category', 'type', 'resolution'])
             ->whereIntegerInRaw('id', collect($matches)->pluck('torrent_id')->toArray())
             ->get());
     }
@@ -33,7 +33,7 @@ class Top10 extends Component
     {
         $matches = Cache::remember('top10WeekMatches', 3_600, fn () => DB::select('SELECT torrent_id, count(*) FROM history WHERE completed_at >= DATE_ADD(CURRENT_TIMESTAMP, INTERVAL -1 WEEK) GROUP BY torrent_id ORDER BY count(*) DESC LIMIT 10'));
 
-        return Cache::remember('top10WeekTorrents', 3_600, fn () => Torrent::with(['user:id,username,group_id', 'category', 'type', 'resolution'])
+        return Cache::remember('top10WeekTorrents', 3_600, fn () => Torrent::with(['user:id,username,group_id' => ['group:id,name,color,icon,effect'], 'category', 'type', 'resolution'])
             ->whereIntegerInRaw('id', collect($matches)->pluck('torrent_id')->toArray())
             ->get());
     }
@@ -42,7 +42,7 @@ class Top10 extends Component
     {
         $matches = Cache::remember('top10MonthMatches', 3_600, fn () => DB::select('SELECT torrent_id, count(*) FROM history WHERE completed_at >= DATE_ADD(CURRENT_TIMESTAMP, INTERVAL -1 MONTH) GROUP BY torrent_id ORDER BY count(*) DESC LIMIT 10'));
 
-        return Cache::remember('top10MonthTorrents', 3_600, fn () => Torrent::with(['user:id,username,group_id', 'category', 'type', 'resolution'])
+        return Cache::remember('top10MonthTorrents', 3_600, fn () => Torrent::with(['user:id,username,group_id' => ['group:id,name,color,icon,effect'], 'category', 'type', 'resolution'])
             ->whereIntegerInRaw('id', collect($matches)->pluck('torrent_id')->toArray())
             ->get());
     }
@@ -51,7 +51,7 @@ class Top10 extends Component
     {
         $matches = Cache::remember('top10YearMatches', 3_600, fn () => DB::select('SELECT torrent_id, count(*) FROM history WHERE completed_at >= DATE_ADD(CURRENT_TIMESTAMP, INTERVAL -1 YEAR) GROUP BY torrent_id ORDER BY count(*) DESC LIMIT 10'));
 
-        return Cache::remember('top10YearTorrents', 3_600, fn () => Torrent::with(['user:id,username,group_id', 'category', 'type', 'resolution'])
+        return Cache::remember('top10YearTorrents', 3_600, fn () => Torrent::with(['user:id,username,group_id' => ['group:id,name,color,icon,effect'], 'category', 'type', 'resolution'])
             ->whereIntegerInRaw('id', collect($matches)->pluck('torrent_id')->toArray())
             ->get());
     }
@@ -60,7 +60,7 @@ class Top10 extends Component
     {
         $matches = Cache::remember('top10AllMatches', 3_600, fn () => DB::select('SELECT torrent_id, count(*) FROM history GROUP BY torrent_id ORDER BY count(*) DESC LIMIT 10'));
 
-        return Cache::remember('top10AllTorrents', 3_600, fn () => Torrent::with(['user:id,username,group_id', 'category', 'type', 'resolution'])
+        return Cache::remember('top10AllTorrents', 3_600, fn () => Torrent::with(['user:id,username,group_id' => ['group:id,name,color,icon,effect'], 'category', 'type', 'resolution'])
             ->whereIntegerInRaw('id', collect($matches)->pluck('torrent_id')->toArray())
             ->get());
     }

--- a/app/Http/Livewire/WarningLogSearch.php
+++ b/app/Http/Livewire/WarningLogSearch.php
@@ -64,7 +64,7 @@ class WarningLogSearch extends Component
     final public function getWarningsProperty(): \Illuminate\Contracts\Pagination\LengthAwarePaginator
     {
         return Warning::query()
-            ->with(['warneduser', 'staffuser', 'torrenttitle'])
+            ->with(['warneduser.group', 'staffuser.group', 'torrenttitle'])
             ->when($this->sender, fn ($query) => $query->whereIn('warned_by', User::select('id')->where('username', '=', $this->sender)))
             ->when($this->receiver, fn ($query) => $query->whereIn('user_id', User::select('id')->where('username', '=', $this->receiver)))
             ->when($this->torrent, fn ($query) => $query->whereIn('torrent', Torrent::select('id')->where('name', 'LIKE', '%'.$this->torrent.'%')))

--- a/app/Http/Livewire/WatchlistSearch.php
+++ b/app/Http/Livewire/WatchlistSearch.php
@@ -49,7 +49,7 @@ class WatchlistSearch extends Component
     final public function getUsersProperty(): \Illuminate\Contracts\Pagination\LengthAwarePaginator
     {
         return Watchlist::query()
-            ->with(['user', 'author'])
+            ->with(['user.group', 'author.group'])
             ->when($this->search, fn ($query) => $query->where('message', 'LIKE', '%'.$this->search.'%'))
             ->orderBy($this->sortField, $this->sortDirection)
             ->paginate($this->perPage);

--- a/app/Models/Forum.php
+++ b/app/Models/Forum.php
@@ -152,14 +152,6 @@ class Forum extends Model
     }
 
     /**
-     * Returns A Table With The Forums In The Category.
-     */
-    public function getForumsInCategory()
-    {
-        return self::where('parent_id', '=', $this->id)->get();
-    }
-
-    /**
      * Returns The Permission Field.
      */
     public function getPermission(): object

--- a/app/Models/Group.php
+++ b/app/Models/Group.php
@@ -53,16 +53,6 @@ class Group extends Model
     }
 
     /**
-     * Returns The Requested Row From The Permissions Table.
-     */
-    public function getPermissionsByForum($forum): ?object
-    {
-        return Permission::where('forum_id', '=', $forum->id)
-            ->where('group_id', '=', $this->id)
-            ->first();
-    }
-
-    /**
      * Get the Group allowed answer as bool.
      */
     public function isAllowed($object, int $groupId): bool

--- a/database/migrations/2023_07_16_010906_add_indexes.php
+++ b/database/migrations/2023_07_16_010906_add_indexes.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::table('private_messages', function (Blueprint $table): void {
+            $table->dropForeign(['sender_id']);
+            $table->dropIndex(['sender_id', 'read']);
+            $table->index(['receiver_id', 'read']);
+            $table->foreign('sender_id')->references('id')->on('users')->cascadeOnUpdate();
+        });
+
+        Schema::table('notifications', function (Blueprint $table): void {
+            $table->index(['notifiable_type', 'notifiable_id', 'read_at']);
+        });
+
+        Schema::table('warnings', function (Blueprint $table): void {
+            $table->index(['user_id', 'active', 'deleted_at']);
+        });
+
+        Schema::table('genre_movie', function (Blueprint $table): void {
+            $table->index('movie_id');
+        });
+    }
+};

--- a/resources/views/Staff/application/index.blade.php
+++ b/resources/views/Staff/application/index.blade.php
@@ -82,7 +82,7 @@
                                 @if ($application->moderated === null)
                                     N/A
                                 @else
-                                    <x-user_tag :anon="false" :user="$application->user" />
+                                    <x-user_tag :anon="false" :user="$application->moderated" />
                                 @endif
                             </td>
                             <td>

--- a/resources/views/Staff/article/index.blade.php
+++ b/resources/views/Staff/article/index.blade.php
@@ -58,7 +58,7 @@
                                 {{ $article->created_at }}
                             </time>
                         </td>
-                        <td>{{ $article->comments->count() }}</td>
+                        <td>{{ $article->comments_count }}</td>
                         <td>
                             <menu class="data-table__actions">
                                 <li class="data-table__action">

--- a/resources/views/Staff/dashboard/index.blade.php
+++ b/resources/views/Staff/dashboard/index.blade.php
@@ -245,8 +245,8 @@
                 <p class="form__group form__group--horizontal">
                     <a class="form__button form__button--text" href="{{ route('staff.applications.index') }}">
                         <i class="{{ config('other.font-awesome') }} fa-list"></i>
-                        {{ __('staff.applications') }} ({{ $apps->pending }})
-                        @if ($apps->pending > 0)
+                        {{ __('staff.applications') }} ({{ $pendingApplicationsCount }})
+                        @if ($pendingApplicationsCount > 0)
                             <x-animation.notification />
                         @endif
                     </a>
@@ -365,8 +365,8 @@
                 <p class="form__group form__group--horizontal">
                     <a class="form__button form__button--text" href="{{ route('staff.reports.index') }}">
                         <i class="{{ config('other.font-awesome') }} fa-file"></i>
-                        {{ __('staff.reports-log') }} ({{ $reports->unsolved }})
-                        @if ($reports->unsolved > 0)
+                        {{ __('staff.reports-log') }} ({{ $unsolvedReportsCount }})
+                        @if ($unsolvedReportsCount > 0)
                             <x-animation.notification />
                         @endif
                     </a>

--- a/resources/views/Staff/forum/edit.blade.php
+++ b/resources/views/Staff/forum/edit.blade.php
@@ -111,7 +111,7 @@
                                             type="checkbox"
                                             name="permissions[{{ $group->id }}][show_forum]"
                                             value="1"
-                                            @checked($group->getPermissionsByForum($forum)->show_forum)
+                                            @checked($forum->permissions->where('group_id', '=', $group->id)->first()->show_forum)
                                         />
                                     </td>
                                     <td>
@@ -119,7 +119,7 @@
                                             type="checkbox"
                                             name="permissions[{{ $group->id }}][read_topic]"
                                             value="1"
-                                            @checked($group->getPermissionsByForum($forum)->read_topic)
+                                            @checked($forum->permissions->where('group_id', '=', $group->id)->first()->read_topic)
                                         />
                                     </td>
                                     <td>
@@ -127,7 +127,7 @@
                                             type="checkbox"
                                             name="permissions[{{ $group->id }}][start_topic]"
                                             value="1"
-                                            @checked($group->getPermissionsByForum($forum)->start_topic)
+                                            @checked($forum->permissions->where('group_id', '=', $group->id)->first()->start_topic)
                                         />
                                     </td>
                                     <td>
@@ -135,7 +135,7 @@
                                             type="checkbox"
                                             name="permissions[{{ $group->id }}][reply_topic]"
                                             value="1"
-                                            @checked($group->getPermissionsByForum($forum)->reply_topic)
+                                            @checked($forum->permissions->where('group_id', '=', $group->id)->first()->reply_topic)
                                         />
                                     </td>
                                 </tr>

--- a/resources/views/Staff/forum/index.blade.php
+++ b/resources/views/Staff/forum/index.blade.php
@@ -86,7 +86,7 @@
                             </menu>
                         </td>
                     </tr>
-                    @foreach ($category->getForumsInCategory()->sortBy('position') as $forum)
+                    @foreach ($category->forums as $forum)
                         <tr>
                             <td style="padding-left: 50px">
                                 <a href="{{ route('staff.forums.edit', ['forum' => $forum]) }}">{{ $forum->name }}</a>

--- a/resources/views/blocks/poll.blade.php
+++ b/resources/views/blocks/poll.blade.php
@@ -1,4 +1,4 @@
-@if ($poll && $poll->voters->where('user_id', '=', auth()->id())->isEmpty())
+@if ($poll && $poll->voters()->where('user_id', '=', auth()->id())->doesntExist())
     <section class="panelV2">
         <h2 class="panel__heading">{{ __('poll.poll') }}: {{ $poll->title }}</h2>
         <div class="panel__body">

--- a/resources/views/livewire/ticket-search.blade.php
+++ b/resources/views/livewire/ticket-search.blade.php
@@ -94,32 +94,14 @@
                     </td>
                     <td>
                         <a href="{{ route('tickets.show', ['ticket' => $ticket]) }}">{{ $ticket->subject }}</a>
-                        @if (auth()->user()->group->is_modo)
-                            @php
-                                $myTicketUnread = DB::table('tickets')
-                                    ->where('id', '=', $ticket->id)
-                                    ->where('staff_id', '=', auth()->id())
-                                    ->where('staff_read', '=', 0)
-                                    ->count();
-
-                                $unasignedTicketUnread = DB::table('tickets')
-                                    ->where('id', '=', $ticket->id)
-                                    ->whereNull('staff_id')
-                                    ->whereNull('closed_at')
-                                    ->count()
-                            @endphp
-                        @else
-                            @php
-                                $myTicketUnread = DB::table('tickets')
-                                    ->where('id', '=', $ticket->id)
-                                    ->where('user_id', '=', auth()->id())
-                                    ->where('user_read', '=', 0)
-                                    ->count();
-
-                                $unasignedTicketUnread = 0
-                            @endphp
-                        @endif
-                        @if ($myTicketUnread > 0 || $unasignedTicketUnread > 0)
+                        @if (
+                            auth()->user()->group->is_modo
+                            && (
+                                ($ticket->staff_id === auth()->id() && $ticket->staff_read === 0) ||
+                                ($ticket->staff_id === null && $ticket->closed_at === null)
+                            )
+                            || ($ticket->user_id === auth()->id() && $ticket->user_read === 0)
+                        )
                             <i style="color: #0dffff;vertical-align: 1px;" class="fas fa-circle fa-xs"></i>
                         @endif
                     </td>

--- a/resources/views/torrent/partials/audits.blade.php
+++ b/resources/views/torrent/partials/audits.blade.php
@@ -15,7 +15,7 @@
                 </tr>
             </thead>
             <tbody>
-                @foreach($audits as $audit)
+                @foreach($audits->load(['user.group']) as $audit)
                     @php $values = json_decode($audit->record, true) @endphp
                     <tr>
                         <td>

--- a/resources/views/torrent/partials/downloads.blade.php
+++ b/resources/views/torrent/partials/downloads.blade.php
@@ -14,7 +14,7 @@
                 </tr>
             </thead>
             <tbody>
-                @foreach(App\Models\TorrentDownload::with(['user'])->where('torrent_id', '=', $torrent->id)->latest()->get() as $download)
+                @foreach(App\Models\TorrentDownload::with(['user:id,username,group_id' => ['group:id,name,color,icon,effect']])->where('torrent_id', '=', $torrent->id)->latest()->get() as $download)
                     <tr>
                         <td>
                             <x-user_tag :user="$download->user" :anon="false" />

--- a/resources/views/user/achievement/index.blade.php
+++ b/resources/views/user/achievement/index.blade.php
@@ -25,7 +25,7 @@
     @section('main')
         <section class="panelV2 achievements__unlocked">
             <h2 class="panel__heading">{{ __('user.unlocked-achievements') }}</h2>
-            @foreach($achievements as $achievement)
+            @foreach($achievements->load('details') as $achievement)
                 <article class="achievement" title="{{ $achievement->points }}/{{ $achievement->details->points }}">
                     <figure class="achievement__badge">
                         <img
@@ -48,7 +48,7 @@
         </section>
         <section class="panelV2 achievements__pending">
             <h2 class="panel__heading">{{ __('user.pending-achievements') }}</h2>
-            @foreach($pending as $achievement)
+            @foreach($pending->load('details') as $achievement)
                 <article class="achievement" title="{{ $achievement->points }}/{{ $achievement->details->points }}">
                     <figure class="achievement__badge">
                         <img


### PR DESCRIPTION
Use eager loading where necessary and add a few indexes. The existing index on private_messages for sender_id and read was probably a typo and intended for receiver_id. The first 3 tables indexes are added to are used for queries ran on every page load: namely the new pm, new notification and warnings indicator in the navbar. Additionally, another index on genre_movie proved useful for finding all the genres when given a movie id. Perhaps, another index for finding all movies within a genre would be good as well, but will leave that for a future optimization if deemed necessary.