### PR TITLE
(Fix) Null season numbers

### DIFF
--- a/app/Jobs/ProcessTvJob.php
+++ b/app/Jobs/ProcessTvJob.php
@@ -190,7 +190,7 @@ class ProcessTvJob implements ShouldQueue
                 'poster'        => $tmdb->image('poster', $season),
                 'name'          => $tmdb->ifExists('name', $season),
                 'overview'      => $tmdb->ifExists('overview', $season),
-                'season_number' => $tmdb->ifExists('season_number', $season),
+                'season_number' => $season['season_number'],
                 'tv_id'         => $this->id,
             ];
 


### PR DESCRIPTION
Sometimes, tmdb is returning null season numbers (even though their documentation states that the return value is always an integer). Fix it by using the originally fetched season number instead of relying on returned data.