### PR TITLE
(Update) Sort peers descending by default

### DIFF
--- a/app/Http/Livewire/PeerSearch.php
+++ b/app/Http/Livewire/PeerSearch.php
@@ -217,7 +217,7 @@ class PeerSearch extends Component
         if ($this->sortField === $field) {
             $this->sortDirection = $this->sortDirection === 'asc' ? 'desc' : 'asc';
         } else {
-            $this->sortDirection = 'asc';
+            $this->sortDirection = 'desc';
         }
 
         $this->sortField = $field;


### PR DESCRIPTION
Most times when you go to sort a column on this page, you want to sort in descending order, so defaulting it to descending saves an extra click and some seconds of page load time.