### PR TITLE
(Fix) Error 500 on login when invalid username

### DIFF
--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -147,6 +147,11 @@ class FortifyServiceProvider extends ServiceProvider
             ]);
 
             $user = User::query()->where('username', $request->username)->first();
+            if ($user == null) {
+                throw ValidationException::withMessages([
+                    Fortify::username() => __('auth.failed'),
+                ]);
+            }
             $password = Hash::check($request->password, $user->password);
 
             if ($user && $password === false) {

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -155,7 +155,7 @@ class FortifyServiceProvider extends ServiceProvider
             }
             $password = Hash::check($request->password, $user->password);
 
-            if ($user && $password === false) {
+            if ($password === false) {
                 FailedLoginAttempt::create([
                     'user_id'    => $user->id,
                     'username'   => $request->username,
@@ -171,7 +171,7 @@ class FortifyServiceProvider extends ServiceProvider
                 ]);
             }
 
-            if ($user && $password === true) {
+            if ($password === true) {
                 // Check if user is activated
                 $validatingGroup = cache()->rememberForever('validating_group', fn () => Group::query()->where('slug', '=', 'validating')->pluck('id'));
 

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -139,7 +139,7 @@ class FortifyServiceProvider extends ServiceProvider
         Fortify::updateUserPasswordsUsing(UpdateUserPassword::class);
         Fortify::resetUserPasswordsUsing(ResetUserPassword::class);
 
-        Fortify::authenticateUsing(function (Request $request): \Illuminate\Database\Eloquent\Model | bool {
+        Fortify::authenticateUsing(function (Request $request): \Illuminate\Database\Eloquent\Model {
             $request->validate([
                 'username' => 'required|string',
                 'password' => 'required|string',
@@ -153,6 +153,7 @@ class FortifyServiceProvider extends ServiceProvider
                     Fortify::username() => __('auth.failed'),
                 ]);
             }
+            
             $password = Hash::check($request->password, $user->password);
 
             if ($password === false) {
@@ -196,8 +197,6 @@ class FortifyServiceProvider extends ServiceProvider
 
                 return $user;
             }
-
-            return false;
         });
 
         RateLimiter::for('login', fn (Request $request) => Limit::perMinute(5)->by($request->ip()));

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -147,6 +147,7 @@ class FortifyServiceProvider extends ServiceProvider
             ]);
 
             $user = User::query()->where('username', $request->username)->first();
+
             if ($user == null) {
                 throw ValidationException::withMessages([
                     Fortify::username() => __('auth.failed'),

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -153,7 +153,7 @@ class FortifyServiceProvider extends ServiceProvider
                     Fortify::username() => __('auth.failed'),
                 ]);
             }
-            
+
             $password = Hash::check($request->password, $user->password);
 
             if ($password === false) {


### PR DESCRIPTION
Instead of showing error 500 when a username was not found, we should return a failed login message.