### PR TITLE
(Fix) User bon earnings calculation

### DIFF
--- a/app/Http/Controllers/User/EarningController.php
+++ b/app/Http/Controllers/User/EarningController.php
@@ -41,10 +41,10 @@ class EarningController extends Controller
 
         // These two partially-built queries are used for constructing all the other queries
         $distinctSeeds = Peer::query()
-            ->select(['user_id', 'torrent_id', 'seeder'])
             ->where('user_id', '=', $user->id)
             ->where('seeder', '=', 1)
             ->where('active', '=', 1)
+            ->groupBy('torrent_id')
             ->distinct();
 
         $history = History::query()


### PR DESCRIPTION
The hourly bon allocation cron job does not multiply the bon by how many peers a user has on a torrent, but the user earnings page did not reflect this.