### PR TITLE
(Update) Remove eloquent updated in commands

### DIFF
--- a/app/Console/Commands/AutoFlushPeers.php
+++ b/app/Console/Commands/AutoFlushPeers.php
@@ -63,8 +63,9 @@ class AutoFlushPeers extends Command
                 ]);
 
             Torrent::where('id', '=', $peer->torrent_id)->update([
-                'seeders'  => DB::raw('seeders - '.((int) $peer->seeder)),
-                'leechers' => DB::raw('leechers - '.((int) !$peer->seeder)),
+                'seeders'    => DB::raw('seeders - '.((int) $peer->seeder)),
+                'leechers'   => DB::raw('leechers - '.((int) !$peer->seeder)),
+                'updated_at' => DB::raw('updated_at'),
             ]);
 
             $peer->active = false;

--- a/app/Console/Commands/AutoHighspeedTag.php
+++ b/app/Console/Commands/AutoHighspeedTag.php
@@ -60,7 +60,8 @@ class AutoHighspeedTag extends Command
                 fn ($join) => $join->on('torrents.id', '=', 'highspeed_torrents.torrent_id')
             )
             ->update([
-                'highspeed' => DB::raw('CASE WHEN highspeed_torrents.torrent_id IS NOT NULL THEN 1 ELSE 0 END'),
+                'highspeed'  => DB::raw('CASE WHEN highspeed_torrents.torrent_id IS NOT NULL THEN 1 ELSE 0 END'),
+                'updated_at' => DB::raw('updated_at'),
             ]);
 
         $this->comment('Automated High Speed Torrents Command Complete');

--- a/app/Console/Commands/AutoTorrentBalance.php
+++ b/app/Console/Commands/AutoTorrentBalance.php
@@ -46,7 +46,10 @@ class AutoTorrentBalance extends Command
             'balances',
             fn ($join) => $join->on('balances.torrent_id', '=', 'torrents.id')
         )
-            ->update(['torrents.balance' => DB::raw('balances.balance')]);
+            ->update([
+                'torrents.balance' => DB::raw('balances.balance'),
+                'updated_at'       => DB::raw('updated_at'),
+            ]);
 
         $this->comment('Torrent balance calculations completed.');
     }


### PR DESCRIPTION
Eloquent is automatically updating the updated_at timestamp. To prevent this, set the updated_at column to itself. Reduces query time by 50-75%.