### PR TITLE
(Fix) Chatbox always scrolling to bottom

### DIFF
--- a/resources/js/components/chat/Chatbox.vue
+++ b/resources/js/components/chat/Chatbox.vue
@@ -1071,10 +1071,14 @@ export default {
 
       if (container === null) return;
 
-      if (this.forced != false && force != true && this.frozen) return;
+      if (!this.forced && !force && this.frozen) return;
 
       if (this.scroll || force) {
-        container.animate({ scrollTop: container.scrollHeight }, 0);
+        container.animate({
+          scrollTop: container.scrollHeight
+        }, {
+          duration: 0
+        });
       }
 
       container.scroll({


### PR DESCRIPTION
The logic behind the chatbox is very difficult to understand, but from what I can tell, we shouldn't be scrolling if we're frozen and the scrolling wasn't forced. In such a case, return early instead.