### PR TITLE
(Fix) Revel code block foreground color

### DIFF
--- a/resources/sass/components/_bbcode-rendered.scss
+++ b/resources/sass/components/_bbcode-rendered.scss
@@ -313,6 +313,7 @@
 
   pre {
     background-color: var(--bbcode-rendered-neutral-muted);
+    color: var(--bbcode-rendered-fg-default);
     border: revert;
     border-radius: 6px;
     margin-top: 0;


### PR DESCRIPTION
Tested with all other stylesheets as well and still looks good.