### PR TITLE
(Fix) Sticky header disappearing due to sticky footer implementation

### DIFF
--- a/resources/sass/layout/_footer.scss
+++ b/resources/sass/layout/_footer.scss
@@ -1,5 +1,5 @@
 html, body {
-    height: 100%;
+    min-height: 100vh; /* Used for sticky footer */
 }
 
 .footer {


### PR DESCRIPTION
This is a bug I've been meaning to fix for a very long time. Ever since I added the sticky footer implementation, the sticky header would disappear once the footer came into view. This workaround fixes this situation.