### PR TITLE
(Fix) Bad mime detection

### DIFF
--- a/app/Http/Requests/StoreTorrentRequest.php
+++ b/app/Http/Requests/StoreTorrentRequest.php
@@ -44,7 +44,6 @@ class StoreTorrentRequest extends FormRequest
             'torrent' => [
                 'required',
                 'file',
-                'mimes:torrent',
                 function (string $attribute, mixed $value, Closure $fail): void {
                     if ($value->getClientOriginalExtension() !== 'torrent') {
                         $fail('The torrent file uploaded does not have a ".torrent" file extension (it has "'.$value->getClientOriginalExtension().'"). Did you upload the correct file?');


### PR DESCRIPTION
Many users often remove the announce url from uploaded torrents (since other tracker codebases are known to log urls of uploaded torrents to breach user accounts on other sites). This unfortunately causes the mime detection to sometimes (not all the time) fail preventing the user from uploading. Now that we're validating by file extension, it should still prevent the case of users accidentally uploading an unrelated file which was the main issue to be solved.