### PR TITLE
(Update) Invalid torrent filenames

### DIFF
--- a/app/Helpers/TorrentTools.php
+++ b/app/Helpers/TorrentTools.php
@@ -200,18 +200,21 @@ class TorrentTools
     /**
      * Check if the filename is valid or not.
      */
-    public static function isValidFilename($filename): bool
+    public static function isValidFilename(string $filename): bool
     {
-        $result = true;
-
-        if (\strlen((string) $filename) > 255 ||
-            preg_match('#[/?<>\\:*|"\x00-\x1f]#', (string) $filename) ||
-            preg_match('#(^\.+|[\. ]+)$#', (string) $filename) ||
-            preg_match('#^(con|prn|aux|nul|com\d|lpt\d)(\..*)?$#i', (string) $filename)) {
-            $result = false;
-        }
-
-        return $result;
+        return !(
+            \strlen($filename) > 255
+            // nodes containing: `\`, `/`, `?`, `<`, `>`, `:`, `8`, `|`, and ascii characters from 0 through 31
+            || preg_match('/[\\\\\\/?<>:*|"\x00-\x1f]/', $filename)
+            // nodes only containing one or many: `.`; or only containing one or many `.`, ` `.
+            || preg_match('/(^\\.+|[. ]+)$/', $filename)
+            // Special windows filenames.
+            || preg_match('/^(con|prn|aux|nul|com\d|lpt\d)(\\..*)?$/i', $filename)
+            // BitComet padding files
+            || preg_match('/^\.?____padding.*$/i', $filename)
+            // BEP 47 torrent padding files that many clients aren't able to handle
+            || str_starts_with($filename, '.pad')
+        );
     }
 
     /**


### PR DESCRIPTION
A few escapes were missing. Added bitcomet and BEP 47 padding files because not all clients support them, and cause new torrents to be generated including the padding files as well as adding even more padding files into the torrent, exponentially including more and more files the more the torrent is crossed. Additionally, reformatted the code to include more comments.