### PR TITLE
(Fix) Case insensitivity duplicate checking in keyword upsert

### DIFF
--- a/app/Helpers/TorrentTools.php
+++ b/app/Helpers/TorrentTools.php
@@ -203,6 +203,9 @@ class TorrentTools
      */
     public static function parseKeywords(string $text): array
     {
-        return array_filter(array_unique(array_map('trim', explode(',', $text))));
+        $keywords = array_filter(array_map('trim', explode(',', $text)));
+
+        // unique keywords only (case insensitive)
+        return array_values(array_intersect_key($keywords, array_unique(array_map('strtolower', $keywords))));
     }
 }

--- a/app/Http/Controllers/API/TorrentController.php
+++ b/app/Http/Controllers/API/TorrentController.php
@@ -288,7 +288,7 @@ class TorrentController extends BaseController
         }
 
         foreach (collect($keywords)->chunk(intdiv(65_000, 2)) as $keywords) {
-            Keyword::upsert($keywords->toArray(), ['torrent_id', 'name'], []);
+            Keyword::upsert($keywords->toArray(), ['torrent_id', 'name']);
         }
 
         // check for trusted user and update torrent

--- a/app/Http/Controllers/TorrentController.php
+++ b/app/Http/Controllers/TorrentController.php
@@ -221,7 +221,7 @@ class TorrentController extends Controller
         }
 
         foreach (collect($keywords)->chunk(65_000 / 2) as $keywords) {
-            Keyword::upsert($keywords->toArray(), ['torrent_id', 'name'], []);
+            Keyword::upsert($keywords->toArray(), ['torrent_id', 'name']);
         }
 
         $category = $torrent->category;
@@ -420,7 +420,7 @@ class TorrentController extends Controller
         }
 
         foreach (collect($keywords)->chunk(intdiv(65_000, 2)) as $keywords) {
-            Keyword::upsert($keywords->toArray(), ['torrent_id', 'name'], []);
+            Keyword::upsert($keywords->toArray(), ['torrent_id', 'name']);
         }
 
         // Cover Image for No-Meta Torrents


### PR DESCRIPTION
We were deduping keywords, but we were only checking for exact duplicates. Now we check for case insensitive duplicates, and make sure to update the duplicates on upsert instead of treating the upsert as an insert. Fixes #3412.