### PR TITLE
(Add) `pre` bbcode syntax for inline code

### DIFF
--- a/app/Helpers/Bbcode.php
+++ b/app/Helpers/Bbcode.php
@@ -177,6 +177,13 @@ class Bbcode
             'closeHtml'   => '</pre>',
             'block'       => true,
         ],
+        'pre' => [
+            'openBbcode'  => '/^\[pre\]/i',
+            'closeBbcode' => '[/pre]',
+            'openHtml'    => '<code>',
+            'closeHtml'   => '</code>',
+            'block'       => false,
+        ],
         'alert' => [
             'openBbcode'  => '/^\[alert\]/i',
             'closeBbcode' => '[/alert]',

--- a/resources/sass/components/_bbcode-rendered.scss
+++ b/resources/sass/components/_bbcode-rendered.scss
@@ -486,6 +486,9 @@
   tt {
     padding: 0.2em 0.4em;
     margin: 0;
+    word-break: normal;
+    overflow-wrap: anywhere;
+    white-space: normal;
     font-size: 13px;
     background-color: var(--bbcode-rendered-neutral-muted);
     border-radius: 6px;


### PR DESCRIPTION
These styles were already available via html and markdown for pages, but now it's available for bbcode as well.