### PR TITLE
(Update) Don't store announce url in torrent file

### DIFF
--- a/app/Helpers/TorrentTools.php
+++ b/app/Helpers/TorrentTools.php
@@ -47,10 +47,6 @@ class TorrentTools
             'pieces'       => '',
         ]);
 
-        // The PID will be set if an user downloads the torrent, but for
-        // security purposes it's better to overwrite the user-provided
-        // announce URL.
-        $result['announce'] = config('app.url').'/announce/PID';
         $result['info']['source'] = config('torrent.source');
         $result['info']['private'] = 1;
 

--- a/app/Http/Controllers/API/TorrentController.php
+++ b/app/Http/Controllers/API/TorrentController.php
@@ -142,7 +142,6 @@ class TorrentController extends BaseController
         $torrent->file_name = $fileName;
         $torrent->num_file = $meta['count'];
         $torrent->folder = Bencode::get_name($decodedTorrent);
-        $torrent->announce = $decodedTorrent['announce'];
         $torrent->size = $meta['size'];
         $torrent->nfo = ($request->hasFile('nfo')) ? TorrentTools::getNfo($request->file('nfo')) : '';
         $torrent->category_id = $category->id;
@@ -211,7 +210,6 @@ class TorrentController extends BaseController
             'info_hash'        => 'required|unique:torrents',
             'file_name'        => 'required',
             'num_file'         => 'required|numeric',
-            'announce'         => 'required',
             'size'             => 'required',
             'category_id'      => 'required|exists:categories,id',
             'type_id'          => 'required|exists:types,id',

--- a/app/Http/Controllers/TorrentController.php
+++ b/app/Http/Controllers/TorrentController.php
@@ -369,7 +369,6 @@ class TorrentController extends Controller
             'file_name'    => $fileName,
             'num_file'     => $meta['count'],
             'folder'       => Bencode::get_name($decodedTorrent),
-            'announce'     => $decodedTorrent['announce'],
             'size'         => $meta['size'],
             'nfo'          => $request->hasFile('nfo') ? TorrentTools::getNfo($request->file('nfo')) : '',
             'user_id'      => $user->id,

--- a/database/factories/TorrentFactory.php
+++ b/database/factories/TorrentFactory.php
@@ -34,7 +34,6 @@ class TorrentFactory extends Factory
             'seeders'         => $this->faker->randomNumber(),
             'times_completed' => $this->faker->randomNumber(),
             'category_id'     => fn () => Category::factory()->create()->id,
-            'announce'        => $this->faker->word(),
             'user_id'         => fn () => User::factory()->create()->id,
             'imdb'            => $this->faker->randomNumber(),
             'tvdb'            => $this->faker->randomNumber(),

--- a/database/migrations/2023_07_31_043749_drop_announce_column_from_torrents.php
+++ b/database/migrations/2023_07_31_043749_drop_announce_column_from_torrents.php
@@ -1,0 +1,14 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::table('torrents', function (Blueprint $table): void {
+            $table->dropColumn('announce');
+        });
+    }
+};


### PR DESCRIPTION
We previously overwrote the provided PID, but all we need to do is just delete it.