### PR TITLE
(Fix) bullet design when users use invalid bbcode

### DIFF
--- a/resources/sass/components/_bbcode-rendered.scss
+++ b/resources/sass/components/_bbcode-rendered.scss
@@ -280,6 +280,7 @@
   & > li,
   :not(ul):not(ol) > li {
     list-style-position: inside;
+    list-style-type: circle;
   }
 
   /* Definition Lists */


### PR DESCRIPTION
Enforcing valid bbcode would be a better idea, but that's not currently possible with how list items are rendered in the bbcode renderer.