### PR TITLE
(Update) Don't fetch history record before updating it

### DIFF
--- a/app/Console/Commands/AutoDeleteStoppedPeers.php
+++ b/app/Console/Commands/AutoDeleteStoppedPeers.php
@@ -40,7 +40,7 @@ class AutoDeleteStoppedPeers extends Command
      */
     public function handle(): void
     {
-        Peer::where('active', '=', 0)->delete();
+        Peer::where('active', '=', 0)->where('updated_at', '>', now()->subHours(2))->delete();
 
         $this->comment('Automated delete stopped peers command complete');
     }

--- a/app/Console/Commands/AutoUpsertHistories.php
+++ b/app/Console/Commands/AutoUpsertHistories.php
@@ -15,6 +15,7 @@ namespace App\Console\Commands;
 
 use App\Models\History;
 use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Redis;
 use Exception;
 
@@ -75,20 +76,18 @@ class AutoUpsertHistories extends Command
                 $histories,
                 ['user_id', 'torrent_id'],
                 [
-                    'user_id',
-                    'torrent_id',
                     'agent',
-                    'uploaded',
-                    'actual_uploaded',
+                    'uploaded'        => DB::raw('uploaded + VALUES(uploaded)'),
+                    'actual_uploaded' => DB::raw('actual_uploaded + VALUES(actual_uploaded)'),
                     'client_uploaded',
-                    'downloaded',
-                    'actual_downloaded',
+                    'downloaded'        => DB::raw('downloaded + VALUES(downloaded)'),
+                    'actual_downloaded' => DB::raw('actual_downloaded + VALUES(actual_downloaded)'),
                     'client_downloaded',
                     'seeder',
                     'active',
-                    'seedtime',
-                    'immune',
-                    'completed_at',
+                    'seedtime'     => DB::raw('IF(DATE_ADD(updated_at, INTERVAL 3600 SECOND) > VALUES(updated_at) AND seeder = 1 AND VALUES(seeder) = 1, seedtime + TIMESTAMPDIFF(SECOND, updated_at, VALUES(updated_at)), seedtime)'),
+                    'immune'       => DB::raw('immune AND VALUES(immune)'),
+                    'completed_at' => DB::raw('COALESCE(completed_at, VALUES(completed_at))'),
                 ],
             );
         }

--- a/app/Http/Controllers/StatsController.php
+++ b/app/Http/Controllers/StatsController.php
@@ -54,8 +54,8 @@ class StatsController extends Controller
         $numSd = cache()->remember('num_sd', $this->carbon, fn () => Torrent::where('sd', '=', 1)->count());
 
         // Generally sites have more seeders than leechers, so it ends up being faster (by approximately 50%) to compute these stats instead of computing them individually
-        $leecherCount = cache()->remember('peer_seeder_count', $this->carbon, fn () => Peer::where('seeder', '=', false)->count());
-        $peerCount = cache()->remember('peer_count', $this->carbon, fn () => Peer::count());
+        $leecherCount = cache()->remember('peer_seeder_count', $this->carbon, fn () => Peer::where('seeder', '=', false)->where('active', '=', true)->count());
+        $peerCount = cache()->remember('peer_count', $this->carbon, fn () => Peer::where('active', '=', true)->count());
 
         $historyStats = cache()->remember(
             'history_stats',

--- a/app/Http/Controllers/TorrentPeerController.php
+++ b/app/Http/Controllers/TorrentPeerController.php
@@ -33,8 +33,8 @@ class TorrentPeerController extends Controller
                 ->select(['torrent_id', 'user_id', 'uploaded', 'downloaded', 'left', 'port', 'agent', 'created_at', 'updated_at', 'seeder', 'active'])
                 ->selectRaw('INET6_NTOA(ip) as ip')
                 ->where('torrent_id', '=', $id)
-                ->where('active', '=', 1)
-                ->latest('seeder')
+                ->orderByDesc('active')
+                ->orderByDesc('seeder')
                 ->get()
                 ->map(function ($peer) use ($torrent) {
                     $progress = 100 * (1 - $peer->left / $torrent->size);

--- a/app/Http/Controllers/User/UserController.php
+++ b/app/Http/Controllers/User/UserController.php
@@ -88,14 +88,16 @@ class UserController extends Controller
                 ->select('agent', 'port')
                 ->selectRaw('INET6_NTOA(ip) as ip, MIN(created_at) as created_at, MAX(updated_at) as updated_at, COUNT(*) as num_peers')
                 ->groupBy(['ip', 'port', 'agent'])
+                ->where('active', '=', true)
                 ->get(),
             'achievements' => AchievementProgress::with('details')
                 ->where('achiever_id', '=', $user->id)
                 ->whereNotNull('unlocked_at')
                 ->get(),
             'peers' => Peer::query()
-                ->selectRaw('SUM(seeder = 0) as leeching')
-                ->selectRaw('SUM(seeder = 1) as seeding')
+                ->selectRaw('SUM(seeder = 0 AND active = 1) as leeching')
+                ->selectRaw('SUM(seeder = 1 AND active = 1) as seeding')
+                ->selectRaw('SUM(active = 0) as inactive')
                 ->where('user_id', '=', $user->id)
                 ->first(),
             'watch' => $user->watchlist,

--- a/app/Http/Livewire/PeerSearch.php
+++ b/app/Http/Livewire/PeerSearch.php
@@ -31,6 +31,7 @@ class PeerSearch extends Component
     public string $agent = '';
     public string $torrent = '';
     public string $connectivity = 'any';
+    public string $active = 'any';
     public string $groupBy = 'none';
     public string $sortField = 'created_at';
     public string $sortDirection = 'desc';
@@ -46,6 +47,7 @@ class PeerSearch extends Component
         'agent'            => ['except' => ''],
         'torrent'          => ['except' => ''],
         'connectivity'     => ['except' => 'any'],
+        'active'           => ['except' => 'any'],
         'groupBy'          => ['except' => 'none'],
         'sortField'        => ['except' => 'created_at'],
         'sortDirection'    => ['except' => 'desc'],
@@ -100,6 +102,7 @@ class PeerSearch extends Component
                         'peers.created_at',
                         'peers.updated_at',
                         'peers.seeder',
+                        'peers.active',
                         'peers.connectable',
                     ])
                     ->selectRaw('INET6_NTOA(peers.ip) as ip')
@@ -119,6 +122,8 @@ class PeerSearch extends Component
                     ->selectRaw('COUNT(DISTINCT(peers.id)) as peer_count')
                     ->selectRaw('SUM(peers.connectable = 1) as connectable_count')
                     ->selectRaw('SUM(peers.connectable = 0) as unconnectable_count')
+                    ->selectRaw('SUM(peers.active = 1) as active_count')
+                    ->selectRaw('SUM(peers.active = 0) as inactive_count')
                     ->groupBy(['peers.user_id', 'peers.agent', 'peers.ip', 'peers.port'])
                     ->with(['user', 'user.group'])
             )
@@ -138,6 +143,8 @@ class PeerSearch extends Component
                     ->selectRaw('COUNT(*) as peer_count')
                     ->selectRaw('SUM(peers.connectable = 1) as connectable_count')
                     ->selectRaw('SUM(peers.connectable = 0) as unconnectable_count')
+                    ->selectRaw('SUM(peers.active = 1) as active_count')
+                    ->selectRaw('SUM(peers.active = 0) as inactive_count')
                     ->groupBy(['peers.user_id', 'peers.ip'])
                     ->with(['user', 'user.group'])
             )
@@ -157,6 +164,8 @@ class PeerSearch extends Component
                     ->selectRaw('COUNT(*) as peer_count')
                     ->selectRaw('SUM(peers.connectable = 1) as connectable_count')
                     ->selectRaw('SUM(peers.connectable = 0) as unconnectable_count')
+                    ->selectRaw('SUM(peers.active = 1) as active_count')
+                    ->selectRaw('SUM(peers.active = 0) as inactive_count')
                     ->groupBy(['peers.user_id'])
                     ->with(['user', 'user.group'])
             )
@@ -197,6 +206,8 @@ class PeerSearch extends Component
             ))
             ->when($this->connectivity === 'connectable', fn ($query) => $query->where('connectable', '=', true))
             ->when($this->connectivity === 'unconnectable', fn ($query) => $query->where('connectable', '=', false))
+            ->when($this->active === 'include', fn ($query) => $query->where('active', '=', true))
+            ->when($this->active === 'exclude', fn ($query) => $query->where('active', '=', false))
             ->orderBy($this->sortField, $this->sortDirection)
             ->paginate($this->perPage);
     }

--- a/app/Http/Livewire/UserActive.php
+++ b/app/Http/Livewire/UserActive.php
@@ -18,6 +18,9 @@ use App\Models\User;
 use Livewire\Component;
 use Livewire\WithPagination;
 
+/**
+ * @property \Illuminate\Contracts\Pagination\LengthAwarePaginator $actives
+ */
 class UserActive extends Component
 {
     use WithPagination;

--- a/app/Http/Livewire/UserActive.php
+++ b/app/Http/Livewire/UserActive.php
@@ -36,6 +36,8 @@ class UserActive extends Component
 
     public string $seeding = 'any';
 
+    public string $active = 'include';
+
     public string $sortField = 'created_at';
 
     public string $sortDirection = 'desc';
@@ -49,6 +51,7 @@ class UserActive extends Component
         'port'              => ['except' => ''],
         'client'            => ['excpet' => ''],
         'seeding'           => ['except' => 'any'],
+        'active'            => ['except' => 'any'],
         'sortField'         => ['except' => 'created_at'],
         'sortDirection'     => ['except' => 'desc'],
         'showMorePrecision' => ['except' => false],
@@ -69,7 +72,7 @@ class UserActive extends Component
         $this->resetPage();
     }
 
-    final public function getActiveProperty(): \Illuminate\Contracts\Pagination\LengthAwarePaginator
+    final public function getActivesProperty(): \Illuminate\Contracts\Pagination\LengthAwarePaginator
     {
         return Peer::query()
             ->join('torrents', 'peers.torrent_id', '=', 'torrents.id')
@@ -85,6 +88,7 @@ class UserActive extends Component
                 'peers.updated_at',
                 'peers.torrent_id',
                 'peers.user_id',
+                'peers.active',
                 'torrents.name',
                 'torrents.size',
                 'torrents.seeders',
@@ -105,6 +109,8 @@ class UserActive extends Component
             ->when($this->client !== '', fn ($query) => $query->where('agent', '=', $this->client))
             ->when($this->seeding === 'include', fn ($query) => $query->where('seeder', '=', 1))
             ->when($this->seeding === 'exclude', fn ($query) => $query->where('seeder', '=', 0))
+            ->when($this->active === 'include', fn ($query) => $query->where('active', '=', 1))
+            ->when($this->active === 'exclude', fn ($query) => $query->where('active', '=', 0))
             ->orderBy($this->sortField, $this->sortDirection)
             ->paginate($this->perPage);
     }
@@ -112,7 +118,7 @@ class UserActive extends Component
     final public function render(): \Illuminate\Contracts\View\Factory|\Illuminate\Contracts\View\View|\Illuminate\Contracts\Foundation\Application
     {
         return view('livewire.user-active', [
-            'actives' => $this->active,
+            'actives' => $this->actives,
         ]);
     }
 

--- a/app/Jobs/ProcessAnnounce.php
+++ b/app/Jobs/ProcessAnnounce.php
@@ -15,7 +15,6 @@
 namespace App\Jobs;
 
 use App\Models\FreeleechToken;
-use App\Models\History;
 use App\Models\Peer;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -57,9 +56,6 @@ class ProcessAnnounce implements ShouldQueue
      */
     public function handle(): void
     {
-        // Flag is tripped if new session is created but client reports up/down > 0
-        $ghost = false;
-
         // Set Variables
         $realUploaded = $this->queries['uploaded'];
         $realDownloaded = $this->queries['downloaded'];
@@ -73,46 +69,18 @@ class ProcessAnnounce implements ShouldQueue
             ->where('user_id', '=', $this->user->id)
             ->first();
 
+        $uploaded = max($realUploaded - ($peer?->uploaded ?? 0), 0);
+        $downloaded = max($realDownloaded >= ($peer?->downloaded ?? 0), 0);
+
         // If no Peer record found then create one
         if ($peer === null) {
             if ($this->queries['uploaded'] > 0 || $this->queries['downloaded'] > 0) {
-                $ghost = true;
                 $event = 'started';
+                $uploaded = 0;
+                $downloaded = 0;
             }
 
             $peer = new Peer();
-        }
-
-        // Get history information
-        $history = History::firstOrNew(
-            [
-                'torrent_id' => $this->torrent->id,
-                'user_id'    => $this->user->id,
-            ],
-            [
-                'uploaded'          => 0,
-                'actual_uploaded'   => 0,
-                'downloaded'        => 0,
-                'actual_downloaded' => 0,
-                'seedtime'          => 0,
-                'immune'            => 0,
-                'completed_at'      => null,
-            ]
-        );
-
-        // Check Ghost Flag
-        if ($ghost) {
-            $uploaded = ($realUploaded >= $history->client_uploaded) ? ($realUploaded - $history->client_uploaded) : 0;
-            $downloaded = ($realDownloaded >= $history->client_downloaded) ? ($realDownloaded - $history->client_downloaded) : 0;
-        } else {
-            $uploaded = ($realUploaded >= $peer->uploaded) ? ($realUploaded - $peer->uploaded) : 0;
-            $downloaded = ($realDownloaded >= $peer->downloaded) ? ($realDownloaded - $peer->downloaded) : 0;
-        }
-
-        if ($history->updated_at !== null && $history->updated_at->timestamp > now()->subHours(2)->timestamp && $history->seeder && $this->queries['left'] == 0) {
-            $oldUpdate = $history->updated_at->timestamp;
-        } else {
-            $oldUpdate = now()->timestamp;
         }
 
         // Modification of Upload and Download (Check cache but in case redis data was lost hit DB)
@@ -159,35 +127,13 @@ class ProcessAnnounce implements ShouldQueue
         $peer->updateConnectableStateIfNeeded();
         $peer->updated_at = now();
 
-        $history->agent = $this->queries['user-agent'];
-        $history->seeder = (int) ($this->queries['left'] == 0);
-        $history->client_uploaded = $realUploaded;
-        $history->client_downloaded = $realDownloaded;
-
         switch ($event) {
             case 'started':
                 $peer->active = true;
 
-                $history->active = 1;
-                $history->immune = (int) ($history->exists ? $history->immune && $this->group->is_immune : $this->group->is_immune);
-
                 break;
             case 'completed':
                 $peer->active = true;
-
-                $history->active = 1;
-                $history->uploaded += $modUploaded;
-                $history->actual_uploaded += $uploaded;
-                $history->downloaded += $modDownloaded;
-                $history->actual_downloaded += $downloaded;
-                $history->completed_at = now();
-
-                // Seedtime allocation
-                if ($this->queries['left'] == 0) {
-                    $newUpdate = $peer->updated_at->timestamp;
-                    $diff = $newUpdate - $oldUpdate;
-                    $history->seedtime += $diff;
-                }
 
                 // User Update
                 if ($modUploaded > 0 || $modDownloaded > 0) {
@@ -205,19 +151,6 @@ class ProcessAnnounce implements ShouldQueue
             case 'stopped':
                 $peer->active = false;
 
-                $history->active = 0;
-                $history->uploaded += $modUploaded;
-                $history->actual_uploaded += $uploaded;
-                $history->downloaded += $modDownloaded;
-                $history->actual_downloaded += $downloaded;
-
-                // Seedtime allocation
-                if ($this->queries['left'] == 0) {
-                    $newUpdate = $peer->updated_at->timestamp;
-                    $diff = $newUpdate - $oldUpdate;
-                    $history->seedtime += $diff;
-                }
-
                 // User Update
                 if ($modUploaded > 0 || $modDownloaded > 0) {
                     $this->user->update([
@@ -229,19 +162,6 @@ class ProcessAnnounce implements ShouldQueue
                 break;
             default:
                 $peer->active = true;
-
-                $history->active = 1;
-                $history->uploaded += $modUploaded;
-                $history->actual_uploaded += $uploaded;
-                $history->downloaded += $modDownloaded;
-                $history->actual_downloaded += $downloaded;
-
-                // Seedtime allocation
-                if ($this->queries['left'] == 0) {
-                    $newUpdate = $peer->updated_at->timestamp;
-                    $diff = $newUpdate - $oldUpdate;
-                    $history->seedtime += $diff;
-                }
 
                 // User Update
                 if ($modUploaded > 0 || $modDownloaded > 0) {
@@ -273,22 +193,22 @@ class ProcessAnnounce implements ShouldQueue
 
         Redis::connection('announce')->command('LPUSH', [
             config('cache.prefix').':histories:batch',
-            serialize($history->only([
-                'user_id',
-                'torrent_id',
-                'agent',
-                'uploaded',
-                'actual_uploaded',
-                'client_uploaded',
-                'downloaded',
-                'actual_downloaded',
-                'client_downloaded',
-                'seeder',
-                'active',
-                'seedtime',
-                'immune',
-                'completed_at',
-            ]))
+            serialize([
+                'user_id'           => $this->user->id,
+                'torrent_id'        => $this->torrent->id,
+                'agent'             => $this->queries['user-agent'],
+                'uploaded'          => $event === 'started' ? 0 : $modUploaded,
+                'actual_uploaded'   => $event === 'started' ? 0 : $uploaded,
+                'client_uploaded'   => $realUploaded,
+                'downloaded'        => $event === 'started' ? 0 : $modDownloaded,
+                'actual_downloaded' => $event === 'started' ? 0 : $downloaded,
+                'client_downloaded' => $realDownloaded,
+                'seeder'            => $this->queries['left'] == 0,
+                'active'            => $event !== 'stopped',
+                'seedtime'          => 0,
+                'immune'            => $this->group->is_immune,
+                'completed_at'      => $event === 'completed' ? now() : null,
+            ])
         ]);
 
         $otherSeeders = $this

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1091,11 +1091,6 @@ parameters:
 			path: app/Http/Livewire/TvSearch.php
 
 		-
-			message: "#^Access to an undefined property App\\\\Http\\\\Livewire\\\\UserActive\\:\\:\\$active\\.$#"
-			count: 1
-			path: app/Http/Livewire/UserActive.php
-
-		-
 			message: "#^Access to an undefined property Illuminate\\\\Contracts\\\\Auth\\\\Authenticatable\\:\\:\\$id\\.$#"
 			count: 1
 			path: app/Http/Livewire/UserActive.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1526,21 +1526,6 @@ parameters:
 			path: app/Http/Resources/UserEchoResource.php
 
 		-
-			message: "#^Property App\\\\Models\\\\History\\:\\:\\$active \\(bool\\) does not accept int\\.$#"
-			count: 4
-			path: app/Jobs/ProcessAnnounce.php
-
-		-
-			message: "#^Property App\\\\Models\\\\History\\:\\:\\$immune \\(bool\\) does not accept int\\.$#"
-			count: 1
-			path: app/Jobs/ProcessAnnounce.php
-
-		-
-			message: "#^Property App\\\\Models\\\\History\\:\\:\\$seeder \\(bool\\) does not accept int\\.$#"
-			count: 1
-			path: app/Jobs/ProcessAnnounce.php
-
-		-
 			message: "#^Called 'pluck' on Laravel collection, but could have been retrieved as a query\\.$#"
 			count: 1
 			path: app/Jobs/ProcessMovieJob.php

--- a/resources/views/livewire/peer-search.blade.php
+++ b/resources/views/livewire/peer-search.blade.php
@@ -31,6 +31,14 @@
                         <label class="form__label form__label--floating">Connectivity</label>
                     </p>
                     <p class="form__group">
+                        <select wire:model="active" class="form__select" placeholder=" ">
+                            <option value="any">Any</option>
+                            <option value="exclude">Inactive</option>
+                            <option value="include">Active</option>
+                        </select>
+                        <label class="form__label form__label--floating">Active</label>
+                    </p>
+                    <p class="form__group">
                         <select wire:model="groupBy" class="form__select" placeholder=" ">
                             <option value="none">None</option>
                             <option value="user_session">User Session</option>
@@ -159,6 +167,21 @@
                                 </th>
                             @endif
                         @endif
+                        @if ($groupBy === 'none')
+                            <th wire:click="sortBy('active')" role="columnheader button" style="text-align: right">
+                                Connectable
+                                @include('livewire.includes._sort-icon', ['field' => 'active'])
+                            </th>
+                        @else
+                            <th wire:click="sortBy('active_count')" role="columnheader button" style="text-align: right">
+                                Connectable {{ __('torrent.peers') }}
+                                @include('livewire.includes._sort-icon', ['field' => 'active_count'])
+                            </th>
+                            <th wire:click="sortBy('inactive_count')" role="columnheader button" style="text-align: right">
+                                Unconnectable {{ __('torrent.peers') }}
+                                @include('livewire.includes._sort-icon', ['field' => 'inactive_count'])
+                            </th>
+                        @endif
                         <th wire:click="sortBy('created_at')" role="columnheader button" style="text-align: right">
                             Started
                             @include('livewire.includes._sort-icon', ['field' => 'created_at'])
@@ -245,6 +268,18 @@
                                     <td style="text-align: right">{{ $peer->connectable_count }}</td>
                                     <td style="text-align: right">{{ $peer->unconnectable_count }}</td>
                                 @endif
+                            @endif
+                            @if ($groupBy === 'none')
+                                <td style="text-align: right">
+                                    @if ($peer->active)
+                                        <i class="{{ config('other.font-awesome') }} text-green fa-check" title="Active"></i>
+                                    @else
+                                        <i class="{{ config('other.font-awesome') }} text-red fa-times" title="Inactive"></i>
+                                    @endif
+                                </td>
+                            @else
+                                <td style="text-align: right">{{ $peer->active_count }}</td>
+                                <td style="text-align: right">{{ $peer->inactive_count }}</td>
                             @endif
                             <td style="text-align: right">{{ $peer->created_at?->diffForHumans() ?? 'N/A' }}</td>
                             <td style="text-align: right">{{ $peer->updated_at?->diffForHumans() ?? 'N/A' }}</td>

--- a/resources/views/livewire/user-active.blade.php
+++ b/resources/views/livewire/user-active.blade.php
@@ -20,6 +20,18 @@
                     </label>
                 </p>
                 <p class="form__group">
+                    <label style="user-select: none" class="form__label" x-data="{ state: @entangle('active'), ...ternaryCheckbox() }">
+                        <input
+                            type="checkbox"
+                            class="user-peers__checkbox"
+                            x-init="updateTernaryCheckboxProperties($el, state)"
+                            x-on:click="state = getNextTernaryCheckboxState(state); updateTernaryCheckboxProperties($el, state)"
+                            x-bind:checked="state === 'include'"
+                        >
+                        {{ __('common.active') }}
+                    </label>
+                </p>
+                <p class="form__group">
                     <label class="form__label">
                         <input type="checkbox" class="user-peers__checkbox" wire:model="showMorePrecision">
                         Show more precision

--- a/resources/views/torrent/peers.blade.php
+++ b/resources/views/torrent/peers.blade.php
@@ -89,7 +89,7 @@
                                     {{ $peer->updated_at ? $peer->updated_at->diffForHumans() : 'N/A' }}
                                 </time>
                             </td>
-                            <td class="{{ $peer->seeder ? 'text-green' : 'text-red' }}">
+                            <td class="{{ $peer->active ? ($peer->seeder ? 'text-green' : 'text-red') : 'text-orange' }}">
                                 @if ($peer->active)
                                     @if ($peer->seeder == 0)
                                         {{ __('torrent.leecher') }}

--- a/resources/views/user/profile/show.blade.php
+++ b/resources/views/user/profile/show.blade.php
@@ -508,6 +508,12 @@
                         </a>
                     </dt>
                     <dd>{{ $peers->leeching ?? 0 }}</dd>
+                    <dt>
+                        <a href="{{ route('users.peers.index', ['user' => $user, 'active' => 'exclude']) }}">
+                            Total Inactive Peers
+                        </a>
+                    </dt>
+                    <dd>{{ $peers->inactive ?? 0 }}</dd>
                 </dl>
             </section>
         @endif


### PR DESCRIPTION
Upsert the history records directly and do basic logic in mysql instead of pulling them into php and doing logic there.

Now that we upsert history records without first selecting them, we can't rely on storing a peer's last uploaded/downloaded values in the history record to determine the user's uploaded/downloaded delta between the last announce. If a user has internet issues for a brief period of time but their client continues working, then their change of upload/download between the two announces needs to be kept track of. This is usually kept track of in the peer record, but if the peer is deleted after 2 hours of not announcing, then their last uploaded/downloaded data is deleted with it. We previously stored this data in the history table to handle such cases but this became erroneous if the user had multiple peers on a torrent. This new solution keeps the peers in the database for 2 days before concluding that the peer isn't coming back and deletes the peer permanently. After which point, a new peer will be created and an assumption is made that they uploaded/downloaded 0 data within their downtime.