### PR TITLE
(Update) Torrent upload keywords and files

### DIFF
--- a/app/Http/Controllers/TorrentController.php
+++ b/app/Http/Controllers/TorrentController.php
@@ -390,7 +390,7 @@ class TorrentController extends Controller
 
         // Can't insert them all at once since some torrents have more files than mysql supports placeholders.
         // Divide by 3 since we're inserting 3 fields: name, size and torrent_id
-        foreach (collect($files)->chunk(65_000 / 3) as $files) {
+        foreach (collect($files)->chunk(intdiv(65_000, 3)) as $files) {
             TorrentFile::insert($files->toArray());
         }
 
@@ -415,8 +415,8 @@ class TorrentController extends Controller
             $keywords[] = ['torrent_id' => $torrent->id, 'name' => $keyword];
         }
 
-        foreach (collect($keywords)->chunk(65_000 / 2) as $keywords) {
-            Keyword::upsert($keywords->toArray(), ['torrent', 'name'], []);
+        foreach (collect($keywords)->chunk(intdiv(65_000, 2)) as $keywords) {
+            Keyword::upsert($keywords->toArray(), ['torrent_id', 'name'], []);
         }
 
         // Cover Image for No-Meta Torrents


### PR DESCRIPTION
Reduce n+1 queries, fix float being passed to `chunk` instead of int, fix incorrect column name (`torrent_id` is the correct one).