### PR TITLE
(Fix) Race condition in download slot limit

### DIFF
--- a/app/Console/Commands/AutoCacheUserLeechCounts.php
+++ b/app/Console/Commands/AutoCacheUserLeechCounts.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * NOTICE OF LICENSE.
+ *
+ * UNIT3D Community Edition is open-sourced software licensed under the GNU Affero General Public License v3.0
+ * The details is bundled with this project in the file LICENSE.txt.
+ *
+ * @project    UNIT3D Community Edition
+ *
+ * @author     Roardom <roardom@protonmail.com>
+ * @license    https://www.gnu.org/licenses/agpl-3.0.en.html/ GNU Affero General Public License v3.0
+ */
+
+namespace App\Console\Commands;
+
+use App\Models\User;
+use Illuminate\Console\Command;
+use Exception;
+
+class AutoCacheUserLeechCounts extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'auto:cache_user_leech_counts';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Caches user leech counts';
+
+    /**
+     * Execute the console command.
+     *
+     * @throws Exception
+     */
+    public function handle(): void
+    {
+        $peerCounts = User::withoutGlobalScopes()
+            ->selectRaw("CONCAT('user-leeching-count:', id) as cacheKey")
+            ->selectRaw('(select COUNT(*) from peers where peers.user_id = users.id and seeder = 0) as count')
+            ->pluck('count', 'cacheKey')
+            ->toArray();
+
+        cache()->putMany($peerCounts);
+
+        $this->comment(\count($peerCounts).' user leech counts cached.');
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -27,6 +27,7 @@ class Kernel extends ConsoleKernel
         $schedule->command('auto:upsert_histories')->everyFiveSeconds();
         $schedule->command('auto:update_user_last_actions')->everyFiveSeconds();
         $schedule->command('auto:delete_stopped_peers')->everyTwoMinutes();
+        $schedule->command('auto:cache_user_leech_counts')->everyThirtyMinutes();
         $schedule->command('auto:group ')->daily();
         $schedule->command('auto:nerdstat ')->hourly();
         $schedule->command('auto:reward_resurrection')->daily();


### PR DESCRIPTION
There's a slight delay between the announce controller and when the job gets ran that could allow extra announces to get through before the controller registers the new count. Let's cache the leech count in redis instead.