### PR TITLE
(Fix) Keep query parameters on inbox/outbox pagination

### DIFF
--- a/app/Http/Controllers/User/ReceivedPrivateMessageController.php
+++ b/app/Http/Controllers/User/ReceivedPrivateMessageController.php
@@ -42,7 +42,8 @@ class ReceivedPrivateMessageController extends Controller
                     fn ($query) => $query->where('subject', 'like', '%'.$request->string('subject').'%')
                 )
                 ->latest()
-                ->paginate(20),
+                ->paginate(20)
+                ->withQueryString(),
             'subject' => $request->subject ?? '',
         ]);
     }

--- a/app/Http/Controllers/User/SentPrivateMessageController.php
+++ b/app/Http/Controllers/User/SentPrivateMessageController.php
@@ -42,7 +42,8 @@ class SentPrivateMessageController extends Controller
                     fn ($query) => $query->where('subject', 'like', '%'.$request->string('subject').'%')
                 )
                 ->latest()
-                ->paginate(25),
+                ->paginate(25)
+                ->withQueryString(),
             'subject' => $request->subject ?? '',
         ]);
     }


### PR DESCRIPTION
Previously, navigating to page 2 wouldn't keep the query parameters so the pagination wouldn't show relevant search results.