### PR TITLE
(Fix) Person credit director/creator order

### DIFF
--- a/resources/views/livewire/person-credit.blade.php
+++ b/resources/views/livewire/person-credit.blade.php
@@ -4,22 +4,22 @@
         <li
             class="panel__tab"
             role="tab"
-            x-bind:class="tab === {{ App\Enums\Occupations::DIRECTOR->value }} && 'panel__tab--active'"
-            x-cloak
-            x-on:click="tab = {{ App\Enums\Occupations::DIRECTOR->value }}"
-            x-show="{{ $directedCount }} > 0"
-        >
-            Director ({{ $directedCount }})
-        </li>
-        <li
-            class="panel__tab"
-            role="tab"
             x-bind:class="tab === {{ App\Enums\Occupations::CREATOR->value }} && 'panel__tab--active'"
             x-cloak
             x-on:click="tab = {{ App\Enums\Occupations::CREATOR->value }}"
             x-show="{{ $createdCount }} > 0"
         >
             Creator ({{ $createdCount }})
+        </li>
+        <li
+            class="panel__tab"
+            role="tab"
+            x-bind:class="tab === {{ App\Enums\Occupations::DIRECTOR->value }} && 'panel__tab--active'"
+            x-cloak
+            x-on:click="tab = {{ App\Enums\Occupations::DIRECTOR->value }}"
+            x-show="{{ $directedCount }} > 0"
+        >
+            Director ({{ $directedCount }})
         </li>
         <li
             class="panel__tab"


### PR DESCRIPTION
The controller expects the creator to be before the director, so the view should match.