### PR TITLE
(Fix) Allow users to reject their own requests

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -163,7 +163,7 @@ Route::middleware('language')->group(function (): void {
 
             Route::prefix('{torrentRequest}/fills')->name('fills.')->group(function (): void {
                 Route::post('/', [App\Http\Controllers\RequestFillController::class, 'store'])->name('store');
-                Route::delete('/', [App\Http\Controllers\RequestFillController::class, 'destroy'])->name('destroy')->middleware('modo');
+                Route::delete('/', [App\Http\Controllers\RequestFillController::class, 'destroy'])->name('destroy');
             });
 
             Route::prefix('{torrentRequest}/approved-fills')->name('approved_fills.')->group(function (): void {


### PR DESCRIPTION
Users should be able to reject fills on their requests. Currently the logic is correct in the controller, but the middleware here is overriding it.