### PR TITLE
(Add) Search by torrent size

### DIFF
--- a/app/Http/Livewire/TorrentSearch.php
+++ b/app/Http/Livewire/TorrentSearch.php
@@ -39,6 +39,14 @@ class TorrentSearch extends Component
 
     public string $endYear = '';
 
+    public ?int $minSize = null;
+
+    public int $minSizeMultiplier = 1;
+
+    public ?int $maxSize = null;
+
+    public int $maxSizeMultiplier = 1;
+
     public array $categories = [];
 
     public array $types = [];
@@ -121,6 +129,8 @@ class TorrentSearch extends Component
         'keywords'        => ['except' => ''],
         'startYear'       => ['except' => ''],
         'endYear'         => ['except' => ''],
+        'minSize'         => ['except' => ''],
+        'maxSize'         => ['except' => ''],
         'categories'      => ['except' => []],
         'types'           => ['except' => []],
         'resolutions'     => ['except' => []],
@@ -241,6 +251,8 @@ class TorrentSearch extends Component
             ->when($this->keywords !== '', fn ($query) => $query->ofKeyword(array_map('trim', explode(',', $this->keywords))))
             ->when($this->startYear !== '', fn ($query) => $query->releasedAfterOrIn((int) $this->startYear))
             ->when($this->endYear !== '', fn ($query) => $query->releasedBeforeOrIn((int) $this->endYear))
+            ->when($this->minSize !== null, fn ($query) => $query->ofSizeGreaterOrEqualto((int) $this->minSize * $this->minSizeMultiplier))
+            ->when($this->maxSize !== null, fn ($query) => $query->ofSizeLesserOrEqualTo((int) $this->maxSize * $this->maxSizeMultiplier))
             ->when($this->categories !== [], fn ($query) => $query->ofCategory($this->categories))
             ->when($this->types !== [], fn ($query) => $query->ofType($this->types))
             ->when($this->resolutions !== [], fn ($query) => $query->ofResolution($this->resolutions))
@@ -328,6 +340,8 @@ class TorrentSearch extends Component
             ->when($this->keywords !== '', fn ($query) => $query->ofKeyword(array_map('trim', explode(',', $this->keywords))))
             ->when($this->startYear !== '', fn ($query) => $query->releasedAfterOrIn((int) $this->startYear))
             ->when($this->endYear !== '', fn ($query) => $query->releasedBeforeOrIn((int) $this->endYear))
+            ->when($this->minSize !== null, fn ($query) => $query->ofSizeGreaterOrEqualto((int) $this->minSize * $this->minSizeMultiplier))
+            ->when($this->maxSize !== null, fn ($query) => $query->ofSizeLesserOrEqualTo((int) $this->maxSize * $this->maxSizeMultiplier))
             ->when($this->categories !== [], fn ($query) => $query->ofCategory($this->categories))
             ->when($this->types !== [], fn ($query) => $query->ofType($this->types))
             ->when($this->resolutions !== [], fn ($query) => $query->ofResolution($this->resolutions))
@@ -439,6 +453,8 @@ class TorrentSearch extends Component
             ->when($this->keywords !== '', fn ($query) => $query->ofKeyword(array_map('trim', explode(',', $this->keywords))))
             ->when($this->startYear !== '', fn ($query) => $query->releasedAfterOrIn((int) $this->startYear))
             ->when($this->endYear !== '', fn ($query) => $query->releasedBeforeOrIn((int) $this->endYear))
+            ->when($this->minSize !== null, fn ($query) => $query->ofSizeGreaterOrEqualto((int) $this->minSize * $this->minSizeMultiplier))
+            ->when($this->maxSize !== null, fn ($query) => $query->ofSizeLesserOrEqualTo((int) $this->maxSize * $this->maxSizeMultiplier))
             ->when($this->categories !== [], fn ($query) => $query->ofCategory($this->categories))
             ->when($this->types !== [], fn ($query) => $query->ofType($this->types))
             ->when($this->resolutions !== [], fn ($query) => $query->ofResolution($this->resolutions))

--- a/app/Traits/TorrentFilter.php
+++ b/app/Traits/TorrentFilter.php
@@ -83,6 +83,16 @@ trait TorrentFilter
         return $query->where('release_year', '<=', $year);
     }
 
+    public function scopeOfSizeGreaterOrEqualTo(Builder $query, int $size): Builder
+    {
+        return $query->where('size', '>=', $size);
+    }
+
+    public function scopeOfSizeLesserOrEqualTo(Builder $query, int $size): Builder
+    {
+        return $query->where('size', '<=', $size);
+    }
+
     public function scopeOfCategory(Builder $query, array $categories): Builder
     {
         return $query->whereIntegerInRaw('category_id', $categories);

--- a/resources/views/livewire/torrent-search.blade.php
+++ b/resources/views/livewire/torrent-search.blade.php
@@ -47,14 +47,48 @@
                         <input wire:model="endYear" class="form__text" placeholder=" ">
                         <label class="form__label form__label--floating">{{ __('torrent.end-year') }}</label>
                     </p>
-                    <p class="form__group">
-                        <input wire:model="playlistId" class="form__text" placeholder=" ">
-                        <label class="form__label form__label--floating">Playlist ID</label>
-                    </p>
-                    <p class="form__group">
-                        <input wire:model="collectionId" class="form__text" placeholder=" ">
-                        <label class="form__label form__label--floating">Collection ID</label>
-                    </p>
+                    <div class="form__group--short-horizontal">
+                        <p class="form__group">
+                            <input wire:model="minSize" class="form__text" placeholder=" ">
+                            <label class="form__label form__label--floating">Minimum Size</label>
+                        </p>
+                        <p class="form__group">
+                            <select wire:model="minSizeMultiplier" class="form__select" placeholder=" ">
+                                <option value="1" selected>Bytes</option>
+                                <option value="1000">KB</option>
+                                <option value="1024">KiB</option>
+                                <option value="1000000">MB</option>
+                                <option value="1048576">MiB</option>
+                                <option value="1000000000">GB</option>
+                                <option value="1073741824">GiB</option>
+                                <option value="1000000000000">TB</option>
+                                <option value="1099511627776">TiB</option>
+
+                            </select>
+                            <label class="form__label form__label--floating">Unit</label>
+                        </p>
+                    </div>
+                    <div class="form__group--short-horizontal">
+                        <p class="form__group">
+                            <input wire:model="maxSize" class="form__text" placeholder=" ">
+                            <label class="form__label form__label--floating">Maximum Size</label>
+                        </p>
+                        <p class="form__group">
+                            <select wire:model="maxSizeMultiplier" class="form__select" placeholder=" ">
+                                <option value="1" selected>Bytes</option>
+                                <option value="1000">KB</option>
+                                <option value="1024">KiB</option>
+                                <option value="1000000">MB</option>
+                                <option value="1048576">MiB</option>
+                                <option value="1000000000">GB</option>
+                                <option value="1073741824">GiB</option>
+                                <option value="1000000000000">TB</option>
+                                <option value="1099511627776">TiB</option>
+
+                            </select>
+                            <label class="form__label form__label--floating">Unit</label>
+                        </p>
+                    </div>
                 </div>
                 <div class="form__group--short-horizontal">
                     <div class="form__group">
@@ -65,6 +99,16 @@
                         @php $distributors = cache()->remember('distributors', 3_600, fn () => App\Models\Distributor::orderBy('name')->get()) @endphp
                         <div id="distributors" wire:ignore></div>
                     </div>
+                </div>
+                <div class="form__group--short-horizontal">
+                    <p class="form__group">
+                        <input wire:model="playlistId" class="form__text" placeholder=" ">
+                        <label class="form__label form__label--floating">Playlist ID</label>
+                    </p>
+                    <p class="form__group">
+                        <input wire:model="collectionId" class="form__text" placeholder=" ">
+                        <label class="form__label form__label--floating">Collection ID</label>
+                    </p>
                     <p class="form__group">
                         <input wire:model="companyId" class="form__text" placeholder=" ">
                         <label class="form__label form__label--floating">Company ID</label>
@@ -582,6 +626,20 @@
                 @break
 
             @case($view === 'group')
+                <table class="data-table">
+                    <thead>
+                        <tr>
+                            <th class="torrent-search--list__completed-header" wire:click="sortBy('times_completed')" role="columnheader button" title="{{ __('torrent.completed') }}">
+                                <i class="fas fa-check-circle"></i>
+                                @include('livewire.includes._sort-icon', ['field' => 'times_completed'])
+                            </th>
+                            <th class="torrent-search--list__age-header" wire:click="sortBy('created_at')" role="columnheader button">
+                                {{ __('common.created_at') }}
+                                @include('livewire.includes._sort-icon', ['field' => 'created_at'])
+                            </th>
+                        </tr>
+                    </thead>
+                </table>
                 <div class="panel__body torrent-search--grouped__results">
                     @forelse ($torrents as $group)
                         @switch ($group->meta)


### PR DESCRIPTION
The use case for this filter is ordering grouped torrents by times_completed, and wanting to filter out low-size torrents since they're often bon farmed and skew the numbers.