### PR TITLE
(Fix) Quickly ticking torrents on similar page

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1136,16 +1136,6 @@ parameters:
 			path: app/Http/Livewire/PersonCredit.php
 
 		-
-			message: "#^Method App\\\\Http\\\\Livewire\\\\SimilarTorrent\\:\\:isChecked\\(\\) has parameter \\$torrentId with no type specified\\.$#"
-			count: 1
-			path: app/Http/Livewire/SimilarTorrent.php
-
-		-
-			message: "#^Method App\\\\Http\\\\Livewire\\\\SimilarTorrent\\:\\:updatedSelectPage\\(\\) has parameter \\$value with no type specified\\.$#"
-			count: 1
-			path: app/Http/Livewire/SimilarTorrent.php
-
-		-
 			message: "#^Property App\\\\Http\\\\Livewire\\\\SimilarTorrent\\:\\:\\$listeners has no type specified\\.$#"
 			count: 1
 			path: app/Http/Livewire/SimilarTorrent.php

--- a/resources/views/livewire/similar-torrent.blade.php
+++ b/resources/views/livewire/similar-torrent.blade.php
@@ -94,9 +94,10 @@
                                         >
                                             <input
                                                 id="torrent_checkbox_{{ $torrent->id }}"
+                                                name="torrent_checkbox_{{ $torrent->id }}"
                                                 type="checkbox"
-                                                value="{{ $torrent->id }}"
-                                                wire:model="checked"
+                                                value="1"
+                                                wire:model="checked.{{ $torrent->id }}"
                                             />
                                         </td>
                                     </tr>


### PR DESCRIPTION
Before, if torrents were ticked faster than the response from the server, the checkboxes would revert to the state of the first response received back.