### PR TITLE
(Fix) Swap `not regex` for `not regexp` in migrations

### DIFF
--- a/database/migrations/2022_11_24_032502_update_torrents_table.php
+++ b/database/migrations/2022_11_24_032502_update_torrents_table.php
@@ -15,28 +15,28 @@ return new class () extends Migration {
             ->whereNull('imdb')
             ->orWhere('imdb', '<', 0)
             ->orWhere('imdb', '>', 2_000_000_000)
-            ->orWhere('imdb', 'not regex', '\d+')
+            ->orWhere('imdb', 'not regexp', '\d+')
             ->update(['imdb' => '0']);
 
         DB::table('torrents')
             ->whereNull('tmdb')
             ->orWhere('tmdb', '<', 0)
             ->orWhere('tmdb', '>', 2_000_000_000)
-            ->orWhere('tmdb', 'not regex', '\d+')
+            ->orWhere('tmdb', 'not regexp', '\d+')
             ->update(['tmdb' => '0']);
 
         DB::table('torrents')
             ->whereNull('tvdb')
             ->orWhere('tvdb', '<', 0)
             ->orWhere('tvdb', '>', 2_000_000_000)
-            ->orWhere('tvdb', 'not regex', '\d+')
+            ->orWhere('tvdb', 'not regexp', '\d+')
             ->update(['tvdb' => '0']);
 
         DB::table('torrents')
             ->whereNull('mal')
             ->orWhere('mal', '<', 0)
             ->orWhere('mal', '>', 2_000_000_000)
-            ->orWhere('mal', 'not regex', '\d+')
+            ->orWhere('mal', 'not regexp', '\d+')
             ->update(['mal' => '0']);
 
         Schema::table('torrents', function (Blueprint $table): void {

--- a/database/migrations/2022_11_24_032521_update_requests_table.php
+++ b/database/migrations/2022_11_24_032521_update_requests_table.php
@@ -15,28 +15,28 @@ return new class () extends Migration {
             ->whereNull('imdb')
             ->orWhere('imdb', '<', 0)
             ->orWhere('imdb', '>', 2_000_000_000)
-            ->orWhere('imdb', 'not regex', '\d+')
+            ->orWhere('imdb', 'not regexp', '\d+')
             ->update(['imdb' => '0']);
 
         DB::table('requests')
             ->whereNull('tmdb')
             ->orWhere('tmdb', '<', 0)
             ->orWhere('tmdb', '>', 2_000_000_000)
-            ->orWhere('tmdb', 'not regex', '\d+')
+            ->orWhere('tmdb', 'not regexp', '\d+')
             ->update(['tmdb' => '0']);
 
         DB::table('requests')
             ->whereNull('tvdb')
             ->orWhere('tvdb', '<', 0)
             ->orWhere('tvdb', '>', 2_000_000_000)
-            ->orWhere('tvdb', 'not regex', '\d+')
+            ->orWhere('tvdb', 'not regexp', '\d+')
             ->update(['tvdb' => '0']);
 
         DB::table('requests')
             ->whereNull('mal')
             ->orWhere('mal', '<', 0)
             ->orWhere('mal', '>', 2_000_000_000)
-            ->orWhere('mal', 'not regex', '\d+')
+            ->orWhere('mal', 'not regexp', '\d+')
             ->update(['mal' => '0']);
 
         Schema::table('requests', function (Blueprint $table): void {


### PR DESCRIPTION
Fixes #3196 