### PR TITLE
(Update) Improve ticket search

### DIFF
--- a/app/Http/Livewire/TicketSearch.php
+++ b/app/Http/Livewire/TicketSearch.php
@@ -14,16 +14,20 @@
 namespace App\Http\Livewire;
 
 use App\Models\Ticket;
+use App\Models\User;
 use Livewire\Component;
 use Livewire\WithPagination;
 
+/**
+ * @property \Illuminate\Contracts\Pagination\LengthAwarePaginator $tickets
+ */
 class TicketSearch extends Component
 {
     use WithPagination;
 
-    public ?\Illuminate\Contracts\Auth\Authenticatable $user = null;
+    public ?User $user = null;
 
-    public bool $show = false;
+    public string $tab = 'open';
 
     public int $perPage = 25;
 
@@ -35,7 +39,7 @@ class TicketSearch extends Component
 
     protected $queryString = [
         'search' => ['except' => ''],
-        'show'   => ['except' => false],
+        'tab'    => ['except' => 'open'],
     ];
 
     final public function mount(): void
@@ -53,35 +57,21 @@ class TicketSearch extends Component
         $this->resetPage();
     }
 
-    final public function updatingShow(): void
+    final public function updatingTab(): void
     {
         $this->resetPage();
     }
 
-    final public function toggleProperties($property): void
-    {
-        if ($property === 'show') {
-            $this->show = ! $this->show;
-        }
-    }
-
     final public function getTicketsProperty(): \Illuminate\Contracts\Pagination\LengthAwarePaginator
     {
-        if ($this->user->group->is_modo) {
-            return Ticket::query()
-                ->with(['user.group', 'staff.group', 'category', 'priority'])
-                ->when($this->show === false, fn ($query) => $query->whereNull('closed_at'))
-                ->when($this->show, fn ($query) => $query->whereNotNull('closed_at'))
-                ->when($this->search, fn ($query) => $query->where('subject', 'LIKE', '%'.$this->search.'%'))
-                ->orderBy($this->sortField, $this->sortDirection)
-                ->paginate($this->perPage);
-        }
-
         return Ticket::query()
             ->with(['user.group', 'staff.group', 'category', 'priority'])
-            ->where('user_id', '=', $this->user->id)
-            ->when($this->show === false, fn ($query) => $query->whereNull('closed_at'))
-            ->when($this->show, fn ($query) => $query->whereNotNull('closed_at'))
+            ->when(! $this->user->group->is_modo, fn ($query) => $query->where('user_id', '=', $this->user->id))
+            ->when(
+                $this->tab === 'open',
+                fn ($query) => $query->whereNull('closed_at'),
+                fn ($query) => $query->whereNotNull('closed_at')
+            )
             ->when($this->search, fn ($query) => $query->where('subject', 'LIKE', '%'.$this->search.'%'))
             ->orderBy($this->sortField, $this->sortDirection)
             ->paginate($this->perPage);

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -961,21 +961,6 @@ parameters:
 			path: app/Http/Livewire/ThankButton.php
 
 		-
-			message: "#^Access to an undefined property App\\\\Http\\\\Livewire\\\\TicketSearch\\:\\:\\$tickets\\.$#"
-			count: 1
-			path: app/Http/Livewire/TicketSearch.php
-
-		-
-			message: "#^Access to an undefined property Illuminate\\\\Contracts\\\\Auth\\\\Authenticatable\\:\\:\\$group\\.$#"
-			count: 1
-			path: app/Http/Livewire/TicketSearch.php
-
-		-
-			message: "#^Access to an undefined property Illuminate\\\\Contracts\\\\Auth\\\\Authenticatable\\:\\:\\$id\\.$#"
-			count: 1
-			path: app/Http/Livewire/TicketSearch.php
-
-		-
 			message: "#^Access to an undefined property App\\\\Http\\\\Livewire\\\\Top10\\:\\:\\$personalFreeleech\\.$#"
 			count: 1
 			path: app/Http/Livewire/Top10.php

--- a/resources/sass/components/_panel.scss
+++ b/resources/sass/components/_panel.scss
@@ -100,6 +100,10 @@
     background-color: var(--data-table-th-bg);
 }
 
+.panel__tabs--centered {
+    justify-content: space-around;
+}
+
 .panel__tab {
     background-color: var(--data-table-th-fg);
     padding: 8px 16px 6px 16px;
@@ -107,6 +111,11 @@
     border-bottom: 2px solid var(--data-table-th-fg);
     cursor: pointer;
     white-space: nowrap;
+}
+
+.panel__tab--full-width {
+    flex: 1;
+    text-align: center;
 }
 
 .panel__tab--active {

--- a/resources/views/livewire/ticket-search.blade.php
+++ b/resources/views/livewire/ticket-search.blade.php
@@ -1,20 +1,7 @@
-<section class="panelV2">
+<section class="panelV2" x-data="{ tab: @entangle('tab') }">
     <header class="panel__header">
         <h2 class="panel__heading">{{ __('ticket.helpdesk') }}</h2>
         <div class="panel__actions">
-            <div class="panel__action">
-                <div class="form__group">
-                    <input
-                        id="show"
-                        class="form__checkbox"
-                        type="checkbox"
-                        wire:click="toggleProperties('show')"
-                    >
-                    <label class="form__label" for="show">
-                        Show Closed Tickets
-                    </label>
-                </div>
-            </div>
             <div class="panel__action">
                 <div class="form__group">
                     <select
@@ -27,7 +14,7 @@
                         <option>50</option>
                         <option>100</option>
                     </select>
-                    <label class="form__label form__label--floating">
+                    <label class="form__label form__label--floating" for="quantity">
                         {{ __('common.quantity') }}
                     </label>
                 </div>
@@ -41,7 +28,7 @@
                         wire:model="search"
                         placeholder=" "
                     />
-                    <label class="form__label form__label--floating">
+                    <label class="form__label form__label--floating" for="search">
                         {{ __('ticket.subject') }}
                     </label>
                 </div>
@@ -53,6 +40,26 @@
             </div>
         </div>
     </header>
+    <menu class="panel__tabs panel__tabs--centered">
+        <li
+            class="panel__tab panel__tab--full-width"
+            role="tab"
+            x-bind:class="tab === 'open' && 'panel__tab--active'"
+            x-cloak
+            x-on:click="tab = 'open'"
+        >
+            Open
+        </li>
+        <li
+            class="panel__tab panel__tab--full-width"
+            role="tab"
+            x-bind:class="tab === 'closed' && 'panel__tab--active'"
+            x-cloak
+            x-on:click="tab = 'closed'"
+        >
+            Closed
+        </li>
+    </menu>
     <div class="data-table-wrapper">
         <table class="data-table">
             <tbody>
@@ -73,10 +80,6 @@
                     {{ __('common.username') }}
                     @include('livewire.includes._sort-icon', ['field' => 'user_id'])
                 </th>
-                <th wire:click="sortBy('closed_at')" role="columnheader button">
-                    {{ __('common.status') }}
-                    @include('livewire.includes._sort-icon', ['field' => 'closed_at'])
-                </th>
                 <th wire:click="sortBy('staff_id')" role="columnheader button">
                     {{ __('ticket.assigned-staff') }}
                     @include('livewire.includes._sort-icon', ['field' => 'staff_id'])
@@ -84,6 +87,14 @@
                 <th wire:click="sortBy('created_at')" role="columnheader button">
                     {{ __('ticket.created') }}
                     @include('livewire.includes._sort-icon', ['field' => 'created_at'])
+                </th>
+                <th wire:click="sortBy('updated_at')" role="columnheader button">
+                    {{ __('torrent.updated') }}
+                    @include('livewire.includes._sort-icon', ['field' => 'updated_at'])
+                </th>
+                <th wire:click="sortBy('closed_at')" role="columnheader button">
+                    {{ __('ticket.closed') }}
+                    @include('livewire.includes._sort-icon', ['field' => 'closed_at'])
                 </th>
                 <th>{{ __('common.action') }}</th>
             </tr>
@@ -123,15 +134,6 @@
                         <x-user_tag :user="$ticket->user" :anon="false" />
                     </td>
                     <td>
-                        @if($ticket->closed_at)
-                            <i class="fas fa-circle text-danger"></i>
-                            Closed
-                        @else
-                            <i class="fas fa-circle text-success"></i>
-                            Open
-                        @endif
-                    </td>
-                    <td>
                         @if ($ticket->staff)
                             <x-user_tag :user="$ticket->staff" :anon="false" />
                         @else
@@ -141,6 +143,16 @@
                     <td>
 						<time datetime="{{ $ticket->created_at }}" title="{{ $ticket->created_at }}">
 							{{ $ticket->created_at->diffForHumans() }}
+                        </time>
+                    </td>
+                    <td>
+                        <time datetime="{{ $ticket->updated_at }}" title="{{ $ticket->updated_at }}">
+                            {{ $ticket->updated_at->diffForHumans() }}
+                        </time>
+                    </td>
+                    <td>
+                        <time datetime="{{ $ticket->closed_at }}" title="{{ $ticket->closed_at }}">
+                            {{ $ticket->closed_at?->diffForHumans() ?? 'N/A' }}
                         </time>
                     </td>
                     <td>


### PR DESCRIPTION
Entangle the "show closed ticket" state using alpinejs. Change the "show closed ticket" from a checkbox to two tabs showing open and closed tickets respectively. Remove the "closed" indicator because all tickets are either open or closed depending on the tab. Add an updated_at column as that's the default sort order.