### PR TITLE
(Fix) Mediainfo copy

### DIFF
--- a/resources/views/torrent/partials/mediainfo.blade.php
+++ b/resources/views/torrent/partials/mediainfo.blade.php
@@ -13,7 +13,7 @@
                     x-data
                     x-on:click.stop="
                         text = document.createElement('textarea');
-                        text.innerHTML = decodeURIComponent(atob($refs.mediainfo.textContent).split('').map((c) => '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2)).join(''));
+                        text.innerHTML = decodeURIComponent($refs.mediainfo.textContent.split('').map((c) => '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2)).join(''));
                         navigator.clipboard.writeText(text.value);
                         Swal.fire({
                               toast: true,


### PR DESCRIPTION
Mediainfo is not returned as b64 from the $refs lookup. The atob call needs removed.