### PR TITLE
(Add) Show information in external tracker

### DIFF
--- a/app/Http/Controllers/ExternalTorrentController.php
+++ b/app/Http/Controllers/ExternalTorrentController.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * NOTICE OF LICENSE.
+ *
+ * UNIT3D Community Edition is open-sourced software licensed under the GNU Affero General Public License v3.0
+ * The details is bundled with this project in the file LICENSE.txt.
+ *
+ * @project    UNIT3D Community Edition
+ *
+ * @author     Roardom <roardom@protonmail.com>
+ * @license    https://www.gnu.org/licenses/agpl-3.0.en.html/ GNU Affero General Public License v3.0
+ */
+
+namespace App\Http\Controllers;
+
+use App\Models\Torrent;
+use App\Services\Unit3dAnnounce;
+
+class ExternalTorrentController extends Controller
+{
+    /**
+     * Display the torrent stored on the external tracker.
+     */
+    public function show(int $id): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
+    {
+        return view('torrent.external-tracker', [
+            'id'              => $id,
+            'torrent'         => Torrent::find($id),
+            'externalTorrent' => Unit3dAnnounce::getTorrent($id),
+        ]);
+    }
+}

--- a/app/Http/Controllers/User/UserController.php
+++ b/app/Http/Controllers/User/UserController.php
@@ -18,6 +18,7 @@ use App\Models\BonTransactions;
 use App\Models\Invite;
 use App\Models\Peer;
 use App\Models\User;
+use App\Services\Unit3dAnnounce;
 use Assada\Achievements\Model\AchievementProgress;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
@@ -102,7 +103,8 @@ class UserController extends Controller
                 ->selectRaw('SUM(active = 0) as inactive')
                 ->where('user_id', '=', $user->id)
                 ->first(),
-            'watch' => $user->watchlist,
+            'watch'        => $user->watchlist,
+            'externalUser' => $user->group->is_modo ? Unit3dAnnounce::getUser($user->id) : null,
         ]);
     }
 

--- a/resources/views/torrent/external-tracker.blade.php
+++ b/resources/views/torrent/external-tracker.blade.php
@@ -1,0 +1,177 @@
+@extends('layout.default')
+
+@section('title')
+    <title>External Tracker - {{ $torrent?->name ?? 'Not Found' }} - {{ config('other.title') }}</title>
+@endsection
+
+@section('meta')
+    <meta name="description" content="{{ __('torrent.peers') }}">
+@endsection
+
+@section('breadcrumbs')
+    <li class="breadcrumbV2">
+        <a href="{{ route('torrents.index') }}" class="breadcrumb__link">
+            {{ __('torrent.torrents') }}
+        </a>
+    </li>
+    <li class="breadcrumbV2">
+        <a href="{{ route('torrents.show', ['id' => $id]) }}" class="breadcrumb__link">
+            {{ $torrent?->name ?? 'Not Found' }}
+        </a>
+    </li>
+    <li class="breadcrumb--active">
+        {{ __('torrent.peers') }}
+    </li>
+@endsection
+
+@section('nav-tabs')
+    <li class="nav-tabV2">
+        <a class="nav-tab__link" href="{{ route('peers', ['id' => $id]) }}">
+            {{ __('torrent.peers') }}
+        </a>
+    </li>
+    <li class="nav-tabV2">
+        <a class="nav-tab__link" href="{{ route('history', ['id' => $id]) }}">
+            {{ __('torrent.history') }}
+        </a>
+    </li>
+    <li class="nav-tab--active">
+        <a class="nav-tab--active__link" href="{{ route('torrents.external_tracker', ['id' => $id]) }}">
+            External Tracker
+        </a>
+    </li>
+@endsection
+
+@section('main')
+    @if ($externalTorrent === true)
+        <section class="panelV2">
+            <h2 class="panel__heading">{{ __('torrent.torrent') }}</h2>
+            <div class="panel__body">
+                External tracker not enabled.
+            </div>
+        </section>
+    @elseif ($externalTorrent === false)
+        <section class="panelV2">
+            <h2 class="panel__heading">{{ __('torrent.torrent') }}</h2>
+            <div class="panel__body">
+                Torrent not found.
+            </div>
+        </section>
+    @elseif ($externalTorrent === [])
+        <section class="panelV2">
+            <h2 class="panel__heading">{{ __('torrent.torrent') }}</h2>
+            <div class="panel__body">
+                Tracker returned an error.
+            </div>
+        </section>
+    @else
+        <section class="panelV2">
+            <h2 class="panel__heading">{{ __('torrent.torrent') }} {{ __('torrent.peers') }}</h2>
+            <div class="data-table-wrapper">
+                <table class="data-table">
+                    <thead>
+                        <tr>
+                            <th>{{ __('common.user') }}</th>
+                            <th>{{ __('torrent.progress') }}</th>
+                            <th>{{ __('common.upload') }}</th>
+                            <th>{{ __('common.download') }}</th>
+                            <th>{{ __('common.ip') }}</th>
+                            <th>{{ __('common.port') }}</th>
+                            <th>{{ __('torrent.started') }}</th>
+                            <th>{{ __('torrent.last-update') }}</th>
+                            <th>{{ __('common.status') }}</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach ($externalTorrent['peers'] ?? [] as $peer)
+                            <tr>
+                                <td>
+                                    @if (null !== ($user = \App\Models\User::find($peer['user_id'])))
+                                        @if ($torrent === null)
+                                            <x-user_tag :user="$user" :anon="true" />
+                                        @else
+                                            <x-user_tag :user="$user" :anon="
+                                                $user->hidden == 1
+                                                || $user->peer_hidden == 1
+                                                || $user->privacy?->show_peer === 0
+                                                || ($user->id == $torrent->user->id && $torrent->anon == 1)
+                                            " />
+                                        @endif
+                                    @else
+                                        User not found
+                                    @endif
+                                </td>
+                                <td>
+                                    @if ($torrent === null)
+                                        Torrent size not available
+                                    @else
+                                        @php
+                                            $progress = 100 * ($peer['downloaded'] % ($torrent->size)) / $torrent->size
+                                        @endphp
+                                        @if (0 < $progress && $progress < 1)
+                                            1%
+                                        @elseif (99 < $progress && $progress < 100)
+                                            99%
+                                        @else
+                                            {{ round($progress) }}
+                                        @endif
+                                    @endif
+                                </td>
+                                <td class="text-green">{{ \App\Helpers\StringHelper::formatBytes($peer['uploaded'] ?? 0, 2) }}</td>
+                                <td class="text-red">{{ \App\Helpers\StringHelper::formatBytes($peer['downloaded'] ?? 0, 2) }}</td>
+                                <td>{{ \App\Helpers\StringHelper::formatBytes($peer['left'] ?? 0, 2) }}</td>
+                                @if (auth()->user()->group->is_modo || auth()->id() == $peer->user_id)
+                                    <td>{{ $peer['ip_address'] }}</td>
+                                    <td>{{ $peer['port'] }}</td>
+                                @else
+                                    <td>---</td>
+                                    <td>---</td>
+                                @endif
+                                <td>
+                                    @php
+                                        $updatedAt = \Illuminate\Support\Carbon::createFromTimestampUTC($peer['updated_at'])
+                                    @endphp
+                                    <time datetime="{{ $updatedAt }}" title="{{ $updatedAt }}">
+                                        {{ $updatedAt ? $updatedAt->diffForHumans() : 'N/A' }}
+                                    </time>
+                                </td>
+                                <td class="{{ $peer['is_active'] ? ($peer['is_seeder'] ? 'text-green' : 'text-red') : 'text-orange' }}">
+                                    @if ($peer['is_active'])
+                                        @if ($peer['is_seeder'])
+                                            {{ __('torrent.seeder') }}
+                                        @else
+                                            {{ __('torrent.leecher') }}
+                                        @endif
+                                    @else
+                                        Inactive
+                                    @endif
+                                </td>
+                            </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+            </div>
+        </section>
+        @section('sidebar')
+            <section class="panelV2">
+                <h2 class="panel__heading">{{ __('torrent.torrent') }}</h2>
+                <dl class="key-value">
+                    <dt>{{ __('common.moderation') }}</dt>
+                    <dd>{{ $externalTorrent['status'] }}</dd>
+                    <dt>{{ __('torrent.seeders') }}</dt>
+                    <dd>{{ $externalTorrent['seeders'] }}</dd>
+                    <dt>{{ __('torrent.leechers') }}</dt>
+                    <dd>{{ $externalTorrent['leechers'] }}</dd>
+                    <dt>{{ __('torrent.completed-times') }}</dt>
+                    <dd>{{ $externalTorrent['times_completed'] }}</dd>
+                    <dt>Download Factor</dt>
+                    <dd>{{ $externalTorrent['download_factor'] }}</dd>
+                    <dt>Upload Factor</dt>
+                    <dd>{{ $externalTorrent['upload_factor'] }}</dd>
+                    <dt>Deleted</dt>
+                    <dd>{{ $externalTorrent['is_deleted'] ? __('common.yes') : __('common.no') }}</dd>
+                </dl>
+            </section>
+        @endsection
+    @endif
+@endsection

--- a/resources/views/torrent/history.blade.php
+++ b/resources/views/torrent/history.blade.php
@@ -35,6 +35,13 @@
             {{ __('torrent.history') }}
         </a>
     </li>
+    @if (config('announce.external_tracker.is_enabled') && auth()->user()->group->is_modo)
+        <li class="nav-tabV2">
+            <a class="nav-tab__link" href="{{ route('torrents.external_tracker', ['id' => $torrent]) }}">
+                External Tracker
+            </a>
+        </li>
+    @endif
 @endsection
 
 @section('content')

--- a/resources/views/torrent/peers.blade.php
+++ b/resources/views/torrent/peers.blade.php
@@ -35,6 +35,13 @@
             {{ __('torrent.history') }}
         </a>
     </li>
+    @if (config('announce.external_tracker.is_enabled') && auth()->user()->group->is_modo)
+        <li class="nav-tabV2">
+            <a class="nav-tab__link" href="{{ route('torrents.external_tracker', ['id' => $torrent]) }}">
+                External Tracker
+            </a>
+        </li>
+    @endif
 @endsection
 
 @section('main')

--- a/resources/views/user/profile/show.blade.php
+++ b/resources/views/user/profile/show.blade.php
@@ -608,6 +608,68 @@
                 </dl>
             </section>
         @endif
+        @if (config('announce.external_tracker.is_enabled') && auth()->user()->group->is_modo)
+            @if ($externalUser === true)
+                <section class="panelV2">
+                    <h2 class="panel__heading">{{ __('torrent.torrent') }}</h2>
+                    <div class="panel__body">
+                        External tracker not enabled.
+                    </div>
+                </section>
+            @elseif ($externalUser === false)
+                <section class="panelV2">
+                    <h2 class="panel__heading">{{ __('torrent.torrent') }}</h2>
+                    <div class="panel__body">
+                        User not found.
+                    </div>
+                </section>
+            @elseif ($externalUser === [])
+                <section class="panelV2">
+                    <h2 class="panel__heading">{{ __('torrent.torrent') }}</h2>
+                    <div class="panel__body">
+                        Tracker returned an error.
+                    </div>
+                </section>
+            @else
+                <section class="panelV2">
+                    <h2 class="panel__heading">External Tracker</h2>
+                    <dl class="key-value">
+                        <dt>{{ __('common.group') }}</dt>
+                        <dd>
+                            @if (null !== ($group = \App\Models\Group::find($externalUser['group_id'])))
+                                <span class="user-tag">
+                                    <a
+                                        class="user-tag__link {{ $group->icon }}"
+                                        href="{{ route('group', ['id' => $group->id]) }}"
+                                        style="color: {{ $group->color }}"
+                                        title="{{ $group->name }}"
+                                    >
+                                        {{ $group->name }}
+                                    </a>
+                                </span>
+                            @else
+                                Unrecognized group_id: {{ $externalUser['group_id'] }}
+                            @endif
+                        </dd>
+                        <dt>{{ __('user.passkey') }}</dt>
+                        <dd>
+
+                            <details>
+                                <summary style="cursor: pointer;">{{ __('user.show-passkey') }}</summary>
+                                <code><pre>{{ $externalUser['passkey'] }}</pre></code>
+                                <span class="text-red">{{ __('user.passkey-warning') }}</span>
+                            </details>
+                        </dd>
+                        <dt>{{ __('user.can-download') }}</dt>
+                        <dd>{{ $externalUser['can_download'] ? __('common.yes') : __('common.no') }}</dd>
+                        <dt>{{ __('user.total-seeding') }}</dt>
+                        <dd>{{ $externalUser['num_seeding'] }}</dd>
+                        <dt>{{ __('user.total-leeching') }}</dt>
+                        <dd>{{ $externalUser['num_leeching'] }}</dd>
+                    </dl>
+                </section>
+            @endif
+        @endif
         @if (auth()->user()->is($user) || auth()->user()->group->is_modo)
             <section class="panelV2">
                 <h2 class="panel__heading">

--- a/routes/web.php
+++ b/routes/web.php
@@ -178,6 +178,7 @@ Route::middleware('language')->group(function (): void {
         Route::prefix('torrents')->group(function (): void {
             Route::get('/{id}/peers', [App\Http\Controllers\TorrentPeerController::class, 'index'])->name('peers');
             Route::get('/{id}/history', [App\Http\Controllers\TorrentHistoryController::class, 'index'])->name('history');
+            Route::get('/{id}/external-tracker', [App\Http\Controllers\ExternalTorrentController::class, 'show'])->name('torrents.external_tracker')->middleware('modo');
             Route::get('/download_check/{id}', [App\Http\Controllers\TorrentDownloadController::class, 'show'])->name('download_check');
             Route::get('/download/{id}', [App\Http\Controllers\TorrentDownloadController::class, 'store'])->name('download');
             Route::post('/{id}/reseed', [App\Http\Controllers\ReseedController::class, 'store'])->name('reseed');


### PR DESCRIPTION
Allows staff to view external tracker torrent/peer/user data via the front-end