### PR TITLE
(Update) Use 64 bit integer for history id

### DIFF
--- a/database/migrations/2024_01_12_092724_alter_history_table_64_int_id.php
+++ b/database/migrations/2024_01_12_092724_alter_history_table_64_int_id.php
@@ -1,0 +1,14 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::table('history', function (Blueprint $table): void {
+            $table->bigIncrements('id')->change();
+        });
+    }
+};


### PR DESCRIPTION
Only took 7 years before running out of ids. Should've been done sooner, but looks like it slipped through the cracks.