### PR TITLE
(Fix) Redundant movie db query for tv api calls

### DIFF
--- a/app/Http/Controllers/API/TorrentController.php
+++ b/app/Http/Controllers/API/TorrentController.php
@@ -459,11 +459,11 @@ class TorrentController extends BaseController
             $torrents = $torrents->through(function ($torrent) use ($movies, $tv) {
                 switch ($torrent->meta) {
                     case 'movie':
-                        $torrent->setRelation('movie', $movies[$torrent->tmdb] ?? collect());
+                        $torrent->setRelation('work', $movies[$torrent->tmdb] ?? collect());
 
                         break;
                     case 'tv':
-                        $torrent->setRelation('tv', $tv[$torrent->tmdb] ?? collect());
+                        $torrent->setRelation('work', $tv[$torrent->tmdb] ?? collect());
 
                         break;
                 }

--- a/app/Http/Resources/TorrentResource.php
+++ b/app/Http/Resources/TorrentResource.php
@@ -25,7 +25,8 @@ class TorrentResource extends JsonResource
      */
     public function toArray($request): array
     {
-        $meta = $this->movie ?? $this->tv;
+        /** @phpstan-ignore-next-line */
+        $meta = $this->work;
 
         return [
             'type'       => 'torrent',


### PR DESCRIPTION
Tv torrents don't have the `movie` relation eager loaded so it will try and fetch the `movie` relation if it's not eager loaded. Since we don't care about movies on a tv torrent, use a variable that doesn't have the same name as a relation so that it can't get loaded.