### PR TITLE
(Fix) History upsert seedtime

### DIFF
--- a/app/Console/Commands/AutoUpsertHistories.php
+++ b/app/Console/Commands/AutoUpsertHistories.php
@@ -83,10 +83,12 @@ class AutoUpsertHistories extends Command
                     'downloaded'        => DB::raw('downloaded + VALUES(downloaded)'),
                     'actual_downloaded' => DB::raw('actual_downloaded + VALUES(actual_downloaded)'),
                     'client_downloaded',
-                    'seeder',
                     'active',
                     // 5400 is the max announce interval defined in the announce controller
-                    'seedtime'     => DB::raw('IF(DATE_ADD(updated_at, INTERVAL 5400 SECOND) > VALUES(updated_at) AND seeder = 1 AND VALUES(seeder) = 1, seedtime + TIMESTAMPDIFF(SECOND, updated_at, VALUES(updated_at)), seedtime)'),
+                    // We need to make sure seeder is updated after seedtime, otherwise the seedtime logic for ensuring left was 0 in the last announce breaks.
+                    // Unfortunately, laravel sorts the keys in this array alphabetically when inserting so reordering the keys themselves in this array doesn't work.
+                    // This leaves us with this hacky fix.
+                    'seedtime'     => DB::raw('IF(DATE_ADD(updated_at, INTERVAL 5400 SECOND) > VALUES(updated_at) AND seeder = 1 AND VALUES(seeder) = 1, seedtime + TIMESTAMPDIFF(SECOND, updated_at, VALUES(updated_at)), seedtime), seeder = VALUES(seeder)'),
                     'immune'       => DB::raw('immune AND VALUES(immune)'),
                     'completed_at' => DB::raw('COALESCE(completed_at, VALUES(completed_at))'),
                 ],


### PR DESCRIPTION
It turns out Laravel will sort the keys in the upsert array alphabetically. This breaks the logic for seedtime calculation which ensures to only increase the seedtime if the previous announce had a `seeder` value of 1. To fix this, we include the sql code necessary to update the `seeder` column inside the `DB::raw()` statement of the `seedtime` update, to make sure `seeder` is updated after `seedtime`. A hacky solution, but seems to be the best way to go about it for now.