### PR TITLE
(Fix) Peer seeder strict type

### DIFF
--- a/resources/views/livewire/user-active.blade.php
+++ b/resources/views/livewire/user-active.blade.php
@@ -186,7 +186,7 @@
                         @endif
                         <td class="user-active__seeding">
                             @if ($active->active)
-                                @if ($active->seeder === 1)
+                                @if ($active->seeder)
                                     <i class="{{ config('other.font-awesome') }} text-green fa-check" title="{{ __('torrent.seeding') }}"></i>
                                 @else
                                     <i class="{{ config('other.font-awesome') }} text-red fa-times" title="Not {{ __('torrent.seeding') }}"></i>

--- a/resources/views/torrent/peers.blade.php
+++ b/resources/views/torrent/peers.blade.php
@@ -104,12 +104,10 @@
                             </td>
                             <td class="{{ $peer->active ? ($peer->seeder ? 'text-green' : 'text-red') : 'text-orange' }}">
                                 @if ($peer->active)
-                                    @if ($peer->seeder == 0)
-                                        {{ __('torrent.leecher') }}
-                                    @elseif ($peer->seeder == 1)
+                                    @if ($peer->seeder)
                                         {{ __('torrent.seeder') }}
                                     @else
-                                        {{ __('common.error') }}
+                                        {{ __('torrent.leecher') }}
                                     @endif
                                 @else
                                     Inactive


### PR DESCRIPTION
We cast this value to boolean on the model now so comparing to `0` and  `1` aren't necessary.