### PR TITLE
(Fix) Torrent activity indicator logic

### DIFF
--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -102,12 +102,15 @@ class HomeController extends Controller
                                 ->where('seeder', '=', 0),
                             'history as not_completed' => fn ($query) => $query->where('user_id', '=', $user->id)
                                 ->where('active', '=', 0)
-                                ->where('seeder', '=', 1)
+                                ->where('seeder', '=', 0)
                                 ->whereNull('completed_at'),
                             'history as not_seeding' => fn ($query) => $query->where('user_id', '=', $user->id)
                                 ->where('active', '=', 0)
-                                ->where('seeder', '=', 1)
-                                ->whereNotNull('completed_at'),
+                                ->where(
+                                    fn ($query) => $query
+                                        ->where('seeder', '=', 1)
+                                        ->orWhereNotNull('completed_at')
+                                ),
                         ])
                         ->selectRaw("
                     CASE
@@ -165,12 +168,15 @@ class HomeController extends Controller
                                 ->where('seeder', '=', 0),
                             'history as not_completed' => fn ($query) => $query->where('user_id', '=', $user->id)
                                 ->where('active', '=', 0)
-                                ->where('seeder', '=', 1)
+                                ->where('seeder', '=', 0)
                                 ->whereNull('completed_at'),
                             'history as not_seeding' => fn ($query) => $query->where('user_id', '=', $user->id)
                                 ->where('active', '=', 0)
-                                ->where('seeder', '=', 1)
-                                ->whereNotNull('completed_at'),
+                                ->where(
+                                    fn ($query) => $query
+                                        ->where('seeder', '=', 1)
+                                        ->orWhereNotNull('completed_at')
+                                ),
                         ])
                         ->selectRaw("
                     CASE
@@ -228,12 +234,15 @@ class HomeController extends Controller
                                 ->where('seeder', '=', 0),
                             'history as not_completed' => fn ($query) => $query->where('user_id', '=', $user->id)
                                 ->where('active', '=', 0)
-                                ->where('seeder', '=', 1)
+                                ->where('seeder', '=', 0)
                                 ->whereNull('completed_at'),
                             'history as not_seeding' => fn ($query) => $query->where('user_id', '=', $user->id)
                                 ->where('active', '=', 0)
-                                ->where('seeder', '=', 1)
-                                ->whereNotNull('completed_at'),
+                                ->where(
+                                    fn ($query) => $query
+                                        ->where('seeder', '=', 1)
+                                        ->orWhereNotNull('completed_at')
+                                ),
                         ])
                         ->selectRaw("
                     CASE
@@ -293,12 +302,15 @@ class HomeController extends Controller
                                 ->where('seeder', '=', 0),
                             'history as not_completed' => fn ($query) => $query->where('user_id', '=', $user->id)
                                 ->where('active', '=', 0)
-                                ->where('seeder', '=', 1)
+                                ->where('seeder', '=', 0)
                                 ->whereNull('completed_at'),
                             'history as not_seeding' => fn ($query) => $query->where('user_id', '=', $user->id)
                                 ->where('active', '=', 0)
-                                ->where('seeder', '=', 1)
-                                ->whereNotNull('completed_at'),
+                                ->where(
+                                    fn ($query) => $query
+                                        ->where('seeder', '=', 1)
+                                        ->orWhereNotNull('completed_at')
+                                ),
                         ])
                         ->selectRaw("
                     CASE
@@ -356,12 +368,15 @@ class HomeController extends Controller
                                 ->where('seeder', '=', 0),
                             'history as not_completed' => fn ($query) => $query->where('user_id', '=', $user->id)
                                 ->where('active', '=', 0)
-                                ->where('seeder', '=', 1)
+                                ->where('seeder', '=', 0)
                                 ->whereNull('completed_at'),
                             'history as not_seeding' => fn ($query) => $query->where('user_id', '=', $user->id)
                                 ->where('active', '=', 0)
-                                ->where('seeder', '=', 1)
-                                ->whereNotNull('completed_at'),
+                                ->where(
+                                    fn ($query) => $query
+                                        ->where('seeder', '=', 1)
+                                        ->orWhereNotNull('completed_at')
+                                ),
                         ])
                         ->selectRaw("
                     CASE

--- a/app/Http/Livewire/SimilarTorrent.php
+++ b/app/Http/Livewire/SimilarTorrent.php
@@ -86,12 +86,15 @@ class SimilarTorrent extends Component
                     ->where('seeder', '=', 0),
                 'history as not_completed' => fn ($query) => $query->where('user_id', '=', $user->id)
                     ->where('active', '=', 0)
-                    ->where('seeder', '=', 1)
+                    ->where('seeder', '=', 0)
                     ->whereNull('completed_at'),
                 'history as not_seeding' => fn ($query) => $query->where('user_id', '=', $user->id)
                     ->where('active', '=', 0)
-                    ->where('seeder', '=', 1)
-                    ->whereNotNull('completed_at'),
+                    ->where(
+                        fn ($query) => $query
+                            ->where('seeder', '=', 1)
+                            ->orWhereNotNull('completed_at')
+                    ),
             ])
             ->when(
                 $this->category->movie_meta,

--- a/app/Http/Livewire/TorrentSearch.php
+++ b/app/Http/Livewire/TorrentSearch.php
@@ -277,12 +277,15 @@ class TorrentSearch extends Component
                     ->where('seeder', '=', 0),
                 'history as not_completed' => fn ($query) => $query->where('user_id', '=', $user->id)
                     ->where('active', '=', 0)
-                    ->where('seeder', '=', 1)
+                    ->where('seeder', '=', 0)
                     ->whereNull('completed_at'),
                 'history as not_seeding' => fn ($query) => $query->where('user_id', '=', $user->id)
                     ->where('active', '=', 0)
-                    ->where('seeder', '=', 1)
-                    ->whereNotNull('completed_at'),
+                    ->where(
+                        fn ($query) => $query
+                            ->where('seeder', '=', 1)
+                            ->orWhereNotNull('completed_at')
+                    ),
             ])
             ->selectRaw("
                 CASE
@@ -369,12 +372,15 @@ class TorrentSearch extends Component
                     ->where('seeder', '=', 0),
                 'history as not_completed' => fn ($query) => $query->where('user_id', '=', $user->id)
                     ->where('active', '=', 0)
-                    ->where('seeder', '=', 1)
+                    ->where('seeder', '=', 0)
                     ->whereNull('completed_at'),
                 'history as not_seeding' => fn ($query) => $query->where('user_id', '=', $user->id)
                     ->where('active', '=', 0)
-                    ->where('seeder', '=', 1)
-                    ->whereNotNull('completed_at'),
+                    ->where(
+                        fn ($query) => $query
+                            ->where('seeder', '=', 1)
+                            ->orWhereNotNull('completed_at')
+                    ),
             ])
             ->select([
                 'id',


### PR DESCRIPTION
Makes more sense for the "no completed" indicator to only count torrents where the user was never a seeder, instead of torrents where they were a seeder. Also completed can either mean they are a seeder, or they have sent the completed event, both should work.