### PR TITLE
(Fix) Decrease torrent seeders/leechers when a peer is marked inactive

### DIFF
--- a/app/Console/Commands/AutoFlushPeers.php
+++ b/app/Console/Commands/AutoFlushPeers.php
@@ -15,9 +15,11 @@ namespace App\Console\Commands;
 
 use App\Models\History;
 use App\Models\Peer;
+use App\Models\Torrent;
 use Illuminate\Console\Command;
 use Illuminate\Support\Carbon;
 use Exception;
+use Illuminate\Support\Facades\DB;
 
 /**
  * @see \Tests\Unit\Console\Commands\AutoFlushPeersTest
@@ -59,6 +61,11 @@ class AutoFlushPeers extends Command
                 $history->timestamps = false;
                 $history->save();
             }
+
+            Torrent::where('id', '=', $peer->torrent_id)->update([
+                'seeders'  => DB::raw('seeders - '.((int) $peer->seeder)),
+                'leechers' => DB::raw('leechers - '.((int) ! $peer->seeder)),
+            ]);
 
             $peer->active = false;
             $peer->timestamps = false;

--- a/app/Console/Commands/SyncPeers.php
+++ b/app/Console/Commands/SyncPeers.php
@@ -47,8 +47,8 @@ class SyncPeers extends Command
             ->leftJoinSub(
                 Peer::query()
                     ->select('torrent_id')
-                    ->addSelect(DB::raw('sum(case when peers.left = 0 then 1 else 0 end) as updated_seeders'))
-                    ->addSelect(DB::raw('sum(case when peers.left <> 0 then 1 else 0 end) as updated_leechers'))
+                    ->addSelect(DB::raw('SUM(peers.left = 0 AND peers.active = 1) AS updated_seeders'))
+                    ->addSelect(DB::raw('SUM(peers.left != 0 AND peers.active = 1) AS updated_leechers'))
                     ->groupBy('torrent_id'),
                 'seeders_leechers',
                 fn ($join) => $join->on('torrents.id', '=', 'seeders_leechers.torrent_id')

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -47,7 +47,7 @@ class Kernel extends ConsoleKernel
         $schedule->command('auto:softdelete_disabled_users')->daily();
         $schedule->command('auto:recycle_claimed_torrent_requests')->daily();
         $schedule->command('auto:correct_history')->daily();
-        $schedule->command('auto:sync_peers')->daily();
+        $schedule->command('auto:sync_peers')->hourly();
         $schedule->command('auto:email-blacklist-update')->weekends();
         $schedule->command('auto:reset_user_flushes')->daily();
         $schedule->command('auto:stats_clients')->daily();

--- a/app/Http/Controllers/AnnounceController.php
+++ b/app/Http/Controllers/AnnounceController.php
@@ -755,6 +755,7 @@ class AnnounceController extends Controller
 
         // Torrent updates
 
+        $isNewPeer = $isNewPeer || ! $peer->active;
         $isDeadPeer = $event === 'stopped';
         $isSeeder = $queries['left'] == 0;
 


### PR DESCRIPTION
Don't include inactive peers in the count of seeders/leechers stored in the torrent table.