### PR TITLE
(Fix) User resurrection creation

### DIFF
--- a/app/Http/Controllers/User/ResurrectionController.php
+++ b/app/Http/Controllers/User/ResurrectionController.php
@@ -63,7 +63,7 @@ class ResurrectionController extends Controller
                 ->withErrors(trans('graveyard.resurrect-failed-pending'));
         }
 
-        $history = History::whereBelongsTo($torrent)->whereBelongsTo($user)->sole();
+        $history = History::whereBelongsTo($torrent)->whereBelongsTo($user)->first();
 
         Graveyard::create([
             'user_id'    => $user->id,


### PR DESCRIPTION
This value needs to be nullable if it doesn't exist so that the seeditme can be set to 0 if there exists no history.