### PR TITLE
(Fix) Forum category creation

### DIFF
--- a/resources/views/Staff/forum/create.blade.php
+++ b/resources/views/Staff/forum/create.blade.php
@@ -48,7 +48,7 @@
                     <label class="form__label form__label--floating" for="description">Description</label>
                 </p>
                 <p class="form__group">
-                    <select id="parent_id" class="form__select" name="parent_id" required>
+                    <select id="parent_id" class="form__select" name="parent_id">
                         <option value="">New Category</option>
                         @foreach ($categories as $category)
                             <option class="form__option" value="{{ $category->id }}">


### PR DESCRIPTION
Categories require a parent of null, which means we need the form value to be an empty string, which prevents us from making the form required.

Fixes #3188.