### PR TITLE
(Fix) Bad Spacing and Special Characters in Torrent Icons

### DIFF
--- a/resources/views/components/partials/_torrent-icons.blade.php
+++ b/resources/views/components/partials/_torrent-icons.blade.php
@@ -56,10 +56,10 @@
                 'fa-calendar-star' => ! $alwaysFreeleech && $torrent->fl_until !== null,
             ])
             title="{{ 
-                ($personalFreeleech ? __('torrent.personal-freeleech') . ($tagsMet++ >= 1 ? "\n" : '') : '') . 
-                ($torrent->freeleechTokens_exists ? __('torrent.freeleech-token') . ($tagsMet++ >= 1 ? "\n" : '') : '') . 
-                (auth()->user()->group->is_freeleech ? __('torrent.special-freeleech') . ($tagsMet++ >= 1 ? "\n" : '') : '') . 
-                (config('other.freeleech') ? __('torrent.global-freeleech') . ($tagsMet++ >= 1 ? "\n" : '') : '') . 
+                ($personalFreeleech ? ($tagsMet++ >= 1 ? "\n" : '') . __('torrent.personal-freeleech') : '') . 
+                ($torrent->freeleechTokens_exists ? ($tagsMet++ >= 1 ? "\n" : '') . __('torrent.freeleech-token') : '') . 
+                (auth()->user()->group->is_freeleech ? ($tagsMet++ >= 1 ? "\n" : '') . __('torrent.special-freeleech') : '') . 
+                (config('other.freeleech') ? ($tagsMet++ >= 1 ? "\n" : '') . __('torrent.global-freeleech') : '') . 
                 ($torrent->free > 0 ? ($tagsMet++ >= 1 ? "\n" : '') . $torrent->free . '% ' . __('common.free') . ($torrent->fl_until !== null ? ' (expires ' . $torrent->fl_until->diffForHumans() . ')' : '') : '') 
             }}"
         ></i>

--- a/resources/views/components/partials/_torrent-icons.blade.php
+++ b/resources/views/components/partials/_torrent-icons.blade.php
@@ -45,7 +45,6 @@
     @endif
     @php
         $alwaysFreeleech = $personalFreeleech || $torrent->freeleechTokens_exists || auth()->user()->group->is_freeleech || config('other.freeleech');
-        $tagsMet = 0;
     @endphp
     @if ($alwaysFreeleech || $torrent->free)
         <i

--- a/resources/views/components/partials/_torrent-icons.blade.php
+++ b/resources/views/components/partials/_torrent-icons.blade.php
@@ -44,7 +44,7 @@
         ></i>
     @endif
     @php
-        $alwaysFreeleech = $personalFreeleech || $torrent->freeleechTokens_exists || auth()->user()->group->is_freeleech || config('other.freeleech');
+        $alwaysFreeleech = $personalFreeleech || $torrent->freeleechTokens_exists || auth()->user()->group->is_freeleech || config('other.freeleech')
     @endphp
     @if ($alwaysFreeleech || $torrent->free)
         <i

--- a/resources/views/components/partials/_torrent-icons.blade.php
+++ b/resources/views/components/partials/_torrent-icons.blade.php
@@ -44,7 +44,8 @@
         ></i>
     @endif
     @php
-        $alwaysFreeleech = $personalFreeleech || $torrent->freeleechTokens_exists || auth()->user()->group->is_freeleech || config('other.freeleech')
+        $alwaysFreeleech = $personalFreeleech || $torrent->freeleechTokens_exists || auth()->user()->group->is_freeleech || config('other.freeleech');
+        $tagsMet = 0;
     @endphp
     @if ($alwaysFreeleech || $torrent->free)
         <i
@@ -54,7 +55,13 @@
                 'fa-star-half' => ! $alwaysFreeleech && $torrent->free < 90 && $torrent->fl_until === null,
                 'fa-calendar-star' => ! $alwaysFreeleech && $torrent->fl_until !== null,
             ])
-            title="@if($personalFreeleech){{ __('torrent.personal-freeleech') }}&NewLine;@endif&ZeroWidthSpace;@if($torrent->freeleechTokens_exists){{ __('torrent.freeleech-token') }}&NewLine;@endif&ZeroWidthSpace;@if(auth()->user()->group->is_freeleech){{ __('torrent.special-freeleech') }}&NewLine;@endif&ZeroWidthSpace;@if(config('other.freeleech')){{ __('torrent.global-freeleech') }}&NewLine;@endif&ZeroWidthSpace;@if($torrent->free > 0){{ $torrent->free }}% {{ __('common.free') }}@if($torrent->fl_until !== null) (expires {{ $torrent->fl_until->diffForHumans() }})@endif&ZeroWidthSpace;@endif"
+            title="{{ 
+                ($personalFreeleech ? __('torrent.personal-freeleech') . ($tagsMet++ >= 1 ? "\n" : '') : '') . 
+                ($torrent->freeleechTokens_exists ? __('torrent.freeleech-token') . ($tagsMet++ >= 1 ? "\n" : '') : '') . 
+                (auth()->user()->group->is_freeleech ? __('torrent.special-freeleech') . ($tagsMet++ >= 1 ? "\n" : '') : '') . 
+                (config('other.freeleech') ? __('torrent.global-freeleech') . ($tagsMet++ >= 1 ? "\n" : '') : '') . 
+                ($torrent->free > 0 ? ($tagsMet++ >= 1 ? "\n" : '') . $torrent->free . '% ' . __('common.free') . ($torrent->fl_until !== null ? ' (expires ' . $torrent->fl_until->diffForHumans() . ')' : '') : '') 
+            }}"
         ></i>
     @endif
     @if (config('other.doubleup') || auth()->user()->group->is_double_upload || $torrent->doubleup)
@@ -65,8 +72,8 @@
     @endif
     @if ($torrent->refundable || auth()->user()->group->is_refundable)
         <i class="{{ config('other.font-awesome') }} fa-percentage"
-           title='{{ __('torrent.refundable') }}'>
-        </i>
+           title='{{ __('torrent.refundable') }}"
+        ></i>
     @endif
     @if ($torrent->sticky)
         <i

--- a/resources/views/components/partials/_torrent-icons.blade.php
+++ b/resources/views/components/partials/_torrent-icons.blade.php
@@ -55,12 +55,14 @@
                 'fa-star-half' => ! $alwaysFreeleech && $torrent->free < 90 && $torrent->fl_until === null,
                 'fa-calendar-star' => ! $alwaysFreeleech && $torrent->fl_until !== null,
             ])
-            title="{{ 
-                ($personalFreeleech ? ($tagsMet++ >= 1 ? "\n" : '') . __('torrent.personal-freeleech') : '') . 
-                ($torrent->freeleechTokens_exists ? ($tagsMet++ >= 1 ? "\n" : '') . __('torrent.freeleech-token') : '') . 
-                (auth()->user()->group->is_freeleech ? ($tagsMet++ >= 1 ? "\n" : '') . __('torrent.special-freeleech') : '') . 
-                (config('other.freeleech') ? ($tagsMet++ >= 1 ? "\n" : '') . __('torrent.global-freeleech') : '') . 
-                ($torrent->free > 0 ? ($tagsMet++ >= 1 ? "\n" : '') . $torrent->free . '% ' . __('common.free') . ($torrent->fl_until !== null ? ' (expires ' . $torrent->fl_until->diffForHumans() . ')' : '') : '') 
+            title="{{
+                implode("\n", array_keys([
+                    __('torrent.personal-freeleech') => $personalFreeleech,
+                    __('torrent.freeleech-token')    => $torrent->freeleechTokens_exists,
+                    __('torrent.special-freeleech')  => auth()->user()->group->is_freeleech,
+                    __('torrent.global-freeleech')   => config('other.freeleech'),
+                    $torrent->free . '% ' . __('common.free') . ($torrent->fl_until !== null ? ' (expires ' . $torrent->fl_until->diffForHumans() . ')' : '') => $torrent->free > 0,
+                ], true))
             }}"
         ></i>
     @endif


### PR DESCRIPTION
It is a bit much to have all in one line of code I would suggest to have it spaced in each tag to make it more readable.
Also fixed a formatting error for refundable torrent.