### PR TITLE
(Update) Update slot-limited peers but exclude from peer lists

### DIFF
--- a/app/Console/Commands/AutoUpsertPeers.php
+++ b/app/Console/Commands/AutoUpsertPeers.php
@@ -48,9 +48,9 @@ class AutoUpsertPeers extends Command
         /**
          * MySql can handle a max of 65k placeholders per query,
          * and there are 15 fields on each peer that are updated.
-         * (`active`, `agent`, `connectable`, `created_at`, `downloaded`, `id`, `ip`, `left`, `peer_id`, `port`, `seeder`, `torrent_id`, `updated_at`, `uploaded`, `user_id`).
+         * (`active`, `agent`, `connectable`, `created_at`, `downloaded`, `id`, `ip`, `left`, `peer_id`, `port`, `seeder`, `torrent_id`, `updated_at`, `uploaded`, `visible`, `user_id`).
          */
-        $peerPerCycle = intdiv(65_000, 15);
+        $peerPerCycle = intdiv(65_000, 16);
 
         $key = config('cache.prefix').':peers:batch';
         $peerCount = Redis::connection('announce')->command('LLEN', [$key]);
@@ -80,7 +80,8 @@ class AutoUpsertPeers extends Command
                         'torrent_id',
                         'user_id',
                         'connectable',
-                        'active'
+                        'active',
+                        'visible',
                     ],
                 );
             }, 5);

--- a/app/Http/Livewire/UserActive.php
+++ b/app/Http/Livewire/UserActive.php
@@ -43,6 +43,8 @@ class UserActive extends Component
 
     public string $active = 'include';
 
+    public string $visible = 'any';
+
     public string $sortField = 'created_at';
 
     public string $sortDirection = 'desc';
@@ -60,6 +62,7 @@ class UserActive extends Component
         'client'            => ['excpet' => ''],
         'seeding'           => ['except' => 'any'],
         'active'            => ['except' => 'any'],
+        'visible'           => ['except' => 'any'],
         'sortField'         => ['except' => 'created_at'],
         'sortDirection'     => ['except' => 'desc'],
         'showMorePrecision' => ['except' => false],
@@ -121,6 +124,8 @@ class UserActive extends Component
             ->when($this->seeding === 'exclude', fn ($query) => $query->where('seeder', '=', 0))
             ->when($this->active === 'include', fn ($query) => $query->where('active', '=', 1))
             ->when($this->active === 'exclude', fn ($query) => $query->where('active', '=', 0))
+            ->when($this->visible === 'include', fn ($query) => $query->where('visible', '=', 1))
+            ->when($this->visible === 'exclude', fn ($query) => $query->where('visible', '=', 0))
             ->orderBy($this->sortField, $this->sortDirection)
             ->paginate($this->perPage);
     }

--- a/app/Jobs/ProcessAnnounce.php
+++ b/app/Jobs/ProcessAnnounce.php
@@ -45,6 +45,7 @@ class ProcessAnnounce implements ShouldQueue
         public AnnounceUserDTO $user,
         public AnnounceTorrentDTO $torrent,
         public ?AnnouncePeerDTO $peer,
+        public bool $visible,
     ) {
     }
 
@@ -170,6 +171,7 @@ class ProcessAnnounce implements ShouldQueue
                 'torrent_id'  => $this->torrent->id,
                 'user_id'     => $this->user->id,
                 'active'      => $event !== 'stopped',
+                'visible'     => $this->visible,
                 'connectable' => $this->getConnectableStatus(),
             ]),
         ]);

--- a/database/migrations/2024_02_07_213520_add_visible_to_peers.php
+++ b/database/migrations/2024_02_07_213520_add_visible_to_peers.php
@@ -1,0 +1,18 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::table('peers', function (Blueprint $table): void {
+            $table->boolean('visible');
+        });
+
+        DB::table('peers')->update([
+            'visible' => true,
+        ]);
+    }
+};

--- a/resources/sass/components/_user-active.scss
+++ b/resources/sass/components/_user-active.scss
@@ -36,6 +36,7 @@
 .user-active__port-header,
 .user-active__connectable-header,
 .user-active__seeding-header,
+.user-active__visible-header,
 .user-active__size-header,
 .user-active__uploaded-header,
 .user-active__downloaded-header,
@@ -66,7 +67,8 @@
 }
 
 .user-active__connectable,
-.user-active__seeding {
+.user-active__seeding,
+.user-active__visible {
     font-size: 11px;
 }
 
@@ -95,6 +97,7 @@
 
 .user-active__connectable-header,
 .user-active__seeding-header,
+.user-active__visible-header,
 .user-active__connectable,
 .user-active__seeding {
     text-align: center;

--- a/resources/views/livewire/user-active.blade.php
+++ b/resources/views/livewire/user-active.blade.php
@@ -54,6 +54,25 @@
                     </label>
                 </p>
                 <p class="form__group">
+                    <label
+                        style="user-select: none"
+                        class="form__label"
+                        x-data="{ state: @entangle('visible'), ...ternaryCheckbox() }"
+                    >
+                        <input
+                            type="checkbox"
+                            class="user-peers__checkbox"
+                            x-init="updateTernaryCheckboxProperties($el, state)"
+                            x-on:click="
+                                state = getNextTernaryCheckboxState(state);
+                                updateTernaryCheckboxProperties($el, state)
+                            "
+                            x-bind:checked="state === 'include'"
+                        />
+                        Visible
+                    </label>
+                </p>
+                <p class="form__group">
                     <label class="form__label">
                         <input
                             type="checkbox"
@@ -163,6 +182,15 @@
                     >
                         <i class="{{ config('other.font-awesome') }} fa-arrow-up"></i>
                         @include('livewire.includes._sort-icon', ['field' => 'seeder'])
+                    </th>
+                    <th
+                        class="user-active__visible-header"
+                        wire:click="sortBy('visible')"
+                        role="columnheader button"
+                        title="Visible"
+                    >
+                        <i class="{{ config('other.font-awesome') }} fa-eye"></i>
+                        @include('livewire.includes._sort-icon', ['field' => 'visible'])
                     </th>
                     <th
                         class="user-active__size-header"
@@ -309,6 +337,22 @@
                                     <i
                                         class="{{ config('other.font-awesome') }} text-blue circle-stop"
                                         title="Stopped {{ __('torrent.seeding') }}"
+                                    ></i>
+                                @endif
+                            </td>
+                            <td
+                                class="user-active__visible {{ $peer->visible ? 'text-green' : 'text-red' }}"
+                            >
+                                @if ($peer->visible)
+                                    <i
+                                        class="{{ config('other.font-awesome') }} text-green eye"
+                                        title="Visible"
+                                    ></i>
+                                    {{ __('common.yes') }}
+                                @else
+                                    <i
+                                        class="{{ config('other.font-awesome') }} text-red eye-slash"
+                                        title="Invisible"
                                     ></i>
                                 @endif
                             </td>

--- a/resources/views/torrent/peers.blade.php
+++ b/resources/views/torrent/peers.blade.php
@@ -69,6 +69,7 @@
                         <th>{{ __('torrent.started') }}</th>
                         <th>{{ __('torrent.last-update') }}</th>
                         <th>{{ __('common.status') }}</th>
+                        <th>Visible</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -140,6 +141,13 @@
                                     @endif
                                 @else
                                         Inactive
+                                @endif
+                            </td>
+                            <td class="{{ $peer->visible ? 'text-green' : 'text-red' }}">
+                                @if ($peer->visible)
+                                    {{ __('common.yes') }}
+                                @else
+                                    {{ __('common.no') }}
                                 @endif
                             </td>
                         </tr>


### PR DESCRIPTION
Sometimes, for whatever reason, a user might have more peers than their slot limit. This occurs because we don't ensure every user completes every download they start. This means a user could stop a torrent, clear the slot, and start a new one, and then resume the first one using peers cached by the client. When a user did this, the peer that was stopped would no longer be shown by the tracker and stats weren't affected. When the user completed the torrent, they got a error saying they couldn't send a completed event without first sending a started event. This could only be resolved by restarting the client or pausing/resuming the torrent which would reset the stats for that torrent session. This PR accounts for this fact and will allow peers updates to continue, but the user will no longer be able to receive peers in the peer list, and other users won't receive their peer in the list.