### PR TITLE
(Fix) Swap order of xss cleaning and bbcode parsing in bbcode preview

### DIFF
--- a/app/Http/Livewire/BbcodeInput.php
+++ b/app/Http/Livewire/BbcodeInput.php
@@ -42,7 +42,7 @@ class BbcodeInput extends Component
     final public function updatedIsPreviewEnabled(): void
     {
         if ($this->isPreviewEnabled) {
-            $this->contentHtml = htmlspecialchars((new AntiXSS())->xss_clean((new Bbcode())->parse($this->contentBbcode)), ENT_NOQUOTES);
+            $this->contentHtml = (new Bbcode())->parse(htmlspecialchars((new AntiXSS())->xss_clean($this->contentBbcode), ENT_NOQUOTES));
         }
     }
 


### PR DESCRIPTION
Follow up to #3497. Had it the wrong way around. We fixed XSS, but broke BBCode.