### PR TITLE
(Update) Make comment replies more intuitive

### DIFF
--- a/resources/sass/components/_comment.scss
+++ b/resources/sass/components/_comment.scss
@@ -5,15 +5,20 @@
     display: flex;
     flex-direction: column;
     row-gap: 18px;
+    background-color: inherit;
 }
 
 .comment__reply-list {
     list-style-type: none;
-    margin: 20px 0 20px 155px;
+    margin: 20px 0 0 155px;
     padding: 0;
     display: flex;
     flex-direction: column;
     row-gap: 18px;
+}
+
+.comment__list-item {
+    background-color: inherit;
 }
 
 .comment {
@@ -139,4 +144,17 @@
 
 .edit-comment {
     margin: 0 12px;
+}
+
+.new-comment {
+    padding-bottom: 12px;
+}
+
+.reply-comment {
+    margin-left: 155px;
+    background-color: inherit;
+}
+
+.comment__replies {
+    background-color: inherit;
 }

--- a/resources/views/livewire/comments.blade.php
+++ b/resources/views/livewire/comments.blade.php
@@ -4,7 +4,7 @@
         {{ __('common.comments') }}
     </h4>
     <div class="panel__body">
-        <form wire:submit.prevent="postComment" class="form new-comment">
+        <form wire:submit.prevent="postComment" class="form new-comment" x-data="{ open: false }">
             <p class="form__group">
                 <textarea
                     name="comment"
@@ -13,6 +13,7 @@
                     aria-describedby="new-comment__textarea-hint"
                     wire:model.defer="newCommentState.content"
                     required
+                    x-on:focus="open = true"
                 ></textarea>
                 <label for="new-comment__textarea" class="form__label form__label--floating">
                     @error('newCommentState.content')
@@ -24,11 +25,11 @@
                     <span class="form__hint" id="new-comment__textarea-hint">{{ $message }}</span>
                 @enderror
             </p>
-            <p class="form__group">
+            <p class="form__group" x-show="open" x-cloak>
                 <input type="checkbox" id="anon" class="form__checkbox" wire:model="anon">
                 <label for="anon" class="form__label">{{ __('common.anonymous') }}?</label>
             </p>
-            <p class="form__group">
+            <p class="form__group" x-show="open" x-cloak>
                 <button type="submit" class="form__button form__button--filled">
                     Comment
                 </button>


### PR DESCRIPTION
- Have a textarea at the bottom of any existing reply chain.
- Hide the comment/cancel/anonymous buttons until the textarea is focused.
- Fix textarea label overlapping with border.