### PR TITLE
(Fix) Batch user last action updates with redis

### DIFF
--- a/app/Console/Commands/AutoUpdateUserLastActions.php
+++ b/app/Console/Commands/AutoUpdateUserLastActions.php
@@ -45,9 +45,11 @@ class AutoUpdateUserLastActions extends Command
         $userIdCount = Redis::command('LLEN', [$key]);
         $userIds = Redis::command('LPOP', [$key, $userIdCount]);
 
-        User::whereIntegerInRaw('id', $userIds)->update([
-            'last_action' => now(),
-        ]);
+        if ($userIds !== null) {
+            User::whereIntegerInRaw('id', $userIds)->update([
+                'last_action' => now(),
+            ]);
+        }
 
         $this->comment('Automated upsert histories command complete');
     }

--- a/app/Http/Middleware/UpdateLastAction.php
+++ b/app/Http/Middleware/UpdateLastAction.php
@@ -29,9 +29,7 @@ class UpdateLastAction
             return $next($request);
         }
 
-        if ($user->last_action->addMinute()->isPast()) {
-            Redis::command('LPUSH', [config('cache.prefix').':user-last-actions:batch', $user->id]);
-        }
+        Redis::command('LPUSH', [config('cache.prefix').':user-last-actions:batch', $user->id]);
 
         return $next($request);
     }


### PR DESCRIPTION
If there are no users in the list, null is returned, so we have to check against null.

Since we cache users for 30 seconds, checking their last action time is pointless.