### PR TITLE
(Fix) Request rejection rejector fetching

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -481,11 +481,6 @@ parameters:
 			path: app/Http/Controllers/RequestController.php
 
 		-
-			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\BelongsTo\\<App\\\\Models\\\\User, App\\\\Models\\\\TorrentRequest\\>\\:\\:\\$username\\.$#"
-			count: 1
-			path: app/Http/Controllers/RequestFillController.php
-
-		-
 			message: "#^If condition is always true\\.$#"
 			count: 2
 			path: app/Http/Controllers/RssController.php


### PR DESCRIPTION
- `->username` isn't a property of `->user()` (relation rather than object)
- Changed the variable names to be more clear.
- Fetch the relations before clearing the fields needed to fetch the relation otherwise the notification will have null as the sender