### PR TITLE
(Add) Notification filters to work as locical "or" filter

### DIFF
--- a/app/Http/Livewire/NotificationSearch.php
+++ b/app/Http/Livewire/NotificationSearch.php
@@ -81,61 +81,63 @@ class NotificationSearch extends Component
             ->select('*')
             ->selectRaw("CASE WHEN read_at IS NULL THEN 'FALSE' ELSE 'TRUE' END as is_read")
             ->where(function ($query): void {
-                $query->when($this->bon_gifts, function ($query): void { $query->orWhere('type', '=', \App\Notifications\NewBon::class);
-            })
-            ->when($this->comment, function ($query): void {
-                $query->orWhere('type', '=', \App\Notifications\NewComment::class);
-            })
-            ->when($this->comment_tags, function ($query): void {
-                $query->orWhere('type', '=', \App\Notifications\NewCommentTag::class);
-            })
-            ->when($this->followers, function ($query): void {
-                $query->orWhere('type', '=', \App\Notifications\NewFollow::class);
-            })
-            ->when($this->posts, function ($query): void {
-                $query->orWhere('type', '=', \App\Notifications\NewPost::class);
-            })
-            ->when($this->post_tags, function ($query): void {
-                $query->orWhere('type', '=', \App\Notifications\NewPostTag::class);
-            })
-            ->when($this->post_tips, function ($query): void {
-                $query->orWhere('type', '=', \App\Notifications\NewPostTip::class);
-            })
-            ->when($this->request_bounties, function ($query): void {
-                $query->orWhere('type', '=', \App\Notifications\NewRequestBounty::class);
-            })
-            ->when($this->request_claims, function ($query): void {
-                $query->orWhere('type', '=', \App\Notifications\NewRequestClaim::class);
-            })
-            ->when($this->request_fills, function ($query): void {
-                $query->orWhere('type', '=', \App\Notifications\NewRequestFill::class);
-            })
-            ->when($this->request_approvals, function ($query): void {
-                $query->orWhere('type', '=', \App\Notifications\NewRequestFillApprove::class);
-            })
-            ->when($this->request_rejections, function ($query): void {
-                $query->orWhere('type', '=', \App\Notifications\NewRequestFillReject::class);
-            })
-            ->when($this->request_unclaims, function ($query): void {
-                $query->orWhere('type', '=', \App\Notifications\NewRequestUnclaim::class);
-            })
-            ->when($this->reseed_requests, function ($query): void {
-                $query->orWhere('type', '=', \App\Notifications\NewReseedRequest::class);
-            })
-            ->when($this->thanks, function ($query): void {
-                $query->orWhere('type', '=', \App\Notifications\NewThank::class);
-            })
-            ->when($this->upload_tips, function ($query): void {
-                $query->orWhere('type', '=', \App\Notifications\NewUploadTip::class);
-            })
-            ->when($this->topics, function ($query): void {
-                $query->orWhere('type', '=', \App\Notifications\NewTopic::class);
-            })
-            ->when($this->unfollows, function ($query): void {
-                $query->orWhere('type', '=', \App\Notifications\NewUnfollow::class);
-            })
-            ->when($this->uploads, function ($query): void {
-                $query->orWhere('type', '=', \App\Notifications\NewUpload::class); });
+                $query->when($this->bon_gifts, function ($query): void {
+                    $query->orWhere('type', '=', \App\Notifications\NewBon::class);
+                })
+                    ->when($this->comment, function ($query): void {
+                        $query->orWhere('type', '=', \App\Notifications\NewComment::class);
+                    })
+                    ->when($this->comment_tags, function ($query): void {
+                        $query->orWhere('type', '=', \App\Notifications\NewCommentTag::class);
+                    })
+                    ->when($this->followers, function ($query): void {
+                        $query->orWhere('type', '=', \App\Notifications\NewFollow::class);
+                    })
+                    ->when($this->posts, function ($query): void {
+                        $query->orWhere('type', '=', \App\Notifications\NewPost::class);
+                    })
+                    ->when($this->post_tags, function ($query): void {
+                        $query->orWhere('type', '=', \App\Notifications\NewPostTag::class);
+                    })
+                    ->when($this->post_tips, function ($query): void {
+                        $query->orWhere('type', '=', \App\Notifications\NewPostTip::class);
+                    })
+                    ->when($this->request_bounties, function ($query): void {
+                        $query->orWhere('type', '=', \App\Notifications\NewRequestBounty::class);
+                    })
+                    ->when($this->request_claims, function ($query): void {
+                        $query->orWhere('type', '=', \App\Notifications\NewRequestClaim::class);
+                    })
+                    ->when($this->request_fills, function ($query): void {
+                        $query->orWhere('type', '=', \App\Notifications\NewRequestFill::class);
+                    })
+                    ->when($this->request_approvals, function ($query): void {
+                        $query->orWhere('type', '=', \App\Notifications\NewRequestFillApprove::class);
+                    })
+                    ->when($this->request_rejections, function ($query): void {
+                        $query->orWhere('type', '=', \App\Notifications\NewRequestFillReject::class);
+                    })
+                    ->when($this->request_unclaims, function ($query): void {
+                        $query->orWhere('type', '=', \App\Notifications\NewRequestUnclaim::class);
+                    })
+                    ->when($this->reseed_requests, function ($query): void {
+                        $query->orWhere('type', '=', \App\Notifications\NewReseedRequest::class);
+                    })
+                    ->when($this->thanks, function ($query): void {
+                        $query->orWhere('type', '=', \App\Notifications\NewThank::class);
+                    })
+                    ->when($this->upload_tips, function ($query): void {
+                        $query->orWhere('type', '=', \App\Notifications\NewUploadTip::class);
+                    })
+                    ->when($this->topics, function ($query): void {
+                        $query->orWhere('type', '=', \App\Notifications\NewTopic::class);
+                    })
+                    ->when($this->unfollows, function ($query): void {
+                        $query->orWhere('type', '=', \App\Notifications\NewUnfollow::class);
+                    })
+                    ->when($this->uploads, function ($query): void {
+                        $query->orWhere('type', '=', \App\Notifications\NewUpload::class);
+                    });
             })
             ->reorder()
             ->orderBy('is_read')

--- a/app/Http/Livewire/NotificationSearch.php
+++ b/app/Http/Livewire/NotificationSearch.php
@@ -80,62 +80,62 @@ class NotificationSearch extends Component
         return auth()->user()->notifications()
             ->select('*')
             ->selectRaw("CASE WHEN read_at IS NULL THEN 'FALSE' ELSE 'TRUE' END as is_read")
-            ->when($this->bon_gifts, function ($query): void {
-                $query->where('type', '=', \App\Notifications\NewBon::class);
+            ->where(function ($query): void {
+                $query->when($this->bon_gifts, function ($query): void { $query->orWhere('type', '=', \App\Notifications\NewBon::class);
             })
             ->when($this->comment, function ($query): void {
-                $query->where('type', '=', \App\Notifications\NewComment::class);
+                $query->orWhere('type', '=', \App\Notifications\NewComment::class);
             })
             ->when($this->comment_tags, function ($query): void {
-                $query->where('type', '=', \App\Notifications\NewCommentTag::class);
+                $query->orWhere('type', '=', \App\Notifications\NewCommentTag::class);
             })
             ->when($this->followers, function ($query): void {
-                $query->where('type', '=', \App\Notifications\NewFollow::class);
+                $query->orWhere('type', '=', \App\Notifications\NewFollow::class);
             })
             ->when($this->posts, function ($query): void {
-                $query->where('type', '=', \App\Notifications\NewPost::class);
+                $query->orWhere('type', '=', \App\Notifications\NewPost::class);
             })
             ->when($this->post_tags, function ($query): void {
-                $query->where('type', '=', \App\Notifications\NewPostTag::class);
+                $query->orWhere('type', '=', \App\Notifications\NewPostTag::class);
             })
             ->when($this->post_tips, function ($query): void {
-                $query->where('type', '=', \App\Notifications\NewPostTip::class);
+                $query->orWhere('type', '=', \App\Notifications\NewPostTip::class);
             })
             ->when($this->request_bounties, function ($query): void {
-                $query->where('type', '=', \App\Notifications\NewRequestBounty::class);
+                $query->orWhere('type', '=', \App\Notifications\NewRequestBounty::class);
             })
             ->when($this->request_claims, function ($query): void {
-                $query->where('type', '=', \App\Notifications\NewRequestClaim::class);
+                $query->orWhere('type', '=', \App\Notifications\NewRequestClaim::class);
             })
             ->when($this->request_fills, function ($query): void {
-                $query->where('type', '=', \App\Notifications\NewRequestFill::class);
+                $query->orWhere('type', '=', \App\Notifications\NewRequestFill::class);
             })
             ->when($this->request_approvals, function ($query): void {
-                $query->where('type', '=', \App\Notifications\NewRequestFillApprove::class);
+                $query->orWhere('type', '=', \App\Notifications\NewRequestFillApprove::class);
             })
             ->when($this->request_rejections, function ($query): void {
-                $query->where('type', '=', \App\Notifications\NewRequestFillReject::class);
+                $query->orWhere('type', '=', \App\Notifications\NewRequestFillReject::class);
             })
             ->when($this->request_unclaims, function ($query): void {
-                $query->where('type', '=', \App\Notifications\NewRequestUnclaim::class);
+                $query->orWhere('type', '=', \App\Notifications\NewRequestUnclaim::class);
             })
             ->when($this->reseed_requests, function ($query): void {
-                $query->where('type', '=', \App\Notifications\NewReseedRequest::class);
+                $query->orWhere('type', '=', \App\Notifications\NewReseedRequest::class);
             })
             ->when($this->thanks, function ($query): void {
-                $query->where('type', '=', \App\Notifications\NewThank::class);
+                $query->orWhere('type', '=', \App\Notifications\NewThank::class);
             })
             ->when($this->upload_tips, function ($query): void {
-                $query->where('type', '=', \App\Notifications\NewUploadTip::class);
+                $query->orWhere('type', '=', \App\Notifications\NewUploadTip::class);
             })
             ->when($this->topics, function ($query): void {
-                $query->where('type', '=', \App\Notifications\NewTopic::class);
+                $query->orWhere('type', '=', \App\Notifications\NewTopic::class);
             })
             ->when($this->unfollows, function ($query): void {
-                $query->where('type', '=', \App\Notifications\NewUnfollow::class);
+                $query->orWhere('type', '=', \App\Notifications\NewUnfollow::class);
             })
             ->when($this->uploads, function ($query): void {
-                $query->where('type', '=', \App\Notifications\NewUpload::class);
+                $query->orWhere('type', '=', \App\Notifications\NewUpload::class); });
             })
             ->reorder()
             ->orderBy('is_read')


### PR DESCRIPTION
Most checkbox filters within the same row use an "or" logic, for example, the resolution filter on `TorrentSearch..php`.
Therefore, it should also be possible to filter notifications by multiple types.

This MR adds the ability to display notifications which are either of type X or of type Y and so on.
