### PR TITLE
(Fix) Seedtime calculation

### DIFF
--- a/app/Console/Commands/AutoUpsertHistories.php
+++ b/app/Console/Commands/AutoUpsertHistories.php
@@ -85,7 +85,8 @@ class AutoUpsertHistories extends Command
                     'client_downloaded',
                     'seeder',
                     'active',
-                    'seedtime'     => DB::raw('IF(DATE_ADD(updated_at, INTERVAL 3600 SECOND) > VALUES(updated_at) AND seeder = 1 AND VALUES(seeder) = 1, seedtime + TIMESTAMPDIFF(SECOND, updated_at, VALUES(updated_at)), seedtime)'),
+                    // 5400 is the max announce interval defined in the announce controller
+                    'seedtime'     => DB::raw('IF(DATE_ADD(updated_at, INTERVAL 5400 SECOND) > VALUES(updated_at) AND seeder = 1 AND VALUES(seeder) = 1, seedtime + TIMESTAMPDIFF(SECOND, updated_at, VALUES(updated_at)), seedtime)'),
                     'immune'       => DB::raw('immune AND VALUES(immune)'),
                     'completed_at' => DB::raw('COALESCE(completed_at, VALUES(completed_at))'),
                 ],


### PR DESCRIPTION
The seedtime should only be incremented by the difference between now and the last announce if the last anounce is shorter than the maximum given time provided by the tracker. Otherwise, it shouldn't be incremented.