### PR TITLE
(Fix) Proper encoding of torrent description/mediainfo/bdinfo copy

### DIFF
--- a/resources/views/torrent/partials/bdinfo.blade.php
+++ b/resources/views/torrent/partials/bdinfo.blade.php
@@ -10,9 +10,7 @@
                     class="form__button form__button--text"
                     x-data
                     x-on:click.stop="
-                        text = document.createElement('textarea');
-                        text.innerHTML = decodeURIComponent($refs.bdinfo.textContent).split('').map((c) => '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2)).join('');
-                        navigator.clipboard.writeText(text.value);
+                        navigator.clipboard.writeText($refs.bdinfo.textContent);
                         Swal.fire({
                               toast: true,
                               position: 'top-end',

--- a/resources/views/torrent/partials/mediainfo.blade.php
+++ b/resources/views/torrent/partials/mediainfo.blade.php
@@ -12,9 +12,7 @@
                     class="form__button form__button--text"
                     x-data
                     x-on:click.stop="
-                        text = document.createElement('textarea');
-                        text.innerHTML = decodeURIComponent($refs.mediainfo.textContent.split('').map((c) => '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2)).join(''));
-                        navigator.clipboard.writeText(text.value);
+                        navigator.clipboard.writeText($refs.mediainfo.textContent);
                         Swal.fire({
                               toast: true,
                               position: 'top-end',


### PR DESCRIPTION
Tested by adding emojis into description/mediainfo/bdinfo, clicking the copy button, pasting them into a text editor, and making sure the the text remained the same.