### PR TITLE
(Update) Improve sync peers command

### DIFF
--- a/app/Console/Commands/SyncPeers.php
+++ b/app/Console/Commands/SyncPeers.php
@@ -54,8 +54,9 @@ class SyncPeers extends Command
                 fn ($join) => $join->on('torrents.id', '=', 'seeders_leechers.torrent_id')
             )
             ->update([
-                'seeders'  => DB::raw('COALESCE(seeders_leechers.updated_seeders, 0)'),
-                'leechers' => DB::raw('COALESCE(seeders_leechers.updated_leechers, 0)'),
+                'seeders'    => DB::raw('COALESCE(seeders_leechers.updated_seeders, 0)'),
+                'leechers'   => DB::raw('COALESCE(seeders_leechers.updated_leechers, 0)'),
+                'updated_at' => DB::raw('updated_at')
             ]);
 
         $this->comment('Torrent Peer Syncing Command Complete');


### PR DESCRIPTION
With 1.3 million peers and 200k torrents, reduces query time from 14240 ms to 3418 ms.