### PR TITLE
(Fix) Validate nfo and torrent file extensions on upload

### DIFF
--- a/app/Http/Requests/StoreTorrentRequest.php
+++ b/app/Http/Requests/StoreTorrentRequest.php
@@ -46,6 +46,10 @@ class StoreTorrentRequest extends FormRequest
                 'file',
                 'mimes:torrent',
                 function (string $attribute, mixed $value, Closure $fail): void {
+                    if ($value->getClientOriginalExtension() !== 'torrent') {
+                        $fail('The torrent file uploaded does not have a ".torrent" file extension (it has "'.$value->getClientOriginalExtension().'"). Did you upload the correct file?');
+                    }
+
                     $decodedTorrent = TorrentTools::normalizeTorrent($value);
 
                     $v2 = Bencode::is_v2_or_hybrid($decodedTorrent);
@@ -78,6 +82,16 @@ class StoreTorrentRequest extends FormRequest
                         };
                     }
                 }
+            ],
+            'nfo' => [
+                'nullable',
+                'sometimes',
+                'file',
+                function (string $attribute, mixed $value, Closure $fail): void {
+                    if ($value->getClientOriginalExtension() !== 'nfo') {
+                        $fail('The NFO uploaded does not have a ".nfo" file extension (it has "'.$value->getClientOriginalExtension().'"). Did you upload the correct file?');
+                    }
+                },
             ],
             'name' => [
                 'required',


### PR DESCRIPTION
There have been cases where users accidentally upload an unrelated file as the .nfo.