### PR TITLE
(Fix) Html entity double encoding

### DIFF
--- a/app/Http/Livewire/BbcodeInput.php
+++ b/app/Http/Livewire/BbcodeInput.php
@@ -35,7 +35,7 @@ class BbcodeInput extends Component
         $this->name = $name;
         $this->label = $label;
         $this->isRequired = $required;
-        $this->contentBbcode = $content ?? old($name) ?? '';
+        $this->contentBbcode = $content === null ? (old($name) ?? '') : htmlspecialchars_decode($content);
     }
 
     final public function updatedIsPreviewEnabled(): void

--- a/app/Models/Playlist.php
+++ b/app/Models/Playlist.php
@@ -66,6 +66,6 @@ class Playlist extends Model
     {
         $bbcode = new Bbcode();
 
-        return (new Linkify())->linky($bbcode->parse(htmlspecialchars_decode($this->description)));
+        return (new Linkify())->linky($bbcode->parse($this->description));
     }
 }

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -105,7 +105,7 @@ class Post extends Model
     {
         $bbcode = new Bbcode();
 
-        return (new Linkify())->linky($bbcode->parse(htmlspecialchars_decode($this->content)));
+        return (new Linkify())->linky($bbcode->parse($this->content));
     }
 
     /**

--- a/database/migrations/2023_07_22_043634_post_playlist_html_special_chars_decode.php
+++ b/database/migrations/2023_07_22_043634_post_playlist_html_special_chars_decode.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        DB::table('posts')
+            ->lazyById()
+            ->each(function (object $post): void {
+                DB::table('posts')
+                    ->where('id', '=', $post->id)
+                    ->update([
+                        'content' => htmlspecialchars_decode($post->content),
+                    ]);
+            });
+
+        DB::table('playlists')
+            ->lazyById()
+            ->each(function (object $playlist): void {
+                DB::table('playlists')
+                    ->where('id', '=', $playlist->id)
+                    ->update([
+                        'description' => htmlspecialchars_decode($playlist->description),
+                    ]);
+            });
+    }
+};

--- a/resources/views/components/forum/post.blade.php
+++ b/resources/views/components/forum/post.blade.php
@@ -1,4 +1,4 @@
-<article class="post" id="post-{{ $post->id }}">
+<article class="post" id="post-{{ $post->id }}" x-data>
     <header class="post__header">
         <time
             class="post__datetime"
@@ -74,11 +74,16 @@
                     <button
                         class="post__quote"
                         title="{{ __('forum.quote') }}"
-                        x-data
                         x-on:click="
                             document.getElementById('forum_reply_form').style.display = 'block';
                             input = document.getElementById('bbcode-content');
-                            input.value += '[quote={{ \htmlspecialchars('@'.$post->user->username) }}] {{ \str_replace(["\n", "\r"], ["\\n", "\\r"], \htmlspecialchars($post->content)) }}[/quote]';
+                            input.value += '[quote={{ \htmlspecialchars('@'.$post->user->username) }}]';
+                            input.value += (() => {
+                                var text = document.createElement('textarea');
+                                text.innerHTML = atob($refs.content.dataset.base64Bbcode);
+                                return text.value;
+                            })();
+                            input.value += '[/quote]';
                             input.dispatchEvent(new Event('input'));
                             input.focus();
                         "
@@ -178,7 +183,8 @@
     </aside>
     <div
         class="post__content bbcode-rendered"
-        data-bbcode="{{ $post->content }}"
+        x-ref="content"
+        data-base64-bbcode="{{ base64_encode($post->content) }}"
     >
         @joypixels($post->getContentHtml())
     </div>


### PR DESCRIPTION
Bbcode is always sanitized first before being saved, which causes html entities. However, when content is edited again, the html entities aren't decoded before the user edits them, which causes the user to remove the html entities before updating the content. This commit now decodes the html back to text and will resanitize again upon save.