### PR TITLE
(Update) Don't change the freeleech/double upload when featured

### DIFF
--- a/app/Console/Commands/AutoRemoveFeaturedTorrent.php
+++ b/app/Console/Commands/AutoRemoveFeaturedTorrent.php
@@ -60,8 +60,6 @@ class AutoRemoveFeaturedTorrent extends Command
             $torrent = Torrent::where('featured', '=', 1)->find($featuredTorrent->torrent_id);
 
             if (isset($torrent)) {
-                $torrent->free = 0;
-                $torrent->doubleup = false;
                 $torrent->featured = false;
                 $torrent->save();
 
@@ -78,6 +76,8 @@ class AutoRemoveFeaturedTorrent extends Command
             // Delete The Record From DB
             $featuredTorrent->delete();
         }
+
+        cache()->forget('featured-torrent-ids');
 
         $this->comment('Automated Removal Featured Torrents Command Complete');
     }

--- a/app/Http/Controllers/TorrentBuffController.php
+++ b/app/Http/Controllers/TorrentBuffController.php
@@ -139,12 +139,8 @@ class TorrentBuffController extends Controller
         $torrent = Torrent::withoutGlobalScope(ApprovedScope::class)->findOrFail($id);
 
         if ($torrent->featured == 0) {
-            $torrent->free = 100;
-            $torrent->doubleup = true;
             $torrent->featured = true;
             $torrent->save();
-
-            cache()->forget('announce-torrents:by-infohash:'.$torrent->info_hash);
 
             Unit3dAnnounce::addTorrent($torrent);
 
@@ -152,6 +148,8 @@ class TorrentBuffController extends Controller
             $featured->user_id = $user->id;
             $featured->torrent_id = $torrent->id;
             $featured->save();
+
+            cache()->forget('featured-torrent-ids');
 
             $torrentUrl = href_torrent($torrent);
             $profileUrl = href_profile($user);
@@ -179,12 +177,8 @@ class TorrentBuffController extends Controller
         $featured_torrent = FeaturedTorrent::where('torrent_id', '=', $id)->sole();
 
         $torrent = Torrent::withoutGlobalScope(ApprovedScope::class)->findOrFail($id);
-        $torrent->free = 0;
-        $torrent->doubleup = false;
         $torrent->featured = false;
         $torrent->save();
-
-        cache()->forget('announce-torrents:by-infohash:'.$torrent->info_hash);
 
         Unit3dAnnounce::addTorrent($torrent);
 
@@ -195,6 +189,8 @@ class TorrentBuffController extends Controller
         );
 
         $featured_torrent->delete();
+
+        cache()->forget('featured-torrent-ids');
 
         return to_route('torrents.show', ['id' => $torrent->id])
             ->withSuccess('Revoked featured from Torrent!');

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -642,7 +642,7 @@ parameters:
 
 		-
 			message: "#^Access to an undefined property object\\:\\:\\$id\\.$#"
-			count: 25
+			count: 26
 			path: app/Http/Controllers/AnnounceController.php
 
 		-

--- a/resources/views/components/partials/_torrent-icons.blade.php
+++ b/resources/views/components/partials/_torrent-icons.blade.php
@@ -92,6 +92,7 @@
                             __('torrent.freeleech-token') => $torrent->freeleech_tokens_exists,
                             __('torrent.special-freeleech') => auth()->user()->group->is_freeleech,
                             __('torrent.global-freeleech') => config('other.freeleech'),
+                            __('torrent.featured') . ' - 100%' . __('torrent.freeleech') => $torrent->featured,
                             $torrent->free . '% ' . __('common.free') . ($torrent->fl_until !== null ? ' (expires ' . $torrent->fl_until->diffForHumans() . ')' : '') => $torrent->free > 0,
                         ],
                         true
@@ -104,7 +105,20 @@
     @if (config('other.doubleup') || auth()->user()->group->is_double_upload || $torrent->doubleup)
         <i
             class="{{ config('other.font-awesome') }} fa-chevron-double-up torrent-icons__double-upload"
-            title="@if(config('other.doubleup')){{ __('torrent.global-double-upload') }}&NewLine;@endif&ZeroWidthSpace;@if(auth()->user()->group->is_double_upload){{ __('torrent.special-double_upload') }}&NewLine;@endif&ZeroWidthSpace;@if($torrent->doubleup > 0)100% {{ __('torrent.double-upload') }}@if($torrent->du_until !== null) (expires {{ $torrent->du_until->diffForHumans() }})@endif&ZeroWidthSpace;@endif"
+            title="{{
+                implode(
+                    "\n",
+                    array_keys(
+                        [
+                            __('torrent.global-double-upload') => config('other.doubleup'),
+                            __('torrent.special-double_upload') => auth()->user()->group->is_double_upload,
+                            __('torrent.featured') . ' - ' . __('torrent.double-upload') => $torrent->featured,
+                            '100% ' . __('torrent.double-upload') . ($torrent->du_until !== null ? ' (expires ' . $torrent->du_until->diffForHumans() . ')' : '') => $torrent->doubleup > 0,
+                        ],
+                        true
+                    )
+                )
+            }}"
         ></i>
     @endif
 


### PR DESCRIPTION
That way, when the feature ends, it will remain with the same freeleech / double upload state it started with.