### PR TITLE
(Update) Allow viewing of user inactive peers

### DIFF
--- a/app/Http/Livewire/UserActive.php
+++ b/app/Http/Livewire/UserActive.php
@@ -101,7 +101,6 @@ class UserActive extends Component
             ->selectRaw('INET6_NTOA(ip) as ip')
             ->selectRaw('(1 - (peers.left / NULLIF(torrents.size, 0))) AS progress')
             ->where('peers.user_id', '=', $this->user->id)
-            ->where('active', '=', 1)
             ->when(
                 $this->name,
                 fn ($query) => $query


### PR DESCRIPTION
This wasn't intended to filter only active peers, but just be the default in the already available search filter.