### PR TITLE
(Update) Harden user security setting editing

### DIFF
--- a/app/Http/Controllers/Staff/UserController.php
+++ b/app/Http/Controllers/Staff/UserController.php
@@ -72,7 +72,7 @@ class UserController extends Controller
         $staff = $request->user();
         $group = Group::findOrFail($request->group_id);
 
-        abort_if(! $staff->group->is_owner && ($staff->group->level < $user->group->level || $staff->group->level < $group->level), 403);
+        abort_if(! $staff->group->is_owner && ($staff->group->level <= $user->group->level || $staff->group->level <= $group->level), 403);
 
         $user->update($request->validated());
 

--- a/app/Http/Controllers/User/ApikeyController.php
+++ b/app/Http/Controllers/User/ApikeyController.php
@@ -30,7 +30,7 @@ class ApikeyController extends Controller
 
         $changedByStaff = $request->user()->isNot($user);
 
-        abort_if($changedByStaff && ! $request->user()->group->is_owner && $request->user()->group->level < $user->group->level, 403);
+        abort_if($changedByStaff && ! $request->user()->group->is_owner && $request->user()->group->level <= $user->group->level, 403);
 
         $user->update([
             'api_token' => Str::random(100),

--- a/app/Http/Controllers/User/EmailController.php
+++ b/app/Http/Controllers/User/EmailController.php
@@ -31,7 +31,7 @@ class EmailController extends Controller
 
         $changedByStaff = $request->user()->isNot($user);
 
-        abort_if($changedByStaff && ! $request->user()->group->is_owner && $request->user()->group->level < $user->group->level, 403);
+        abort_if($changedByStaff && ! $request->user()->group->is_owner && $request->user()->group->level <= $user->group->level, 403);
 
         $request->validate([
             'email' => [

--- a/app/Http/Controllers/User/PasskeyController.php
+++ b/app/Http/Controllers/User/PasskeyController.php
@@ -30,7 +30,7 @@ class PasskeyController extends Controller
 
         $changedByStaff = $request->user()->isNot($user);
 
-        abort_if($changedByStaff && ! $request->user()->group->is_owner && $request->user()->group->level < $user->group->level, 403);
+        abort_if($changedByStaff && ! $request->user()->group->is_owner && $request->user()->group->level <= $user->group->level, 403);
 
         $user->update([
             'passkey' => md5(random_bytes(60).$user->password)

--- a/app/Http/Controllers/User/PasswordController.php
+++ b/app/Http/Controllers/User/PasswordController.php
@@ -32,7 +32,7 @@ class PasswordController extends Controller
 
         $changedByStaff = $request->user()->isNot($user);
 
-        abort_if($changedByStaff && ! $request->user()->group->is_owner && $request->user()->group->level < $user->group->level, 403);
+        abort_if($changedByStaff && ! $request->user()->group->is_owner && $request->user()->group->level <= $user->group->level, 403);
 
         $request->validate([
             'current_password' => Rule::when(! $changedByStaff, [

--- a/app/Http/Controllers/User/RsskeyController.php
+++ b/app/Http/Controllers/User/RsskeyController.php
@@ -29,7 +29,7 @@ class RsskeyController extends Controller
 
         $changedByStaff = $request->user()->isNot($user);
 
-        abort_if($changedByStaff && ! $request->user()->group->is_owner && $request->user()->group->level < $user->group->level, 403);
+        abort_if($changedByStaff && ! $request->user()->group->is_owner && $request->user()->group->level <= $user->group->level, 403);
 
         $user->update([
             'rsskey' => md5(random_bytes(60).$user->password),

--- a/app/Http/Controllers/User/TwoStepController.php
+++ b/app/Http/Controllers/User/TwoStepController.php
@@ -29,7 +29,7 @@ class TwoStepController extends Controller
 
         $changedByStaff = $request->user()->isNot($user);
 
-        abort_if($changedByStaff && ! $request->user()->group->is_owner && $request->user()->group->level < $user->group->level, 403);
+        abort_if($changedByStaff && ! $request->user()->group->is_owner && $request->user()->group->level <= $user->group->level, 403);
 
         $request->validate([
             'twostep' => 'required|boolean',


### PR DESCRIPTION
Although convenient for staff to be able to edit users of the same rank, this presents a security risk