### PR TITLE
(Update) Improve test speed

### DIFF
--- a/database/factories/ApplicationImageProofFactory.php
+++ b/database/factories/ApplicationImageProofFactory.php
@@ -32,7 +32,7 @@ class ApplicationImageProofFactory extends Factory
     {
         return [
             'application_id' => Application::factory(),
-            'image'          => $this->faker->image(),
+            'image'          => $this->faker->imageUrl(),
         ];
     }
 }

--- a/database/factories/ArticleFactory.php
+++ b/database/factories/ArticleFactory.php
@@ -32,7 +32,7 @@ class ArticleFactory extends Factory
     {
         return [
             'title'   => $this->faker->sentence(),
-            'image'   => $this->faker->image(),
+            'image'   => null,
             'content' => $this->faker->text(),
             'user_id' => User::factory(),
         ];

--- a/database/factories/CategoryFactory.php
+++ b/database/factories/CategoryFactory.php
@@ -31,7 +31,7 @@ class CategoryFactory extends Factory
     {
         return [
             'name'        => $this->faker->name(),
-            'image'       => $this->faker->image(),
+            'image'       => null,
             'position'    => $this->faker->randomNumber(),
             'icon'        => $this->faker->word(),
             'no_meta'     => $this->faker->boolean(),

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -46,7 +46,7 @@ class UserFactory extends Factory
             'active'              => true,
             'uploaded'            => $this->faker->randomNumber(),
             'downloaded'          => $this->faker->randomNumber(),
-            'image'               => $this->faker->image(),
+            'image'               => null,
             'title'               => $this->faker->sentence(),
             'about'               => $this->faker->text(),
             'signature'           => $this->faker->text(),

--- a/tests/Feature/Factories/UserFactoryTest.php
+++ b/tests/Feature/Factories/UserFactoryTest.php
@@ -16,52 +16,63 @@ use App\Models\User;
 test('user factory returns correct values when created', function (): void {
     $user = User::factory()->create();
 
-    $this->assertInstanceOf(User::class, $user);
+    $user->makeVisible([
+        'email',
+        'password',
+        'passkey',
+        'rsskey',
+        'remember_token',
+        'api_token',
+    ]);
 
-    $this->assertArrayHasKey('username', $user);
-    $this->assertArrayHasKey('email', $user);
-    $this->assertArrayHasKey('email_verified_at', $user);
-    $this->assertArrayHasKey('password', $user);
-    $this->assertArrayHasKey('passkey', $user);
-    $this->assertArrayHasKey('group_id', $user);
-    $this->assertArrayHasKey('active', $user);
-    $this->assertArrayHasKey('uploaded', $user);
-    $this->assertArrayHasKey('downloaded', $user);
-    $this->assertArrayHasKey('image', $user);
-    $this->assertArrayHasKey('title', $user);
-    $this->assertArrayHasKey('about', $user);
-    $this->assertArrayHasKey('signature', $user);
-    $this->assertArrayHasKey('fl_tokens', $user);
-    $this->assertArrayHasKey('seedbonus', $user);
-    $this->assertArrayHasKey('invites', $user);
-    $this->assertArrayHasKey('hitandruns', $user);
-    $this->assertArrayHasKey('rsskey', $user);
-    $this->assertArrayHasKey('chatroom_id', $user);
-    $this->assertArrayHasKey('censor', $user);
-    $this->assertArrayHasKey('chat_hidden', $user);
-    $this->assertArrayHasKey('hidden', $user);
-    $this->assertArrayHasKey('style', $user);
-    $this->assertArrayHasKey('torrent_layout', $user);
-    $this->assertArrayHasKey('torrent_filters', $user);
-    $this->assertArrayHasKey('custom_css', $user);
-    $this->assertArrayHasKey('read_rules', $user);
-    $this->assertArrayHasKey('can_chat', $user);
-    $this->assertArrayHasKey('can_comment', $user);
-    $this->assertArrayHasKey('can_download', $user);
-    $this->assertArrayHasKey('can_request', $user);
-    $this->assertArrayHasKey('can_invite', $user);
-    $this->assertArrayHasKey('can_upload', $user);
-    $this->assertArrayHasKey('show_poster', $user);
-    $this->assertArrayHasKey('peer_hidden', $user);
-    $this->assertArrayHasKey('private_profile', $user);
-    $this->assertArrayHasKey('block_notifications', $user);
-    $this->assertArrayHasKey('stat_hidden', $user);
-    $this->assertArrayHasKey('remember_token', $user);
-    $this->assertArrayHasKey('api_token', $user);
-    $this->assertArrayHasKey('last_login', $user);
-    $this->assertArrayHasKey('last_action', $user);
-    //$this->assertArrayHasKey('disabled_at', $user);
-    //$this->assertArrayHasKey('deleted_by', $user);
-    $this->assertArrayHasKey('locale', $user);
-    $this->assertArrayHasKey('chat_status_id', $user);
+    expect($user)
+        ->toBeInstanceOf(User::class)
+        ->toHaveKeys([
+            'username',
+            'email',
+            'email_verified_at',
+            'password',
+            'passkey',
+            'group_id',
+            'active',
+            'uploaded',
+            'downloaded',
+            'image',
+            'title',
+            'about',
+            'signature',
+            'fl_tokens',
+            'seedbonus',
+            'invites',
+            'hitandruns',
+            'rsskey',
+            'chatroom_id',
+            'censor',
+            'chat_hidden',
+            'hidden',
+            'style',
+            'torrent_layout',
+            'torrent_filters',
+            'custom_css',
+            'read_rules',
+            'can_chat',
+            'can_comment',
+            'can_download',
+            'can_request',
+            'can_invite',
+            'can_upload',
+            'show_poster',
+            'peer_hidden',
+            'private_profile',
+            'block_notifications',
+            'stat_hidden',
+            'remember_token',
+            'api_token',
+            'last_login',
+            'last_action',
+            //    'disabled_at',
+            //    'deleted_by',
+            'locale',
+            'chat_status_id',
+        ]);
 });


### PR DESCRIPTION
The php faker image formatter fetches an image from an online source, stores it, and uses its filename as the database value. We don't currently use this functionality, and replacing it with generating a string speeds up tests by a factor of 5.