### PR TITLE
(Fix) Personal freeleech caching

### DIFF
--- a/app/Console/Commands/AutoRemovePersonalFreeleech.php
+++ b/app/Console/Commands/AutoRemovePersonalFreeleech.php
@@ -58,7 +58,7 @@ class AutoRemovePersonalFreeleech extends Command
             // Delete The Record From DB
             $pfl->delete();
 
-            cache()->forget('personal_freeleech:'.$pfl->user_id);
+            cache()->put('personal_freeleech:'.$pfl->user_id, false);
             Unit3dAnnounce::removePersonalFreeleech($pfl->user_id);
         }
 

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -57,7 +57,7 @@ class HomeController extends Controller
 
         return view('home.index', [
             'user'               => $user,
-            'personal_freeleech' => cache()->has('personal_freeleech:'.$user->id),
+            'personal_freeleech' => cache()->get('personal_freeleech:'.$user->id),
             'users'              => cache()->remember(
                 'online_users',
                 $expiresAt,

--- a/app/Http/Controllers/SimilarTorrentController.php
+++ b/app/Http/Controllers/SimilarTorrentController.php
@@ -89,7 +89,7 @@ class SimilarTorrentController extends Controller
                 break;
         }
 
-        $personalFreeleech = cache()->has('personal_freeleech:'.auth()->id());
+        $personalFreeleech = cache()->get('personal_freeleech:'.auth()->id());
 
         return view('torrent.similar', [
             'meta'               => $meta,

--- a/app/Http/Controllers/TorrentController.php
+++ b/app/Http/Controllers/TorrentController.php
@@ -131,7 +131,7 @@ class TorrentController extends Controller
         return view('torrent.show', [
             'torrent'            => $torrent,
             'user'               => $user,
-            'personal_freeleech' => cache()->has('personal_freeleech:'.$user->id),
+            'personal_freeleech' => cache()->get('personal_freeleech:'.$user->id),
             'freeleech_token'    => cache()->get('freeleech_token:'.$user->id.':'.$torrent->id),
             'meta'               => $meta,
             'trailer'            => $trailer,

--- a/app/Http/Controllers/User/TransactionController.php
+++ b/app/Http/Controllers/User/TransactionController.php
@@ -83,14 +83,13 @@ class TransactionController extends Controller
 
                     break;
                 case $bonExchange->personal_freeleech:
-                    if (cache()->has('personal_freeleech:'.$user->id)) {
+                    if (cache()->get('personal_freeleech:'.$user->id)) {
                         return back()->withErrors('Your previous personal freeleech is still active.');
                     }
 
                     PersonalFreeleech::create(['user_id' => $user->id]);
 
-                    // Allow the user 25 hours since the AutoRemovePersonalFreeleech command is only run every hour.
-                    cache()->put('personal_freeleech:'.$user->id, true, now()->addHours(25));
+                    cache()->put('personal_freeleech:'.$user->id, true);
 
                     Unit3dAnnounce::addPersonalFreeleech($user->id);
 

--- a/app/Http/Livewire/PersonCredit.php
+++ b/app/Http/Livewire/PersonCredit.php
@@ -49,7 +49,7 @@ class PersonCredit extends Component
 
     final public function getPersonalFreeleechProperty()
     {
-        return cache()->has('personal_freeleech:'.auth()->user()->id);
+        return cache()->get('personal_freeleech:'.auth()->user()->id);
     }
 
     /*

--- a/app/Http/Livewire/SimilarTorrent.php
+++ b/app/Http/Livewire/SimilarTorrent.php
@@ -216,7 +216,7 @@ class SimilarTorrent extends Component
 
     final public function getPersonalFreeleechProperty()
     {
-        return cache()->has('personal_freeleech:'.auth()->id());
+        return cache()->get('personal_freeleech:'.auth()->id());
     }
 
     final public function render(): \Illuminate\Contracts\View\Factory|\Illuminate\Contracts\View\View|\Illuminate\Contracts\Foundation\Application

--- a/app/Http/Livewire/Top10.php
+++ b/app/Http/Livewire/Top10.php
@@ -67,7 +67,7 @@ class Top10 extends Component
 
     final public function getPersonalFreeleechProperty()
     {
-        return cache()->has('personal_freeleech:'.auth()->id());
+        return cache()->get('personal_freeleech:'.auth()->id());
     }
 
     final public function render(): \Illuminate\Contracts\View\Factory|\Illuminate\Contracts\View\View|\Illuminate\Contracts\Foundation\Application

--- a/app/Http/Livewire/TorrentSearch.php
+++ b/app/Http/Livewire/TorrentSearch.php
@@ -175,7 +175,7 @@ class TorrentSearch extends Component
 
     final public function getPersonalFreeleechProperty()
     {
-        return cache()->has('personal_freeleech:'.auth()->id());
+        return cache()->get('personal_freeleech:'.auth()->id());
     }
 
     final public function getTorrentsProperty(): \Illuminate\Contracts\Pagination\LengthAwarePaginator

--- a/app/Jobs/ProcessAnnounce.php
+++ b/app/Jobs/ProcessAnnounce.php
@@ -17,6 +17,7 @@ namespace App\Jobs;
 use App\Models\FreeleechToken;
 use App\Models\History;
 use App\Models\Peer;
+use App\Models\PersonalFreeleech;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
@@ -116,7 +117,10 @@ class ProcessAnnounce implements ShouldQueue
         }
 
         // Modification of Upload and Download (Check cache but in case redis data was lost hit DB)
-        $personalFreeleech = cache()->has('personal_freeleech:'.$this->user->id);
+        $personalFreeleech = cache()->get('personal_freeleech:'.$this->user->id) ??
+            PersonalFreeleech::query()
+                ->where('user_id', '=', $this->user->id)
+                ->exists();
         $freeleechToken = cache()->get('freeleech_token:'.$this->user->id.':'.$this->torrent->id) ??
             FreeleechToken::query()
                 ->where('user_id', '=', $this->user->id)

--- a/app/Jobs/ProcessAnnounce.php
+++ b/app/Jobs/ProcessAnnounce.php
@@ -117,10 +117,12 @@ class ProcessAnnounce implements ShouldQueue
         }
 
         // Modification of Upload and Download (Check cache but in case redis data was lost hit DB)
-        $personalFreeleech = cache()->get('personal_freeleech:'.$this->user->id) ??
-            PersonalFreeleech::query()
+        $personalFreeleech = cache()->rememberForever(
+            'personal_freeleech:'.$this->user->id,
+            fn () => PersonalFreeleech::query()
                 ->where('user_id', '=', $this->user->id)
-                ->exists();
+                ->exists()
+        );
         $freeleechToken = cache()->get('freeleech_token:'.$this->user->id.':'.$this->torrent->id) ??
             FreeleechToken::query()
                 ->where('user_id', '=', $this->user->id)

--- a/app/Models/Torrent.php
+++ b/app/Models/Torrent.php
@@ -323,7 +323,7 @@ class Torrent extends Model
      */
     public function isFreeleech($user = null): bool
     {
-        $pfree = $user && ($user->group->is_freeleech || cache()->has('personal_freeleech:'.$user->id));
+        $pfree = $user && ($user->group->is_freeleech || cache()->get('personal_freeleech:'.$user->id));
 
         return $this->free || config('other.freeleech') || $pfree;
     }


### PR DESCRIPTION
If we only store the value in redis, then we can't flush the cache without destructive consequences.

Also improve the cache so that we store it regardless of it it's true or false, otherwise we're constantly querying when a personal freeleech doesn't exist (which is 99% of the time)