### PR TITLE
(Fix) Don't potentially download html file of an error message

### DIFF
--- a/resources/views/components/partials/_torrent-group-row.blade.php
+++ b/resources/views/components/partials/_torrent-group-row.blade.php
@@ -28,7 +28,6 @@
 <td class="torrent-search--grouped__download">
     @if (config('torrent.download_check_page') == 1)
         <a
-            download
             href="{{ route('download_check', ['id' => $torrent->id]) }}"
             title="{{ __('common.download') }}"
         >
@@ -36,7 +35,6 @@
         </a>
     @else
         <a
-            download
             href="{{ route('download', ['id' => $torrent->id]) }}"
             title="{{ __('common.download') }}"
         >

--- a/resources/views/components/torrent/card.blade.php
+++ b/resources/views/components/torrent/card.blade.php
@@ -130,7 +130,6 @@
             @if (config('torrent.download_check_page'))
                 <a
                     class="form__standard-icon-button"
-                    download
                     href="{{ route('download_check', ['id' => $torrent->id]) }}"
                 >
                     <i class="{{ \config('other.font-awesome') }} fa-download"></i>
@@ -138,7 +137,6 @@
             @else
                 <a
                     class="form__standard-icon-button"
-                    download
                     href="{{ route('download', ['id' => $torrent->id]) }}"
                 >
                     <i class="{{ \config('other.font-awesome') }} fa-download"></i>

--- a/resources/views/components/torrent/row.blade.php
+++ b/resources/views/components/torrent/row.blade.php
@@ -126,7 +126,6 @@
                 <a
                     class="torrent-search--list__file form__standard-icon-button"
                     href="{{ route('download_check', ['id' => $torrent->id]) }}"
-                    download
                     title="{{ __('common.download') }}"
                 >
                     <i class="{{ config('other.font-awesome') }} fa-download"></i>
@@ -135,7 +134,6 @@
                 <a
                     class="torrent-search--list__file form__standard-icon-button"
                     href="{{ route('download', ['id' => $torrent->id]) }}"
-                    download
                     title="{{ __('common.download') }}"
                 >
                     <i class="{{ config('other.font-awesome') }} fa-download"></i>

--- a/resources/views/playlist/show.blade.php
+++ b/resources/views/playlist/show.blade.php
@@ -102,7 +102,6 @@
                     <a
                         href="{{ route('playlist_zips.show', ['playlist' => $playlist]) }}"
                         class="form__button form__button--filled form__button--centered"
-                        download
                     >
                         <i class='{{ config('other.font-awesome') }} fa-download'></i>
                         {{ __('playlist.download-all') }}

--- a/resources/views/torrent/partials/buttons.blade.php
+++ b/resources/views/torrent/partials/buttons.blade.php
@@ -5,7 +5,6 @@
                 <a
                     class="form__button form__button--filled form__button--centered"
                     href="{{ route('download_check', ['id' => $torrent->id]) }}" role="button"
-                    download
                 >
                     <i class='{{ config("other.font-awesome") }} fa-download'></i> {{ __('common.download') }}
                 </a>
@@ -13,7 +12,6 @@
                 <a
                     class="form__button form__button--filled form__button--centered"
                     href="{{ route('download', ['id' => $torrent->id]) }}"
-                    download
                 >
                     <i class='{{ config("other.font-awesome") }} fa-download'></i> {{ __('common.download') }}
                 </a>

--- a/resources/views/torrent/partials/subtitles.blade.php
+++ b/resources/views/torrent/partials/subtitles.blade.php
@@ -48,7 +48,6 @@
                                         href="{{ route('subtitles.download', ['subtitle' => $subtitle]) }}"
                                         class="form__button form__button--text"
                                         title="{{ __('common.download') }}"
-                                        download
                                     >
                                         {{ __('common.download') }}
                                     </a>

--- a/resources/views/user/buttons/user.blade.php
+++ b/resources/views/user/buttons/user.blade.php
@@ -201,7 +201,7 @@
                     </button>
                 </form>
                 <li class="nav-tabV2">
-                    <a download class="nav-tab__link" href="{{ route('users.torrent_zip.show', ['user' => $user]) }}">
+                    <a class="nav-tab__link" href="{{ route('users.torrent_zip.show', ['user' => $user]) }}">
                         {{ __('torrent.download-all') }}
                     </a>
                 </li>


### PR DESCRIPTION
These controller methods may potentially return a pop up with an error message. The `download` attribute will automatically download the html for this error message instead of displaying it, so we shouldn't use it for these cases.