### PR TITLE
(Fix) Alpinejs cloak on login styles

### DIFF
--- a/resources/sass/main/login.scss
+++ b/resources/sass/main/login.scss
@@ -252,3 +252,7 @@ font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, A
     font-weight: bold;
     font-size: 16px;
 }
+
+[x-cloak] {
+    display: none !important;
+}


### PR DESCRIPTION
We don't import our normal styles to the login page, so we have to define it separately.