### PR TITLE
(Fix) Double html entity encoding

### DIFF
--- a/app/Http/Requests/UpdatePlaylistRequest.php
+++ b/app/Http/Requests/UpdatePlaylistRequest.php
@@ -15,7 +15,6 @@ namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Http\Request;
-use voku\helper\AntiXSS;
 
 /**
  * @see \Tests\Todo\Unit\Http\Requests\VoteOnPollTest
@@ -35,8 +34,6 @@ class UpdatePlaylistRequest extends FormRequest
      */
     public function rules(Request $request): array
     {
-        $this->sanitize();
-
         return [
             'name' => [
                 'required',
@@ -51,14 +48,5 @@ class UpdatePlaylistRequest extends FormRequest
                 'boolean',
             ],
         ];
-    }
-
-    private function sanitize(): void
-    {
-        $input = $this->all();
-
-        $input['description'] = htmlspecialchars((new AntiXSS())->xss_clean($input['description']), ENT_NOQUOTES);
-
-        $this->replace($input);
     }
 }

--- a/app/Http/Requests/UpdateTorrentRequest.php
+++ b/app/Http/Requests/UpdateTorrentRequest.php
@@ -19,7 +19,6 @@ use App\Models\Torrent;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Http\Request;
 use Illuminate\Validation\Rule;
-use voku\helper\AntiXSS;
 
 class UpdateTorrentRequest extends FormRequest
 {
@@ -36,8 +35,6 @@ class UpdateTorrentRequest extends FormRequest
      */
     public function rules(Request $request): array
     {
-        $this->sanitize();
-
         $category = Category::findOrFail($request->integer('category_id'));
 
         return [
@@ -144,14 +141,5 @@ class UpdateTorrentRequest extends FormRequest
                 Rule::when(! $request->user()->group->is_modo && ! $request->user()->group->is_internal, 'prohibited'),
             ],
         ];
-    }
-
-    private function sanitize(): void
-    {
-        $input = $this->all();
-
-        $input['description'] = htmlspecialchars((new AntiXSS())->xss_clean($input['description']), ENT_NOQUOTES);
-
-        $this->replace($input);
     }
 }

--- a/app/Http/Requests/UpdateTorrentRequestRequest.php
+++ b/app/Http/Requests/UpdateTorrentRequestRequest.php
@@ -14,7 +14,6 @@
 namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
-use voku\helper\AntiXSS;
 
 class UpdateTorrentRequestRequest extends FormRequest
 {
@@ -31,8 +30,6 @@ class UpdateTorrentRequestRequest extends FormRequest
      */
     public function rules(): array
     {
-        $this->sanitize();
-
         return [
             'name' => [
                 'required',
@@ -79,14 +76,5 @@ class UpdateTorrentRequestRequest extends FormRequest
                 'boolean',
             ],
         ];
-    }
-
-    private function sanitize(): void
-    {
-        $input = $this->all();
-
-        $input['description'] = htmlspecialchars((new AntiXSS())->xss_clean($input['description']), ENT_NOQUOTES);
-
-        $this->replace($input);
     }
 }


### PR DESCRIPTION
Caused by redundant sanitization already present in the Model setter functions.

I was originally under the impression that mass assignment bypassed Model setter functions, but seems that's only when you use the query builder. 