### PR TITLE
(Update) Prevent announce/rss/api from using some middleware

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -32,10 +32,6 @@ class Kernel extends HttpKernel
         \Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class,
         //\App\Http\Middleware\TrustProxies::class,
         \Illuminate\Http\Middleware\HandleCors::class,
-
-        // Extra
-        \HDVinnie\SecureHeaders\SecureHeadersMiddleware::class,
-        \App\Http\Middleware\Http2ServerPush::class,
     ];
 
     /**
@@ -53,6 +49,8 @@ class Kernel extends HttpKernel
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
             \App\Http\Middleware\VerifyCsrfToken::class,
             \App\Http\Middleware\UpdateLastAction::class,
+            \HDVinnie\SecureHeaders\SecureHeadersMiddleware::class,
+            \App\Http\Middleware\Http2ServerPush::class,
             //'throttle:web',
         ],
         'api' => [


### PR DESCRIPTION
The announce, rss and api have no use for HTTP2 server push, nor do they need all the extra web browser headers added.