### PR TITLE
Output torrent name during fetch:meta execution

### DIFF
--- a/app/Console/Commands/FetchMeta.php
+++ b/app/Console/Commands/FetchMeta.php
@@ -41,19 +41,20 @@ class FetchMeta extends Command
         $this->alert('Meta Fetcher Started');
 
         $tmdbScraper = new TMDBScraper();
-        $torrents = Torrent::with('category')->select('tmdb', 'category_id')->whereNotNull('tmdb')->where('tmdb', '!=', 0)->oldest()->get();
+        $torrents = Torrent::with('category')->select('tmdb', 'category_id', 'name')->whereNotNull('tmdb')->where('tmdb', '!=', 0)->oldest()->get();
 
         foreach ($torrents as $torrent) {
             sleep(3);
 
             if ($torrent->category->tv_meta) {
                 $tmdbScraper->tv($torrent->tmdb);
-                $this->info('TV Fetched');
+                $this->info(sprintf('(%s) Metadata Fetched For Torrent %s ', $torrent->category->name, $torrent->name));
+
             }
 
             if ($torrent->category->movie_meta) {
                 $tmdbScraper->movie($torrent->tmdb);
-                $this->info('Movie Fetched');
+                $this->info(sprintf('(%s) Metadata Fetched For Torrent %s ', $torrent->category->name, $torrent->name));
             }
         }
 


### PR DESCRIPTION
Output torrent name during fetch:meta execution. That will help admins know if the changes are taking effect and keep track of the progress