### PR TITLE
(Fix) De-indent first quote

### DIFF
--- a/resources/sass/components/_bbcode-rendered.scss
+++ b/resources/sass/components/_bbcode-rendered.scss
@@ -261,6 +261,8 @@
   }
 
   blockquote {
+    margin-left: 2px;
+    margin-right: 2px;
     padding: 0.25em 0.25em 0.25em 1em;
     color: var(--bbcode-rendered-fg-muted);
     border-left: 0.25em solid var(--bbcode-rendered-quote-border);
@@ -272,6 +274,11 @@
   blockquote > cite {
     font-size: 12px;
     font-weight: bold;
+  }
+
+  blockquote > blockquote {
+    margin-left: 6px;
+    margin-right: 20px;
   }
 
   ul,


### PR DESCRIPTION
Only nested quotes are supposed to have the spacing. Reduce the spacing as well for more natural nesting.