### PR TITLE
(Update) Allow Admins to Edit Any Profile

### DIFF
--- a/app/Http/Controllers/Staff/UserController.php
+++ b/app/Http/Controllers/Staff/UserController.php
@@ -72,7 +72,7 @@ class UserController extends Controller
         $staff = $request->user();
         $group = Group::findOrFail($request->group_id);
 
-        abort_if(! $staff->group->is_owner && ($staff->group->level <= $user->group->level || $staff->group->level <= $group->level), 403);
+        abort_if(! ($staff->group->is_owner || $staff->group->is_admin) && ($staff->group->level <= $user->group->level || $staff->group->level <= $group->level), 403);
 
         $user->update($request->validated());
 


### PR DESCRIPTION
Required for incrementing invites,  otherwise coder/owner will have to.

Has con of admin being able to edit owner's profile, but assuming owner has infra access and can handle "retribution" on their own. 

If you want to handle this a different way or just dont want to my feelings won't be hurt

Note: Static Analysis Failure is unrelated to this code change