### PR TITLE
(Fix) Announce torrent cache busting

### DIFF
--- a/app/Http/Controllers/AnnounceController.php
+++ b/app/Http/Controllers/AnnounceController.php
@@ -798,7 +798,7 @@ class AnnounceController extends Controller
                 'times_completed' => DB::raw('times_completed + '.$completedCountDelta),
             ]);
 
-            cache()->forget('announce-torrents:by-infohash:'.$torrent->info_hash);
+            cache()->forget('announce-torrents:by-infohash:'.$queries['info_hash']);
         }
     }
 


### PR DESCRIPTION
We don't select the info_hash on the torrent. We have to take it from the validated query parameter instead.