### PR TITLE
(Update) Use foreign key constraints for forum and topics ids

### DIFF
--- a/app/Http/Controllers/ForumCategoryController.php
+++ b/app/Http/Controllers/ForumCategoryController.php
@@ -29,7 +29,7 @@ class ForumCategoryController extends Controller
         $forum = Forum::findOrFail($id);
 
         // Check if this is a category or forum
-        if ($forum->parent_id != 0) {
+        if ($forum->parent_id !== null) {
             return to_route('forums.show', ['id' => $forum->id]);
         }
 

--- a/app/Http/Controllers/ForumController.php
+++ b/app/Http/Controllers/ForumController.php
@@ -35,7 +35,7 @@ class ForumController extends Controller
                         ->whereRelation('permissions', [['show_forum', '=', 1], ['group_id', '=', $request->user()->group_id]]),
                     'forums.latestPoster',
                 ])
-                ->where('parent_id', '=', 0)
+                ->whereNull('parent_id')
                 ->whereRelation('permissions', [['show_forum', '=', 1], ['group_id', '=', $request->user()->group_id]])
                 ->orderBy('position')
                 ->get(),
@@ -54,7 +54,7 @@ class ForumController extends Controller
         $forum = Forum::findOrFail($id);
 
         // Check if this is a category or forum
-        if ($forum->parent_id == 0) {
+        if ($forum->parent_id === null) {
             return to_route('forums.categories.show', ['id' => $forum->id]);
         }
 

--- a/app/Http/Controllers/Staff/ForumController.php
+++ b/app/Http/Controllers/Staff/ForumController.php
@@ -34,7 +34,7 @@ class ForumController extends Controller
     {
         return view('Staff.forum.index', [
             'categories' => Forum::orderBy('position')
-                ->where('parent_id', '=', 0)
+                ->whereNull('parent_id')
                 ->with(['forums' => fn ($query) => $query->orderBy('position')])
                 ->get(),
         ]);
@@ -46,7 +46,7 @@ class ForumController extends Controller
     public function create(): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
     {
         return view('Staff.forum.create', [
-            'categories' => Forum::where('parent_id', '=', 0)->get(),
+            'categories' => Forum::whereNull('parent_id')->get(),
             'groups'     => Group::all(),
         ]);
     }
@@ -106,7 +106,7 @@ class ForumController extends Controller
     public function edit(Forum $forum): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
     {
         return view('Staff.forum.edit', [
-            'categories' => Forum::where('parent_id', '=', 0)->get(),
+            'categories' => Forum::whereNull('parent_id')->get(),
             'groups'     => Group::all(),
             'forum'      => $forum->load('permissions'),
         ]);
@@ -122,7 +122,7 @@ class ForumController extends Controller
         $forum->update(
             [
                 'slug'      => Str::slug($request->title),
-                'parent_id' => $request->forum_type === 'category' ? 0 : $request->parent_id,
+                'parent_id' => $request->forum_type === 'category' ? null : $request->parent_id,
             ]
             + $request->safe()->only(['name', 'position', 'description'])
         );
@@ -162,7 +162,7 @@ class ForumController extends Controller
     {
         $forum->permissions()->delete();
 
-        if ($forum->parent_id == 0) {
+        if ($forum->parent_id === null) {
             $category = $forum;
 
             foreach ($category->forums as $forum) {

--- a/app/Http/Controllers/TopicController.php
+++ b/app/Http/Controllers/TopicController.php
@@ -200,7 +200,7 @@ class TopicController extends Controller
             ['show_forum', '=', 1],
             ['start_topic', '=', 1],
         ])
-            ->where('parent_id', '=', 0)
+            ->whereNull('parent_id')
             ->with([
                 'forums' => fn ($query) => $query->whereRelation('permissions', [
                     ['show_forum', '=', 1],

--- a/app/Http/Livewire/SubscribedForum.php
+++ b/app/Http/Livewire/SubscribedForum.php
@@ -25,7 +25,7 @@ class SubscribedForum extends Component
     {
         return Forum::query()
             ->with('latestPoster')
-            ->where('parent_id', '!=', 0)
+            ->whereNotNull('parent_id')
             ->whereRelation('subscribedUsers', 'users.id', '=', auth()->id())
             ->whereRelation('permissions', [['show_forum', '=', 1], ['group_id', '=', auth()->user()->group_id]])
             ->orderBy('position')

--- a/app/Http/Livewire/TopicSearch.php
+++ b/app/Http/Livewire/TopicSearch.php
@@ -56,7 +56,7 @@ class TopicSearch extends Component
             ->with(['forums' => fn ($query) => $query
                 ->whereRelation('permissions', [['show_forum', '=', 1], ['group_id', '=', auth()->user()->group_id]])
             ])
-            ->where('parent_id', '=', 0)
+            ->whereNull('parent_id')
             ->whereRelation('permissions', [['show_forum', '=', 1], ['group_id', '=', auth()->user()->group_id]])
             ->orderBy('position')
             ->get();

--- a/app/Http/Requests/Staff/StoreForumRequest.php
+++ b/app/Http/Requests/Staff/StoreForumRequest.php
@@ -41,7 +41,8 @@ class StoreForumRequest extends FormRequest
                 'required',
             ],
             'parent_id' => [
-                'required',
+                'sometimes',
+                'nullable',
                 'integer',
             ],
             'permissions' => [

--- a/app/Http/Requests/Staff/UpdateForumRequest.php
+++ b/app/Http/Requests/Staff/UpdateForumRequest.php
@@ -41,7 +41,8 @@ class UpdateForumRequest extends FormRequest
                 'required',
             ],
             'parent_id' => [
-                'required',
+                'sometimes',
+                'nullable',
                 'integer',
             ],
             'permissions' => [

--- a/database/migrations/2023_08_13_234828_add_forum_foreign_key_constraints.php
+++ b/database/migrations/2023_08_13_234828_add_forum_foreign_key_constraints.php
@@ -1,0 +1,109 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        // Topic id
+
+        Schema::table('topics', function (Blueprint $table): void {
+            $table->increments('id')->change();
+        });
+
+        // Subscriptions topic_id
+
+        DB::table('subscriptions')
+            ->whereNotIn('topic_id', DB::table('topics')->select('id'))
+            ->whereNotNull('topic_id')
+            ->delete();
+
+        Schema::table('subscriptions', function (Blueprint $table): void {
+            $table->unsignedInteger('topic_id')->change();
+            $table->foreign('topic_id')->references('id')->on('topics')->cascadeOnUpdate()->cascadeOnDelete();
+        });
+
+        // Posts topic_id
+
+        DB::table('posts')
+            ->whereNotIn('topic_id', DB::table('topics')->select('id'))
+            ->whereNotNull('topic_id')
+            ->delete();
+
+        Schema::table('posts', function (Blueprint $table): void {
+            $table->unsignedInteger('topic_id')->change();
+            $table->foreign('topic_id')->references('id')->on('topics')->cascadeOnUpdate()->cascadeOnDelete();
+        });
+
+        // Forums last_topic_id
+
+        DB::table('forums')
+            ->whereNotIn('last_topic_id', DB::table('topics')->select('id'))
+            ->whereNotNull('last_topic_id')
+            ->update([
+                'last_topic_id' => null,
+            ]);
+
+        Schema::table('forums', function (Blueprint $table): void {
+            $table->unsignedInteger('last_topic_id')->change();
+            $table->foreign('last_topic_id')->references('id')->on('topics')->cascadeOnUpdate()->nullOnDelete();
+        });
+
+        // Forums id
+
+        Schema::table('forums', function (Blueprint $table): void {
+            $table->smallIncrements('id')->change();
+        });
+
+        // Subscriptions forum_id
+
+        DB::table('subscriptions')
+            ->whereNotIn('forum_id', DB::table('forums')->select('id'))
+            ->whereNotNull('forum_id')
+            ->delete();
+
+        Schema::table('subscriptions', function (Blueprint $table): void {
+            $table->unsignedSmallInteger('forum_id')->change();
+            $table->foreign('forum_id')->references('id')->on('forums')->cascadeOnUpdate()->cascadeOnDelete();
+        });
+
+        // Topics forum_id
+
+        DB::table('topics')
+            ->whereNotIn('forum_id', DB::table('forums')->select('id'))
+            ->delete();
+
+        Schema::table('topics', function (Blueprint $table): void {
+            $table->unsignedSmallInteger('forum_id')->change();
+            $table->foreign('forum_id')->references('id')->on('forums')->cascadeOnUpdate()->cascadeOnDelete();
+        });
+
+        // Permissions forum_id
+
+        DB::table('permissions')
+            ->whereNotIn('forum_id', DB::table('forums')->select('id'))
+            ->delete();
+
+        Schema::table('permissions', function (Blueprint $table): void {
+            $table->unsignedSmallInteger('forum_id')->change();
+            $table->foreign('forum_id')->references('id')->on('forums')->cascadeOnUpdate()->cascadeOnDelete();
+        });
+
+        // Forums parent_id
+
+        $forumIds = DB::table('forums')->pluck('id');
+
+        DB::table('forums')
+            ->whereIntegerNotInRaw('parent_id', $forumIds)
+            ->update([
+                'parent_id' => null,
+            ]);
+
+        Schema::table('forums', function (Blueprint $table): void {
+            $table->unsignedSmallInteger('parent_id')->change();
+            $table->foreign('parent_id')->references('id')->on('forums')->cascadeOnUpdate()->nullOnDelete();
+        });
+    }
+};

--- a/database/seeders/ForumsTableSeeder.php
+++ b/database/seeders/ForumsTableSeeder.php
@@ -50,7 +50,7 @@ class ForumsTableSeeder extends Seeder
                 'name'                    => 'UNIT3D Forums',
                 'slug'                    => 'unit3d-forums',
                 'description'             => 'UNIT3D Forums',
-                'parent_id'               => 0,
+                'parent_id'               => null,
                 'created_at'              => '2017-01-03 18:29:21',
                 'updated_at'              => '2017-01-03 18:29:21',
             ],

--- a/resources/views/Staff/forum/create.blade.php
+++ b/resources/views/Staff/forum/create.blade.php
@@ -49,7 +49,7 @@
                 </p>
                 <p class="form__group">
                     <select id="parent_id" class="form__select" name="parent_id" required>
-                        <option value="0">New Category</option>
+                        <option value="">New Category</option>
                         @foreach ($categories as $category)
                             <option class="form__option" value="{{ $category->id }}">
                                 New Forum In {{ $category->name }} Category

--- a/tests/Feature/Http/Controllers/ForumControllerTest.php
+++ b/tests/Feature/Http/Controllers/ForumControllerTest.php
@@ -74,9 +74,10 @@ class ForumControllerTest extends TestCase
         // (and not a "Forum Category").
 
         $forum = Forum::factory()->create([
-            'parent_id'               => 0,
+            'parent_id'               => null,
             'last_post_user_id'       => $user->id,
             'last_post_user_username' => $user->username,
+            'last_topic_id'           => null,
         ]);
 
         $permissions = Permission::factory()->create([

--- a/tests/Todo/Feature/Http/Controllers/ForumCategoryControllerTest.php
+++ b/tests/Todo/Feature/Http/Controllers/ForumCategoryControllerTest.php
@@ -56,7 +56,7 @@ class ForumCategoryControllerTest extends TestCase
         // (and not a "Forum Category").
 
         $forum = Forum::factory()->create([
-            'parent_id'               => 0,
+            'parent_id'               => null,
             'last_post_user_id'       => $user->id,
             'last_post_user_username' => $user->username,
         ]);


### PR DESCRIPTION
Also rely on parent_id = null, instead of parent_id = 0 to determine if the forum is a category.