### PR TITLE
(Add) Loading indicator to peers search

### DIFF
--- a/resources/views/livewire/peer-search.blade.php
+++ b/resources/views/livewire/peer-search.blade.php
@@ -65,6 +65,9 @@
     </section>
     <section class="panelV2">
         <h2 class="panel__heading">Peers</h2>
+        <div class="panel__body" wire:loading.block>
+            Loading...
+        </div>
         <div class="data-table-wrapper">
             <table class="data-table">
                 <thead>


### PR DESCRIPTION
Some search parameters can cause it to take awhile to load. A loading indicator is helpful for such scenarios.