### PR TITLE
(Add) Redis history batching

### DIFF
--- a/app/Console/Commands/AutoUpsertHistories.php
+++ b/app/Console/Commands/AutoUpsertHistories.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * NOTICE OF LICENSE.
+ *
+ * UNIT3D Community Edition is open-sourced software licensed under the GNU Affero General Public License v3.0
+ * The details is bundled with this project in the file LICENSE.txt.
+ *
+ * @project    UNIT3D Community Edition
+ *
+ * @author     Roardom <roardom@protonmail.com>
+ * @license    https://www.gnu.org/licenses/agpl-3.0.en.html/ GNU Affero General Public License v3.0
+ */
+
+namespace App\Console\Commands;
+
+use App\Models\History;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Redis;
+use Exception;
+
+class AutoUpsertHistories extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'auto:upsert_histories';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Upserts peer histories in batches';
+
+    /**
+     * Execute the console command.
+     *
+     * @throws Exception
+     */
+    public function handle(): void
+    {
+        /**
+         * MySql can handle a max of 65535 placeholders per query,
+         * and there are 16 fields on each history that are updated:.
+         *
+         * - user_id
+         * - torrent_id
+         * - agent
+         * - uploaded
+         * - actual_uploaded
+         * - client_uploaded
+         * - downloaded
+         * - actual_downloaded
+         * - client_downloaded
+         * - seeder
+         * - active
+         * - seedtime
+         * - immune
+         * - completed_at
+         * - created_at
+         * - updated_at
+         */
+        $historiesPerCycle = intdiv(65_000, 16);
+
+        $key = config('cache.prefix').':histories:batch';
+        $historyCount = Redis::connection('announce')->command('LLEN', [$key]);
+
+        for ($historiesLeft = $historyCount; $historiesLeft > 0; $historiesLeft -= $historiesPerCycle) {
+            $histories = Redis::connection('announce')->command('LPOP', [$key, $historiesPerCycle]);
+            $histories = array_map('unserialize', $histories);
+
+            History::upsert(
+                $histories,
+                ['user_id', 'torrent_id'],
+                [
+                    'user_id',
+                    'torrent_id',
+                    'agent',
+                    'uploaded',
+                    'actual_uploaded',
+                    'client_uploaded',
+                    'downloaded',
+                    'actual_downloaded',
+                    'client_downloaded',
+                    'seeder',
+                    'active',
+                    'seedtime',
+                    'immune',
+                    'completed_at',
+                ],
+            );
+        }
+
+        $this->comment('Automated upsert histories command complete');
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -23,6 +23,7 @@ class Kernel extends ConsoleKernel
      */
     protected function schedule(Schedule $schedule): void
     {
+        $schedule->command('auto:upsert_histories')->everyFiveSeconds();
         $schedule->command('auto:group ')->daily();
         $schedule->command('auto:nerdstat ')->hourly();
         $schedule->command('auto:graveyard')->daily();

--- a/app/Models/History.php
+++ b/app/Models/History.php
@@ -15,6 +15,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use DateTimeInterface;
 
 class History extends Model
 {
@@ -62,5 +63,13 @@ class History extends Model
     public function torrent(): \Illuminate\Database\Eloquent\Relations\BelongsTo
     {
         return $this->belongsTo(Torrent::class);
+    }
+
+    /**
+     * Prepare a date for array / JSON serialization.
+     */
+    protected function serializeDate(DateTimeInterface $date): string
+    {
+        return $date->format('Y-m-d H:i:s');
     }
 }

--- a/config/database.php
+++ b/config/database.php
@@ -172,6 +172,16 @@ return [
             'database'           => env('REDIS_BROADCAST_DB', 4),
             'read_write_timeout' => -1,
         ],
+
+        'announce' => [
+            'url'                => env('REDIS_URL'),
+            'host'               => env('REDIS_HOST', '127.0.0.1'),
+            'username'           => env('REDIS_USERNAME'),
+            'password'           => env('REDIS_PASSWORD', null),
+            'port'               => env('REDIS_PORT', 6379),
+            'database'           => env('REDIS_BROADCAST_DB', 5),
+            'read_write_timeout' => -1,
+        ],
     ],
 
     'pristine-db-file' => env('PRISTINE_DB_FILE'),


### PR DESCRIPTION
Although now currently functional, #2565 unfortunately doesn't offer any performance improvements. This is most likely because `history` seems to be the main bottleneck, not `peers`. This PR follows the same code structure, but for the history records instead. It also uses the new Laravel feature to have commands be ran more often than once per minute.