### PR TITLE
(Update) Decrease chatbox font size from 18px to 16px

### DIFF
--- a/resources/sass/chat/chatbox.scss
+++ b/resources/sass/chat/chatbox.scss
@@ -482,7 +482,7 @@
                         width: 100%;
                         max-width: 100%;
                         line-height: 130%;
-                        font-size: 18px;
+                        font-size: 16px;
                         font-weight: 400;
 
                         .system {


### PR DESCRIPTION
This is the same size as the system messages which should be the same, and it just looks better.