### PR TITLE
(Refactor) Drop unused genre_torrent table

### DIFF
--- a/app/Models/Torrent.php
+++ b/app/Models/Torrent.php
@@ -129,14 +129,6 @@ class Torrent extends Model
     }
 
     /**
-     * Has Many Genres.
-     */
-    public function genres(): \Illuminate\Database\Eloquent\Relations\BelongsToMany
-    {
-        return $this->belongsToMany(Genre::class, 'genre_torrent', 'torrent_id', 'genre_id', 'id', 'id');
-    }
-
-    /**
      * Torrent Has Been Moderated By.
      */
     public function moderated(): \Illuminate\Database\Eloquent\Relations\BelongsTo

--- a/database/migrations/2023_07_23_190319_drop_genre_torrent_table.php
+++ b/database/migrations/2023_07_23_190319_drop_genre_torrent_table.php
@@ -1,0 +1,14 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::table('genre_torrent', function (Blueprint $table): void {
+            $table->drop();
+        });
+    }
+};


### PR DESCRIPTION
We store genres via the genre_movie and genre_tv pivot tables now.