### PR TITLE
(Fix) History upsert seedtime

### DIFF
--- a/app/Console/Commands/AutoUpsertHistories.php
+++ b/app/Console/Commands/AutoUpsertHistories.php
@@ -83,12 +83,11 @@ class AutoUpsertHistories extends Command
                     'downloaded'        => DB::raw('downloaded + VALUES(downloaded)'),
                     'actual_downloaded' => DB::raw('actual_downloaded + VALUES(actual_downloaded)'),
                     'client_downloaded',
-                    'active',
                     // 5400 is the max announce interval defined in the announce controller
-                    // We need to make sure seeder is updated after seedtime, otherwise the seedtime logic for ensuring left was 0 in the last announce breaks.
+                    // We need to make sure seeder and active are updated after seedtime, otherwise the seedtime logic for ensuring it's not a new announce and the left was 0 in the last announce breaks.
                     // Unfortunately, laravel sorts the keys in this array alphabetically when inserting so reordering the keys themselves in this array doesn't work.
                     // This leaves us with this hacky fix.
-                    'seedtime'     => DB::raw('IF(DATE_ADD(updated_at, INTERVAL 5400 SECOND) > VALUES(updated_at) AND seeder = 1 AND VALUES(seeder) = 1, seedtime + TIMESTAMPDIFF(SECOND, updated_at, VALUES(updated_at)), seedtime), seeder = VALUES(seeder)'),
+                    'seedtime'     => DB::raw('IF(DATE_ADD(updated_at, INTERVAL 5400 SECOND) > VALUES(updated_at) AND seeder = 1 AND active = 1 AND VALUES(seeder) = 1, seedtime + TIMESTAMPDIFF(SECOND, updated_at, VALUES(updated_at)), seedtime), seeder = VALUES(seeder), active = VALUES(active)'),
                     'immune'       => DB::raw('immune AND VALUES(immune)'),
                     'completed_at' => DB::raw('COALESCE(completed_at, VALUES(completed_at))'),
                 ],


### PR DESCRIPTION
We need to prevent seedtime from incrementing if the user pauses the torrent and then reannounces before the next announce