### PR TITLE
(Update) Use queued announce updates

### DIFF
--- a/app/DTO/AnnounceGroupDTO.php
+++ b/app/DTO/AnnounceGroupDTO.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * NOTICE OF LICENSE.
+ *
+ * UNIT3D Community Edition is open-sourced software licensed under the GNU Affero General Public License v3.0
+ * The details is bundled with this project in the file LICENSE.txt.
+ *
+ * @project    UNIT3D Community Edition
+ *
+ * @author     Roardom <roardom@protonmail.com>
+ * @license    https://www.gnu.org/licenses/agpl-3.0.en.html/ GNU Affero General Public License v3.0
+ */
+
+namespace App\DTO;
+
+readonly class AnnounceGroupDTO
+{
+    public function __construct(
+        public bool $isFreeleech,
+        public bool $isDoubleUpload,
+        public bool $isImmune,
+    ) {
+    }
+}

--- a/app/DTO/AnnouncePeerDTO.php
+++ b/app/DTO/AnnouncePeerDTO.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * NOTICE OF LICENSE.
+ *
+ * UNIT3D Community Edition is open-sourced software licensed under the GNU Affero General Public License v3.0
+ * The details is bundled with this project in the file LICENSE.txt.
+ *
+ * @project    UNIT3D Community Edition
+ *
+ * @author     Roardom <roardom@protonmail.com>
+ * @license    https://www.gnu.org/licenses/agpl-3.0.en.html/ GNU Affero General Public License v3.0
+ */
+
+namespace App\DTO;
+
+readonly class AnnouncePeerDTO
+{
+    public function __construct(
+        public bool $active,
+        public int $uploaded,
+        public int $downloaded,
+        public int $left,
+    ) {
+    }
+}

--- a/app/DTO/AnnounceQueryDTO.php
+++ b/app/DTO/AnnounceQueryDTO.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * NOTICE OF LICENSE.
+ *
+ * UNIT3D Community Edition is open-sourced software licensed under the GNU Affero General Public License v3.0
+ * The details is bundled with this project in the file LICENSE.txt.
+ *
+ * @project    UNIT3D Community Edition
+ *
+ * @author     Roardom <roardom@protonmail.com>
+ * @license    https://www.gnu.org/licenses/agpl-3.0.en.html/ GNU Affero General Public License v3.0
+ */
+
+namespace App\DTO;
+
+readonly class AnnounceQueryDTO
+{
+    private string $agent;
+    private string $infoHash;
+    private string $peerId;
+    private string $ip;
+
+    public function __construct(
+        public int $port,
+        public int $uploaded,
+        public int $downloaded,
+        public int $left,
+        public int $corrupt,
+        public int $numwant,
+        public string $event,
+        public string $key,
+        string $agent,
+        string $infoHash,
+        string $peerId,
+        string $ip,
+    ) {
+        $this->agent = bin2hex($agent);
+        $this->infoHash = bin2hex($infoHash);
+        $this->peerId = bin2hex($peerId);
+        $this->ip = bin2hex($ip);
+    }
+
+    public function getAgent(): string
+    {
+        /** @var string */
+        return hex2bin($this->agent);
+    }
+
+    public function getInfoHash(): string
+    {
+        /** @var string */
+        return hex2bin($this->infoHash);
+    }
+
+    public function getPeerId(): string
+    {
+        /** @var string */
+        return hex2bin($this->peerId);
+    }
+
+    public function getIp(): string
+    {
+        /** @var string */
+        return hex2bin($this->ip);
+    }
+}

--- a/app/DTO/AnnounceTorrentDTO.php
+++ b/app/DTO/AnnounceTorrentDTO.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * NOTICE OF LICENSE.
+ *
+ * UNIT3D Community Edition is open-sourced software licensed under the GNU Affero General Public License v3.0
+ * The details is bundled with this project in the file LICENSE.txt.
+ *
+ * @project    UNIT3D Community Edition
+ *
+ * @author     Roardom <roardom@protonmail.com>
+ * @license    https://www.gnu.org/licenses/agpl-3.0.en.html/ GNU Affero General Public License v3.0
+ */
+
+namespace App\DTO;
+
+readonly class AnnounceTorrentDTO
+{
+    public function __construct(
+        public int $id,
+        public int $percentFree,
+        public bool $isDoubleUpload,
+    ) {
+    }
+}

--- a/app/DTO/AnnounceUserDTO.php
+++ b/app/DTO/AnnounceUserDTO.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * NOTICE OF LICENSE.
+ *
+ * UNIT3D Community Edition is open-sourced software licensed under the GNU Affero General Public License v3.0
+ * The details is bundled with this project in the file LICENSE.txt.
+ *
+ * @project    UNIT3D Community Edition
+ *
+ * @author     Roardom <roardom@protonmail.com>
+ * @license    https://www.gnu.org/licenses/agpl-3.0.en.html/ GNU Affero General Public License v3.0
+ */
+
+namespace App\DTO;
+
+readonly class AnnounceUserDTO
+{
+    public function __construct(
+        public int $id,
+        public AnnounceGroupDTO $group,
+    ) {
+    }
+}

--- a/app/Http/Controllers/AnnounceController.php
+++ b/app/Http/Controllers/AnnounceController.php
@@ -17,20 +17,23 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers;
 
+use App\DTO\AnnounceGroupDTO;
+use App\DTO\AnnouncePeerDTO;
+use App\DTO\AnnounceQueryDTO;
+use App\DTO\AnnounceTorrentDTO;
+use App\DTO\AnnounceUserDTO;
 use App\Exceptions\TrackerException;
 use App\Jobs\ProcessAnnounce;
 use App\Models\BlacklistClient;
-use App\Models\FeaturedTorrent;
-use App\Models\FreeleechToken;
 use App\Models\Group;
 use App\Models\Peer;
-use App\Models\PersonalFreeleech;
 use App\Models\Scopes\ApprovedScope;
 use App\Models\Torrent;
 use App\Models\User;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\DB;
+use Random\RandomException;
 use Throwable;
 use Exception;
 use Illuminate\Support\Facades\Redis;
@@ -97,7 +100,7 @@ final class AnnounceController extends Controller
             $group = $this->checkGroup($user);
 
             // Get Torrent Info Array from queries and judge if user can reach it.
-            $torrent = $this->checkTorrent($queries['info_hash']);
+            $torrent = $this->checkTorrent($queries->getInfoHash());
 
             // Check if a user is announcing a torrent as completed but no peer is in db.
             $this->checkPeer($torrent, $queries, $user);
@@ -120,9 +123,11 @@ final class AnnounceController extends Controller
             $this->processAnnounceJob($queries, $user, $group, $torrent);
         } catch (TrackerException $exception) {
             $response = $this->generateFailedAnnounceResponse($exception);
-        } finally {
-            return $this->sendFinalAnnounceResponse($response);
+        } catch (Exception) {
+            $response = 'd14:failure reason21:Internal Server Error8:intervali5400e12:min intervali5400ee';
         }
+
+        return $this->sendFinalAnnounceResponse($response);
     }
 
     /**
@@ -175,7 +180,7 @@ final class AnnounceController extends Controller
         // Block Blacklisted Clients
         $blacklistedPeerIdPrefixes = cache()->rememberForever('client_blacklist', fn () => BlacklistClient::pluck('peer_id_prefix')->toArray());
 
-        $peerId = $request->query->get('peer_id');
+        $peerId = $request->query->getString('peer_id');
 
         foreach ($blacklistedPeerIdPrefixes as $blacklistedPeerIdPrefix) {
             if (str_starts_with($peerId, $blacklistedPeerIdPrefix)) {
@@ -190,20 +195,20 @@ final class AnnounceController extends Controller
      * @throws TrackerException
      * @throws Throwable
      */
-    private function checkPasskey($passkey): void
+    private function checkPasskey(string $passkey): void
     {
         // If Passkey Is Not Provided Return Error to Client
-        if ($passkey === null) {
+        if ($passkey === '') {
             throw new TrackerException(130, [':attribute' => 'passkey']);
         }
 
         // If Passkey Length Is Wrong
-        if(\strlen((string) $passkey) !== 32) {
+        if(\strlen($passkey) !== 32) {
             throw new TrackerException(132, [':attribute' => 'passkey', ':rule' => 32]);
         }
 
         // If Passkey Format Is Wrong
-        if (strspn(strtolower((string) $passkey), 'abcdef0123456789') !== 32) {
+        if (strspn(strtolower($passkey), 'abcdef0123456789') !== 32) {
             throw new TrackerException(131, [':attribute' => 'passkey', ':reason' => 'Passkey format is incorrect']);
         }
     }
@@ -214,11 +219,11 @@ final class AnnounceController extends Controller
      * @throws TrackerException
      * @throws Throwable
      */
-    private function checkAnnounceFields(Request $request): array
+    private function checkAnnounceFields(Request $request): AnnounceQueryDTO
     {
         $queries = [];
 
-        // Part.1 Extract required announce fields
+        // Part.1 Validate required announce fields
         foreach (['info_hash', 'peer_id', 'port', 'uploaded', 'downloaded', 'left'] as $item) {
             $itemData = $request->query->get($item);
 
@@ -241,8 +246,6 @@ final class AnnounceController extends Controller
             if (!is_numeric($itemData) || $itemData < 0) {
                 throw new TrackerException(134, [':attribute' => $item]);
             }
-
-            $queries[$item] = (int) $itemData;
         }
 
         // Part.2 Extract optional announce fields
@@ -259,28 +262,20 @@ final class AnnounceController extends Controller
             if (!is_numeric($queries[$item]) || $queries[$item] < 0) {
                 throw new TrackerException(134, [':attribute' => $item]);
             }
-
-            $queries[$item] = (int) $queries[$item];
         }
 
-        $queries['event'] = strtolower($queries['event']);
+        $queries['event'] = strtolower((string) $queries['event']);
 
         if (!\in_array($queries['event'], ['started', 'completed', 'stopped', 'paused', ''])) {
             throw new TrackerException(136, [':event' => $queries['event']]);
         }
 
         // Part.3 check Port is Valid and Allowed
-        /**
-         * Normally , the port must in 1 - 65535 , that is ( $port > 0 && $port < 0xffff )
-         * However, in some case , When `&event=stopped` the port may set to 0.
-         */
-        if ($queries['port'] === 0 && $queries['event'] !== 'stopped') {
-            throw new TrackerException(137, [':event' => $queries['event']]);
-        }
-
         if (
-            !is_numeric($queries['port'])
-            || $queries['port'] < 1024 // Block system-reserved ports since 99.9% of the time they're fake and thus not connectable
+            !ctype_digit($queries['port'])
+            // Block system-reserved ports since 99.9% of the time they're fake and thus not connectable
+            // Some clients will send port of 0 on 'stopped' events. Let them through as they won't receive peers anyway.
+            || ($queries['port'] < 1024 && $queries['event'] !== 'stopped')
             || $queries['port'] > 0xFFFF
             || \in_array($queries['port'], self::BLACK_PORTS, true)
         ) {
@@ -288,12 +283,23 @@ final class AnnounceController extends Controller
         }
 
         // Part.4 Get request ip and convert it to packed form
-        $queries['ip-address'] = inet_pton($request->getClientIp());
+        /** @var string */
+        $ip = inet_pton($request->getClientIp());
 
-        // Part.5 Get Users Agent
-        $queries['user-agent'] = $request->headers->get('user-agent');
-
-        return $queries;
+        return new AnnounceQueryDTO(
+            (int) $queries['port'],
+            (int) $queries['uploaded'],
+            (int) $queries['downloaded'],
+            (int) $queries['left'],
+            (int) $queries['corrupt'],
+            (int) $queries['numwant'],
+            $queries['event'],
+            (string) $queries['key'],
+            $request->headers->get('user-agent'),
+            (string) $queries['info_hash'],
+            (string) $queries['peer_id'],
+            $ip,
+        );
     }
 
     /**
@@ -302,7 +308,7 @@ final class AnnounceController extends Controller
      * @throws TrackerException
      * @throws Throwable
      */
-    private function checkUser(string $passkey, array $queries): object
+    private function checkUser(string $passkey, AnnounceQueryDTO $queries): User
     {
         // Check Passkey Against Users Table
         $user = cache()->remember('user:'.$passkey, 8 * 3600, fn () => User::query()
@@ -316,7 +322,7 @@ final class AnnounceController extends Controller
         }
 
         // If User Download Rights Are Disabled Return Error to Client
-        if ($user->can_download === false && $queries['left'] !== 0) {
+        if ($user->can_download === false && $queries->left !== 0) {
             throw new TrackerException(142);
         }
 
@@ -329,7 +335,7 @@ final class AnnounceController extends Controller
      * @throws TrackerException
      * @throws Throwable
      */
-    private function checkGroup($user): object
+    private function checkGroup(User $user): Group
     {
         $deniedGroups = cache()->remember('denied_groups', 8 * 3600, fn () => DB::table('groups')
             ->selectRaw("min(case when slug = 'banned' then id end) as banned_id")
@@ -366,7 +372,7 @@ final class AnnounceController extends Controller
      * @throws TrackerException
      * @throws Throwable
      */
-    private function checkTorrent(string $infoHash): object
+    private function checkTorrent(string $infoHash): Torrent
     {
         $torrent = cache()->remember(
             'announce-torrents:by-infohash:'.$infoHash,
@@ -415,12 +421,12 @@ final class AnnounceController extends Controller
      * @throws TrackerException
      * @throws Throwable
      */
-    private function checkPeer(object $torrent, array $queries, object $user): void
+    private function checkPeer(Torrent $torrent, AnnounceQueryDTO $queries, User $user): void
     {
         if (
-            $queries['event'] === 'completed'
+            $queries->event === 'completed'
             && $torrent->peers
-                ->where('peer_id', '=', $queries['peer_id'])
+                ->where('peer_id', '=', $queries->getPeerId())
                 ->where('user_id', '=', $user->id)
                 ->isEmpty()
         ) {
@@ -435,21 +441,21 @@ final class AnnounceController extends Controller
      * @throws Exception
      * @throws Throwable
      */
-    private function checkMinInterval(object $torrent, array $queries, object $user): void
+    private function checkMinInterval(Torrent $torrent, AnnounceQueryDTO $queries, User $user): void
     {
-        $event = match ($queries['event']) {
+        $event = match ($queries->event) {
             'started'   => 'started',
             'completed' => 'completed',
             'stopped'   => 'stopped',
             default     => 'empty',
         };
 
-        $now = now()->timestamp;
+        $now = (int) now()->timestamp;
 
         // Detect broken (namely qBittorrent) clients sending duplicate announces
         // and eliminate them from screwing up stats.
 
-        $duplicateAnnounceKey = config('cache.prefix').'announce-lock:'.$user->id.'-'.$torrent->id.'-'.$queries['peer_id'].'-'.$event;
+        $duplicateAnnounceKey = config('cache.prefix').'announce-lock:'.$user->id.'-'.$torrent->id.'-'.$queries->getPeerId().'-'.$event;
 
         $lastAnnouncedAt = Redis::connection('announce')->command('SET', [$duplicateAnnounceKey, $now, ['NX', 'GET', 'EX' => 30]]);
 
@@ -459,7 +465,7 @@ final class AnnounceController extends Controller
 
         // Block clients disrespecting the min interval
 
-        $lastAnnouncedKey = config('cache.prefix').'peer-last-announced:'.$user->id.'-'.$torrent->id.'-'.$queries['peer_id'];
+        $lastAnnouncedKey = config('cache.prefix').'peer-last-announced:'.$user->id.'-'.$torrent->id.'-'.$queries->getPeerId();
 
         $randomMinInterval = intdiv(random_int(85, 95) * self::MIN, 100);
 
@@ -480,7 +486,7 @@ final class AnnounceController extends Controller
      * @throws TrackerException
      * @throws Throwable
      */
-    private function checkMaxConnections(object $torrent, object $user): void
+    private function checkMaxConnections(Torrent $torrent, User $user): void
     {
         // Pull Count On Users Peers Per Torrent For Rate Limiting
         $connections = $torrent->peers
@@ -500,12 +506,12 @@ final class AnnounceController extends Controller
      * @throws TrackerException
      * @throws Throwable
      */
-    private function checkDownloadSlots(array $queries, object $torrent, object $user, object $group): void
+    private function checkDownloadSlots(AnnounceQueryDTO $queries, Torrent $torrent, User $user, Group $group): void
     {
         $max = $group->download_slots;
 
         $peer = $torrent->peers
-            ->where('peer_id', '=', $queries['peer_id'])
+            ->where('peer_id', '=', $queries->getPeerId())
             ->where('user_id', '=', $user->id)
             ->first();
 
@@ -514,8 +520,8 @@ final class AnnounceController extends Controller
         $count = cache()->get($cacheKey, 0);
 
         $isNewPeer = $peer === null;
-        $isDeadPeer = $queries['event'] === 'stopped';
-        $isSeeder = $queries['left'] === 0;
+        $isDeadPeer = $queries->event === 'stopped';
+        $isSeeder = $queries->left === 0;
 
         $newLeech = $isNewPeer && !$isDeadPeer && !$isSeeder;
         $stoppedLeech = !$isNewPeer && $isDeadPeer && !$isSeeder;
@@ -536,9 +542,9 @@ final class AnnounceController extends Controller
     /**
      * Generate A Successful Announce Response For Client.
      *
-     * @throws Exception
+     * @throws RandomException
      */
-    private function generateSuccessAnnounceResponse(array $queries, object $torrent, object $user): string
+    private function generateSuccessAnnounceResponse(AnnounceQueryDTO $queries, Torrent $torrent, User $user): string
     {
         // Build Response For Bittorrent Client
         // Keys must be ordered alphabetically
@@ -562,11 +568,11 @@ final class AnnounceController extends Controller
          * For non `stopped` event only where either the torrent has at least one leech, or the user is a leech.
          * We query peers from database and send peerlist, otherwise just quick return.
          */
-        if ($queries['event'] !== 'stopped' && ($queries['left'] !== 0 || $torrent->leechers !== 0)) {
-            $limit = (min($queries['numwant'], 25));
+        if ($queries->event !== 'stopped' && ($queries->left !== 0 || $torrent->leechers !== 0)) {
+            $limit = (min($queries->numwant, 25));
 
             // Get Torrents Peers (Only include leechers in a seeder's peerlist)
-            if ($queries['left'] === 0) {
+            if ($queries->left === 0) {
                 foreach ($torrent->peers as $peer) {
                     // Don't include other seeders, inactive peers, nor other peers belonging to the same user
                     if ($peer->seeder || !$peer->active || $peer->user_id === $user->id) {
@@ -626,228 +632,24 @@ final class AnnounceController extends Controller
     /**
      * Process Announce Database Queries.
      */
-    private function processAnnounceJob(array $queries, object $user, object $group, object $torrent): void
+    private function processAnnounceJob(AnnounceQueryDTO $queries, User $user, Group $group, Torrent $torrent): void
     {
-        // Set Variables
-        $event = $queries['event'];
-
-        // Get The Current Peer
         $peer = null;
 
         foreach ($torrent->peers as $torrentPeer) {
-            if ($torrentPeer->user_id === $user->id && $torrentPeer->peer_id === $queries['peer_id']) {
+            if ($torrentPeer->user_id === $user->id && $torrentPeer->peer_id === $queries->getPeerId()) {
                 $peer = $torrentPeer;
 
                 break;
             }
         }
 
-        $isNewPeer = $peer === null;
+        $groupDto = new AnnounceGroupDTO((bool) $group->is_freeleech, (bool) $group->is_double_upload, (bool) $group->is_immune);
+        $userDto = new AnnounceUserDTO($user->id, $groupDto);
+        $torrentDto = new AnnounceTorrentDTO($torrent->id, $torrent->free, $torrent->doubleup);
+        $previousPeerDto = $peer === null ? null : new AnnouncePeerDTO($peer->active, $peer->uploaded, $peer->downloaded, $peer->left);
 
-        // Calculate the change in upload/download compared to the last announce
-        $uploadedDelta = max($queries['uploaded'] - ($peer?->uploaded ?? 0), 0);
-        $downloadedDelta = max($queries['downloaded'] - ($peer?->downloaded ?? 0), 0);
-
-        // If no peer record found then set deltas to 0 and change to `started` event
-        if ($isNewPeer) {
-            if ($queries['uploaded'] > 0 || $queries['downloaded'] > 0) {
-                $event = 'started';
-                $uploadedDelta = 0;
-                $downloadedDelta = 0;
-            }
-
-            $peer = new Peer();
-        }
-
-        // Check if user currently has a personal freeleech
-        $personalFreeleech = cache()->rememberForever(
-            'personal_freeleech:'.$user->id,
-            fn () => PersonalFreeleech::query()
-                ->where('user_id', '=', $user->id)
-                ->exists()
-        );
-
-        // Check if user has a freeleech token on this torrent
-        $freeleechToken = cache()->rememberForever(
-            'freeleech_token:'.$user->id.':'.$torrent->id,
-            fn () => FreeleechToken::query()
-                ->where('user_id', '=', $user->id)
-                ->where('torrent_id', '=', $torrent->id)
-                ->exists(),
-        );
-
-        // Check if the torrent is featured
-        $isFeatured = \in_array(
-            $torrent->id,
-            cache()->rememberForever(
-                'featured-torrent-ids',
-                fn () => FeaturedTorrent::select('id')->pluck('id')->toArray(),
-            ),
-            true
-        );
-
-        // Calculate credited Download
-        if (
-            $personalFreeleech
-            || $group->is_freeleech
-            || $freeleechToken
-            || $isFeatured
-            || config('other.freeleech')
-        ) {
-            $creditedDownloadedDelta = 0;
-        } elseif ($torrent->free >= 1) {
-            // Freeleech values in the database are from 0 to 100
-            // 0 means 0% of the bytes are freeleech, i.e. 100% of the bytes are counted.
-            // 100 means 100% of the bytes are freeleech, i.e. 0% of the bytes are counted.
-            // This means we have to subtract the value stored in the database from 100 before multiplying.
-            // Also make sure that 100% is the highest value of freeleech possible
-            // in order to not subtract download from an account.
-            $creditedDownloadedDelta = $downloadedDelta * (100 - min(100, $torrent->free)) / 100;
-        } else {
-            $creditedDownloadedDelta = $downloadedDelta;
-        }
-
-        // Calculate credited upload
-        if (
-            $torrent->doubleup
-            || $group->is_double_upload
-            || $isFeatured
-            || config('other.doubleup')
-        ) {
-            $creditedUploadedDelta = $uploadedDelta * 2;
-        } else {
-            $creditedUploadedDelta = $uploadedDelta;
-        }
-
-        // User Updates
-        if (($creditedUploadedDelta > 0 || $creditedDownloadedDelta > 0) && $event !== 'started') {
-            $user->update([
-                'uploaded'   => DB::raw('uploaded + '.(int) $creditedUploadedDelta),
-                'downloaded' => DB::raw('downloaded + '.(int) $creditedDownloadedDelta),
-            ]);
-        }
-
-        // Peer Updates
-        // Don't Dispatch ProcessAnnounce Job To Queue If Connectable Check Is Disabled For Performance Reasons
-        if (config('announce.connectable_check')) {
-            /**
-             * Process Peers Job.
-             *
-             * @see ProcessAnnounce
-             */
-            ProcessAnnounce::dispatch(
-                bin2hex($queries['peer_id']),
-                bin2hex($queries['ip-address']),
-                $queries['port'],
-                bin2hex($queries['user-agent']),
-                $queries['uploaded'],
-                $queries['downloaded'],
-                $queries['left'],
-                $queries['left'] === 0,
-                $torrent->id,
-                $user->id,
-                $event !== 'stopped',
-            );
-        } else {
-            /**
-             * Peer batch upsert.
-             *
-             * @see \App\Console\Commands\AutoUpsertPeers
-             */
-            Redis::connection('announce')->command('RPUSH', [
-                config('cache.prefix').':peers:batch',
-                serialize([
-                    'peer_id'     => $queries['peer_id'],
-                    'ip'          => $queries['ip-address'],
-                    'port'        => $queries['port'],
-                    'agent'       => $queries['user-agent'],
-                    'uploaded'    => $queries['uploaded'],
-                    'downloaded'  => $queries['downloaded'],
-                    'left'        => $queries['left'],
-                    'seeder'      => $queries['left'] === 0,
-                    'torrent_id'  => $torrent->id,
-                    'user_id'     => $user->id,
-                    'active'      => $event !== 'stopped',
-                    'connectable' => false,
-                ])
-            ]);
-        }
-
-        /**
-         * History batch upsert.
-         *
-         * @see \App\Console\Commands\AutoUpsertHistories
-         */
-        Redis::connection('announce')->command('RPUSH', [
-            config('cache.prefix').':histories:batch',
-            serialize([
-                'user_id'           => $user->id,
-                'torrent_id'        => $torrent->id,
-                'agent'             => $queries['user-agent'],
-                'uploaded'          => $event === 'started' ? 0 : $creditedUploadedDelta,
-                'actual_uploaded'   => $event === 'started' ? 0 : $uploadedDelta,
-                'client_uploaded'   => $queries['uploaded'],
-                'downloaded'        => $event === 'started' ? 0 : $creditedDownloadedDelta,
-                'actual_downloaded' => $event === 'started' ? 0 : $downloadedDelta,
-                'client_downloaded' => $queries['downloaded'],
-                'seeder'            => $queries['left'] === 0,
-                'active'            => $event !== 'stopped',
-                'seedtime'          => 0,
-                'immune'            => $group->is_immune,
-                'completed_at'      => $event === 'completed' ? now() : null,
-            ])
-        ]);
-
-        if (config('announce.log_announces')) {
-            /**
-             * Announce batch upsert.
-             *
-             * @see \App\Console\Commands\AutoUpsertAnnounces
-             */
-            Redis::connection('announce')->command('RPUSH', [
-                config('cache.prefix').':announces:batch',
-                serialize([
-                    'user_id'    => $user->id,
-                    'torrent_id' => $torrent->id,
-                    'uploaded'   => $queries['uploaded'],
-                    'downloaded' => $queries['downloaded'],
-                    'left'       => $queries['left'],
-                    'corrupt'    => $queries['corrupt'],
-                    'peer_id'    => $queries['peer_id'],
-                    'port'       => $queries['port'],
-                    'numwant'    => $queries['numwant'],
-                    'event'      => $queries['event'],
-                    'key'        => $queries['key'],
-                ])
-            ]);
-        }
-
-        // Torrent updates
-
-        $isNewPeer = $isNewPeer || !$peer->active;
-        $isDeadPeer = $event === 'stopped';
-        $isSeeder = $queries['left'] === 0;
-
-        $newSeed = $isNewPeer && !$isDeadPeer && $isSeeder;
-        $newLeech = $isNewPeer && !$isDeadPeer && !$isSeeder;
-        $stoppedSeed = !$isNewPeer && $isDeadPeer && $isSeeder;
-        $stoppedLeech = !$isNewPeer && $isDeadPeer && !$isSeeder;
-        $leechBecomesSeed = !$isNewPeer && !$isDeadPeer && $isSeeder && $peer->left > 0;
-        $seedBecomesLeech = !$isNewPeer && !$isDeadPeer && !$isSeeder && $peer->left === 0;
-
-        $seederCountDelta = ($newSeed || $leechBecomesSeed) <=> ($stoppedSeed || $seedBecomesLeech);
-        $leecherCountDelta = ($newLeech || $seedBecomesLeech) <=> ($stoppedLeech || $leechBecomesSeed);
-        $completedCountDelta = (int) ($event === 'completed');
-
-        if ($seederCountDelta !== 0 || $leecherCountDelta !== 0 || $completedCountDelta !== 0) {
-            $torrent->update([
-                'seeders'         => DB::raw('seeders + '.$seederCountDelta),
-                'leechers'        => DB::raw('leechers + '.$leecherCountDelta),
-                'times_completed' => DB::raw('times_completed + '.$completedCountDelta),
-            ]);
-
-            cache()->forget('announce-torrents:by-infohash:'.$queries['info_hash']);
-        }
+        ProcessAnnounce::dispatch($queries, $userDto, $torrentDto, $previousPeerDto);
     }
 
     private function generateFailedAnnounceResponse(TrackerException $trackerException): string

--- a/app/Jobs/ProcessAnnounce.php
+++ b/app/Jobs/ProcessAnnounce.php
@@ -279,7 +279,7 @@ class ProcessAnnounce implements ShouldQueue
             $ip = '['.$ip.']';
         }
 
-        $key = $ip.'-'.$this->queries->port.'-'.hex2bin($this->queries->getAgent());
+        $key = $ip.'-'.$this->queries->port.'-'.$this->queries->getAgent();
 
         // Check cache
         if (cache()->has('peers:connectable-timer:'.$key)) {

--- a/app/Jobs/ProcessAnnounce.php
+++ b/app/Jobs/ProcessAnnounce.php
@@ -14,11 +14,19 @@
 
 namespace App\Jobs;
 
+use App\DTO\AnnouncePeerDTO;
+use App\DTO\AnnounceQueryDTO;
+use App\DTO\AnnounceTorrentDTO;
+use App\DTO\AnnounceUserDTO;
+use App\Models\FreeleechToken;
+use App\Models\PersonalFreeleech;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\Middleware\WithoutOverlapping;
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Redis;
 
 class ProcessAnnounce implements ShouldQueue
@@ -32,18 +40,21 @@ class ProcessAnnounce implements ShouldQueue
      * Create a new job instance.
      */
     public function __construct(
-        public string $peerId,
-        public string $ip,
-        public int $port,
-        public string $agent,
-        public int $uploaded,
-        public int $downloaded,
-        public int $left,
-        public bool $seeder,
-        public int $torrentId,
-        public int $userId,
-        public bool $active,
+        public AnnounceQueryDTO $queries,
+        public AnnounceUserDTO $user,
+        public AnnounceTorrentDTO $torrent,
+        public ?AnnouncePeerDTO $peer,
     ) {
+    }
+
+    /**
+     * Get the middleware the job should pass through.
+     *
+     * @return array<int, object>
+     */
+    public function middleware(): array
+    {
+        return [(new WithoutOverlapping($this->user->id.':'.$this->torrent->id))->releaseAfter(30)];
     }
 
     /**
@@ -51,6 +62,94 @@ class ProcessAnnounce implements ShouldQueue
      */
     public function handle(): void
     {
+        // Set Variables
+        $event = $this->queries->event;
+
+        $isNewPeer = $this->peer === null;
+
+        // Calculate the change in upload/download compared to the last announce
+        $uploadedDelta = max($this->queries->uploaded - ($this->peer?->uploaded ?? 0), 0);
+        $downloadedDelta = max($this->queries->downloaded - ($this->peer?->downloaded ?? 0), 0);
+
+        // If no peer record found then set deltas to 0 and change to `started` event
+        if ($isNewPeer) {
+            if ($this->queries->uploaded > 0 || $this->queries->downloaded > 0) {
+                $event = 'started';
+                $uploadedDelta = 0;
+                $downloadedDelta = 0;
+            }
+        }
+
+        // Check if user currently has a personal freeleech
+        $personalFreeleech = cache()->rememberForever(
+            'personal_freeleech:'.$this->user->id,
+            fn () => PersonalFreeleech::query()
+                ->where('user_id', '=', $this->user->id)
+                ->exists()
+        );
+
+        // Check if user has a freeleech token on this torrent
+        $freeleechToken = cache()->rememberForever(
+            'freeleech_token:'.$this->user->id.':'.$this->torrent->id,
+            fn () => FreeleechToken::query()
+                ->where('user_id', '=', $this->user->id)
+                ->where('torrent_id', '=', $this->torrent->id)
+                ->exists(),
+        );
+
+        // Check if the torrent is featured
+        $isFeatured = \in_array(
+            $this->torrent->id,
+            cache()->rememberForever(
+                'featured-torrent-ids',
+                fn () => FeaturedTorrent::select('id')->pluck('id')->toArray(),
+            ),
+            true
+        );
+
+        // Calculate credited Download
+        if (
+            $personalFreeleech
+            || $this->user->group->isFreeleech
+            || $freeleechToken
+            || $isFeatured
+            || config('other.freeleech')
+        ) {
+            $creditedDownloadedDelta = 0;
+        } elseif ($this->torrent->percentFree >= 1) {
+            // Freeleech values in the database are from 0 to 100
+            // 0 means 0% of the bytes are freeleech, i.e. 100% of the bytes are counted.
+            // 100 means 100% of the bytes are freeleech, i.e. 0% of the bytes are counted.
+            // This means we have to subtract the value stored in the database from 100 before multiplying.
+            // Also make sure that 100% is the highest value of freeleech possible
+            // in order to not subtract download from an account.
+            $creditedDownloadedDelta = $downloadedDelta * (100 - min(100, $this->torrent->percentFree)) / 100;
+        } else {
+            $creditedDownloadedDelta = $downloadedDelta;
+        }
+
+        // Calculate credited upload
+        if (
+            $this->torrent->isDoubleUpload
+            || $this->user->group->isDoubleUpload
+            || $isFeatured
+            || config('other.doubleup')
+        ) {
+            $creditedUploadedDelta = $uploadedDelta * 2;
+        } else {
+            $creditedUploadedDelta = $uploadedDelta;
+        }
+
+        // User Updates
+        if (($creditedUploadedDelta > 0 || $creditedDownloadedDelta > 0) && $event !== 'started') {
+            DB::table('users')->where('id', '=', $this->user->id)->update([
+                'uploaded'   => DB::raw('uploaded + '.(int) $creditedUploadedDelta),
+                'downloaded' => DB::raw('downloaded + '.(int) $creditedDownloadedDelta),
+            ]);
+        }
+
+        // Peer updates
+
         /**
          * Peer batch upsert.
          *
@@ -59,20 +158,98 @@ class ProcessAnnounce implements ShouldQueue
         Redis::connection('announce')->command('RPUSH', [
             config('cache.prefix').':peers:batch',
             serialize([
-                'peer_id'     => hex2bin($this->peerId),
-                'ip'          => hex2bin($this->ip),
-                'port'        => $this->port,
-                'agent'       => hex2bin($this->agent),
-                'uploaded'    => $this->uploaded,
-                'downloaded'  => $this->downloaded,
-                'left'        => $this->left,
-                'seeder'      => $this->seeder,
-                'torrent_id'  => $this->torrentId,
-                'user_id'     => $this->userId,
-                'active'      => $this->active,
+                'peer_id'     => $this->queries->getPeerId(),
+                'ip'          => $this->queries->getIp(),
+                'port'        => $this->queries->port,
+                'agent'       => $this->queries->getAgent(),
+                'uploaded'    => $this->queries->uploaded,
+                'downloaded'  => $this->queries->downloaded,
+                'left'        => $this->queries->left,
+                'seeder'      => $this->queries->left === 0,
+                'torrent_id'  => $this->torrent->id,
+                'user_id'     => $this->user->id,
+                'active'      => $event !== 'stopped',
                 'connectable' => $this->getConnectableStatus(),
             ]),
         ]);
+
+        // History updates
+
+        /**
+         * History batch upsert.
+         *
+         * @see \App\Console\Commands\AutoUpsertHistories
+         */
+        Redis::connection('announce')->command('RPUSH', [
+            config('cache.prefix').':histories:batch',
+            serialize([
+                'user_id'           => $this->user->id,
+                'torrent_id'        => $this->torrent->id,
+                'agent'             => $this->queries->getAgent(),
+                'uploaded'          => $event === 'started' ? 0 : $creditedUploadedDelta,
+                'actual_uploaded'   => $event === 'started' ? 0 : $uploadedDelta,
+                'client_uploaded'   => $this->queries->uploaded,
+                'downloaded'        => $event === 'started' ? 0 : $creditedDownloadedDelta,
+                'actual_downloaded' => $event === 'started' ? 0 : $downloadedDelta,
+                'client_downloaded' => $this->queries->downloaded,
+                'seeder'            => $this->queries->left === 0,
+                'active'            => $event !== 'stopped',
+                'seedtime'          => 0,
+                'immune'            => $this->user->group->isImmune,
+                'completed_at'      => $event === 'completed' ? now() : null,
+            ])
+        ]);
+
+        if (config('announce.log_announces')) {
+            /**
+             * Announce batch upsert.
+             *
+             * @see \App\Console\Commands\AutoUpsertAnnounces
+             */
+            Redis::connection('announce')->command('RPUSH', [
+                config('cache.prefix').':announces:batch',
+                serialize([
+                    'user_id'    => $this->user->id,
+                    'torrent_id' => $this->torrent->id,
+                    'uploaded'   => $this->queries->uploaded,
+                    'downloaded' => $this->queries->downloaded,
+                    'left'       => $this->queries->left,
+                    'corrupt'    => $this->queries->corrupt,
+                    'peer_id'    => $this->queries->getPeerId(),
+                    'port'       => $this->queries->port,
+                    'numwant'    => $this->queries->numwant,
+                    'event'      => $this->queries->event,
+                    'key'        => $this->queries->key,
+                ])
+            ]);
+        }
+
+        // Torrent updates
+
+        $isNewPeer = $isNewPeer || !$this->peer->active;
+        $isDeadPeer = $event === 'stopped';
+        $isSeeder = $this->queries->left === 0;
+
+        $newSeed = $isNewPeer && !$isDeadPeer && $isSeeder;
+        $newLeech = $isNewPeer && !$isDeadPeer && !$isSeeder;
+        $stoppedSeed = !$isNewPeer && $isDeadPeer && $isSeeder;
+        $stoppedLeech = !$isNewPeer && $isDeadPeer && !$isSeeder;
+        $leechBecomesSeed = !$isNewPeer && !$isDeadPeer && $isSeeder && $this->peer->left > 0;
+        $seedBecomesLeech = !$isNewPeer && !$isDeadPeer && !$isSeeder && $this->peer->left === 0;
+
+        $seederCountDelta = ($newSeed || $leechBecomesSeed) <=> ($stoppedSeed || $seedBecomesLeech);
+        $leecherCountDelta = ($newLeech || $seedBecomesLeech) <=> ($stoppedLeech || $leechBecomesSeed);
+        $completedCountDelta = (int) ($event === 'completed');
+
+        if ($seederCountDelta !== 0 || $leecherCountDelta !== 0 || $completedCountDelta !== 0) {
+            DB::table('torrents')->where('id', '=', $this->torrent->id)->update([
+                'seeders'         => DB::raw('seeders + '.$seederCountDelta),
+                'leechers'        => DB::raw('leechers + '.$leecherCountDelta),
+                'times_completed' => DB::raw('times_completed + '.$completedCountDelta),
+            ]);
+
+            cache()->forget('announce-torrents:by-infohash:'.$this->queries->getInfoHash());
+        }
     }
 
     /**
@@ -83,12 +260,11 @@ class ProcessAnnounce implements ShouldQueue
      */
     private function getConnectableStatus(): bool
     {
-        // Unhex
-        $ip = hex2bin($this->ip);
-
-        if ($ip === false) {
+        if (!config('announce.connectable_check')) {
             return false;
         }
+
+        $ip = $this->queries->getIp();
 
         // Pack
         $ip = inet_ntop(pack('A'.\strlen($ip), $ip));
@@ -102,7 +278,7 @@ class ProcessAnnounce implements ShouldQueue
             $ip = '['.$ip.']';
         }
 
-        $key = $ip.'-'.$this->port.'-'.hex2bin($this->agent);
+        $key = $ip.'-'.$this->queries->port.'-'.hex2bin($this->queries->getAgent());
 
         // Check cache
         if (cache()->has('peers:connectable-timer:'.$key)) {
@@ -110,7 +286,7 @@ class ProcessAnnounce implements ShouldQueue
         }
 
         // Connect
-        $connection = @fsockopen($ip, $this->port, $_, $_, 1);
+        $connection = @fsockopen($ip, $this->queries->port, $_, $_, 1);
 
         if ($connectable = \is_resource($connection)) {
             fclose($connection);

--- a/app/Jobs/ProcessAnnounce.php
+++ b/app/Jobs/ProcessAnnounce.php
@@ -18,6 +18,7 @@ use App\DTO\AnnouncePeerDTO;
 use App\DTO\AnnounceQueryDTO;
 use App\DTO\AnnounceTorrentDTO;
 use App\DTO\AnnounceUserDTO;
+use App\Models\FeaturedTorrent;
 use App\Models\FreeleechToken;
 use App\Models\PersonalFreeleech;
 use Illuminate\Bus\Queueable;

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1146,11 +1146,6 @@ parameters:
 			path: app/Http/Resources/UserResource.php
 
 		-
-			message: "#^Call to static method select\\(\\) on an unknown class App\\\\Jobs\\\\FeaturedTorrent\\.$#"
-			count: 1
-			path: app/Jobs/ProcessAnnounce.php
-
-		-
 			message: "#^Parameter \\#1 \\$string of function htmlspecialchars expects string, array\\<string\\>\\|string given\\.$#"
 			count: 1
 			path: app/Models/Article.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -626,131 +626,6 @@ parameters:
 			path: app/Http/Controllers/API/TorrentController.php
 
 		-
-			message: "#^Access to an undefined property object\\:\\:\\$doubleup\\.$#"
-			count: 1
-			path: app/Http/Controllers/AnnounceController.php
-
-		-
-			message: "#^Access to an undefined property object\\:\\:\\$download_slots\\.$#"
-			count: 1
-			path: app/Http/Controllers/AnnounceController.php
-
-		-
-			message: "#^Access to an undefined property object\\:\\:\\$free\\.$#"
-			count: 1
-			path: app/Http/Controllers/AnnounceController.php
-
-		-
-			message: "#^Access to an undefined property object\\:\\:\\$id\\.$#"
-			count: 26
-			path: app/Http/Controllers/AnnounceController.php
-
-		-
-			message: "#^Access to an undefined property object\\:\\:\\$is_double_upload\\.$#"
-			count: 1
-			path: app/Http/Controllers/AnnounceController.php
-
-		-
-			message: "#^Access to an undefined property object\\:\\:\\$is_freeleech\\.$#"
-			count: 1
-			path: app/Http/Controllers/AnnounceController.php
-
-		-
-			message: "#^Access to an undefined property object\\:\\:\\$is_immune\\.$#"
-			count: 1
-			path: app/Http/Controllers/AnnounceController.php
-
-		-
-			message: "#^Access to an undefined property object\\:\\:\\$leechers\\.$#"
-			count: 2
-			path: app/Http/Controllers/AnnounceController.php
-
-		-
-			message: "#^Access to an undefined property object\\:\\:\\$peers\\.$#"
-			count: 6
-			path: app/Http/Controllers/AnnounceController.php
-
-		-
-			message: "#^Access to an undefined property object\\:\\:\\$seeders\\.$#"
-			count: 1
-			path: app/Http/Controllers/AnnounceController.php
-
-		-
-			message: "#^Access to an undefined property object\\:\\:\\$times_completed\\.$#"
-			count: 1
-			path: app/Http/Controllers/AnnounceController.php
-
-		-
-			message: "#^Binary operation \"\\-\" between float\\|int\\|string and 300 results in an error\\.$#"
-			count: 1
-			path: app/Http/Controllers/AnnounceController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:update\\(\\)\\.$#"
-			count: 2
-			path: app/Http/Controllers/AnnounceController.php
-
-		-
-			message: "#^Method App\\\\Http\\\\Controllers\\\\AnnounceController\\:\\:checkAnnounceFields\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/Http/Controllers/AnnounceController.php
-
-		-
-			message: "#^Method App\\\\Http\\\\Controllers\\\\AnnounceController\\:\\:checkDownloadSlots\\(\\) has parameter \\$queries with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/Http/Controllers/AnnounceController.php
-
-		-
-			message: "#^Method App\\\\Http\\\\Controllers\\\\AnnounceController\\:\\:checkGroup\\(\\) has parameter \\$user with no type specified\\.$#"
-			count: 1
-			path: app/Http/Controllers/AnnounceController.php
-
-		-
-			message: "#^Method App\\\\Http\\\\Controllers\\\\AnnounceController\\:\\:checkMinInterval\\(\\) has parameter \\$queries with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/Http/Controllers/AnnounceController.php
-
-		-
-			message: "#^Method App\\\\Http\\\\Controllers\\\\AnnounceController\\:\\:checkPasskey\\(\\) has parameter \\$passkey with no type specified\\.$#"
-			count: 1
-			path: app/Http/Controllers/AnnounceController.php
-
-		-
-			message: "#^Method App\\\\Http\\\\Controllers\\\\AnnounceController\\:\\:checkPeer\\(\\) has parameter \\$queries with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/Http/Controllers/AnnounceController.php
-
-		-
-			message: "#^Method App\\\\Http\\\\Controllers\\\\AnnounceController\\:\\:checkUser\\(\\) has parameter \\$queries with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/Http/Controllers/AnnounceController.php
-
-		-
-			message: "#^Method App\\\\Http\\\\Controllers\\\\AnnounceController\\:\\:generateSuccessAnnounceResponse\\(\\) has parameter \\$queries with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/Http/Controllers/AnnounceController.php
-
-		-
-			message: "#^Method App\\\\Http\\\\Controllers\\\\AnnounceController\\:\\:processAnnounceJob\\(\\) has parameter \\$queries with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/Http/Controllers/AnnounceController.php
-
-		-
-			message: "#^Parameter \\#1 \\$haystack of function str_starts_with expects string, bool\\|float\\|int\\|string\\|null given\\.$#"
-			count: 1
-			path: app/Http/Controllers/AnnounceController.php
-
-		-
-			message: "#^Parameter \\#1 \\$string of function strtolower expects string, bool\\|float\\|int\\|string\\|null given\\.$#"
-			count: 1
-			path: app/Http/Controllers/AnnounceController.php
-
-		-
-			message: "#^Variable \\$response might not be defined\\.$#"
-			count: 1
-			path: app/Http/Controllers/AnnounceController.php
-
-		-
 			message: "#^Access to an undefined property App\\\\Models\\\\Torrent\\:\\:\\$meta\\.$#"
 			count: 10
 			path: app/Http/Controllers/HomeController.php
@@ -1269,6 +1144,11 @@ parameters:
 			message: "#^Method App\\\\Http\\\\Resources\\\\UserResource\\:\\:toArray\\(\\) return type with generic interface Illuminate\\\\Contracts\\\\Support\\\\Arrayable does not specify its types\\: TKey, TValue$#"
 			count: 1
 			path: app/Http/Resources/UserResource.php
+
+		-
+			message: "#^Call to static method select\\(\\) on an unknown class App\\\\Jobs\\\\FeaturedTorrent\\.$#"
+			count: 1
+			path: app/Jobs/ProcessAnnounce.php
 
 		-
 			message: "#^Parameter \\#1 \\$string of function htmlspecialchars expects string, array\\<string\\>\\|string given\\.$#"


### PR DESCRIPTION
There were very minor edge cases with the previous system that had issues when users paused a torrent immediately after they completed it, causing data to be duplicated. We now opt to use DTOs to transfer the data into the job queue instead of models to prevent the extra database queries caused by passing models into a job queue.

Still requires testing.