### PR TITLE
(Fix) Redundant fetching of records from the database

### DIFF
--- a/app/Http/Controllers/AnnounceController.php
+++ b/app/Http/Controllers/AnnounceController.php
@@ -567,7 +567,7 @@ class AnnounceController extends Controller
      */
     private function processAnnounceJob($queries, $user, $group, $torrent): void
     {
-        ProcessAnnounce::dispatch($queries, $user, $group, $torrent);
+        ProcessAnnounce::dispatch($queries, serialize($user), serialize($group), serialize($torrent));
     }
 
     protected function generateFailedAnnounceResponse(TrackerException $trackerException): array

--- a/app/Jobs/ProcessAnnounce.php
+++ b/app/Jobs/ProcessAnnounce.php
@@ -15,15 +15,18 @@
 namespace App\Jobs;
 
 use App\Models\FreeleechToken;
+use App\Models\Group;
 use App\Models\History;
 use App\Models\Peer;
 use App\Models\PersonalFreeleech;
+use App\Models\Torrent;
+use App\Models\User;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\Middleware\WithoutOverlapping;
-use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Redis;
 
@@ -32,13 +35,19 @@ class ProcessAnnounce implements ShouldQueue
     use Dispatchable;
     use InteractsWithQueue;
     use Queueable;
-    use SerializesModels;
+
+    private Torrent $torrent;
+    private User $user;
+    private Group $group;
 
     /**
      * Create a new job instance.
      */
-    public function __construct(protected $queries, protected $user, protected $group, protected $torrent)
+    public function __construct(protected array $queries, string $user, string $group, string $torrent)
     {
+        $this->torrent = unserialize($torrent, ['allowed_classes' => [Torrent::class, Collection::class, Peer::class]]);
+        $this->user = unserialize($user, ['allowed_classes' => [User::class]]);
+        $this->group = unserialize($group, ['allowed_classes' => [Group::class]]);
     }
 
     /**

--- a/app/Jobs/ProcessAnnounce.php
+++ b/app/Jobs/ProcessAnnounce.php
@@ -18,7 +18,6 @@ use App\Models\FreeleechToken;
 use App\Models\Group;
 use App\Models\History;
 use App\Models\Peer;
-use App\Models\PersonalFreeleech;
 use App\Models\Torrent;
 use App\Models\User;
 use Illuminate\Bus\Queueable;

--- a/app/Jobs/ProcessAnnounce.php
+++ b/app/Jobs/ProcessAnnounce.php
@@ -165,7 +165,7 @@ class ProcessAnnounce implements ShouldQueue
         $peer->agent = $this->queries['user-agent'];
         $peer->uploaded = $realUploaded;
         $peer->downloaded = $realDownloaded;
-        $peer->seeder = (int) ($this->queries['left'] == 0);
+        $peer->seeder = $this->queries['left'] == 0;
         $peer->left = $this->queries['left'];
         $peer->torrent_id = $this->torrent->id;
         $peer->user_id = $this->user->id;
@@ -178,14 +178,14 @@ class ProcessAnnounce implements ShouldQueue
 
         switch ($event) {
             case 'started':
-                $peer->active = 1;
+                $peer->active = true;
 
                 $history->active = 1;
                 $history->immune = (int) ($history->exists ? $history->immune && $this->group->is_immune : $this->group->is_immune);
 
                 break;
             case 'completed':
-                $peer->active = 1;
+                $peer->active = true;
 
                 $history->active = 1;
                 $history->uploaded += $modUploaded;
@@ -215,7 +215,7 @@ class ProcessAnnounce implements ShouldQueue
 
                 break;
             case 'stopped':
-                $peer->active = 0;
+                $peer->active = false;
 
                 $history->active = 0;
                 $history->uploaded += $modUploaded;
@@ -240,7 +240,7 @@ class ProcessAnnounce implements ShouldQueue
                 // End User Update
                 break;
             default:
-                $peer->active = 1;
+                $peer->active = true;
 
                 $history->active = 1;
                 $history->uploaded += $modUploaded;

--- a/app/Models/Peer.php
+++ b/app/Models/Peer.php
@@ -24,6 +24,16 @@ class Peer extends Model
     use HasFactory;
 
     /**
+     * The attributes that should be cast.
+     *
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'active' => 'boolean',
+        'seeder' => 'boolean',
+    ];
+
+    /**
      * Prepare a date for array / JSON serialization.
      */
     protected function serializeDate(DateTimeInterface $date): string


### PR DESCRIPTION
The `SerializesModels` trait fetches a new copy of the record from the database, causing 4 more queries than we thought we were using. This change reduces the query time in the ProcessAnnounce job by 55%.