### PR TITLE
(Fix) Torrent card meta query

### DIFF
--- a/resources/views/blocks/featured.blade.php
+++ b/resources/views/blocks/featured.blade.php
@@ -15,7 +15,7 @@
                         @continue
                     @endif
                     @php
-                        $meta = match(1) {
+                        $meta = match(true) {
                             $feature->torrent->category->tv_meta => App\Models\Tv::query()->with('genres', 'networks', 'seasons')->find($feature->torrent->tmdb ?? 0),
                             $feature->torrent->category->movie_meta => App\Models\Movie::query()->with('genres', 'companies', 'collection')->find($feature->torrent->tmdb ?? 0),
                             $feature->torrent->category->game_meta => MarcReichel\IGDBLaravel\Models\Game::query()->with(['artworks' => ['url', 'image_id'], 'genres' => ['name']])->find((int) $feature->torrent->igdb),

--- a/resources/views/playlist/show.blade.php
+++ b/resources/views/playlist/show.blade.php
@@ -149,7 +149,7 @@
         <div class="panel__body playlist__torrents">
             @foreach($torrents as $torrent)
                 @php
-                    $meta = match(1) {
+                    $meta = match(true) {
                         $torrent->category->tv_meta => App\Models\Tv::query()->with('genres', 'networks', 'seasons')->find($torrent->tmdb ?? 0),
                         $torrent->category->movie_meta => App\Models\Movie::query()->with('genres', 'companies', 'collection')->find($torrent->tmdb ?? 0),
                         $torrent->category->game_meta => MarcReichel\IGDBLaravel\Models\Game::query()->with(['artworks' => ['url', 'image_id'], 'genres' => ['name']])->find((int) $playlistTorrent->torrent->igdb),


### PR DESCRIPTION
Wrong type is used, since now we cast `movie_meta`, `tv_meta`, `game_meta`, and `music_meta` to booleans.