### PR TITLE
(Update) Speed up topic loading with many posts

### DIFF
--- a/database/migrations/2024_02_19_233644_add_permission_indexes.php
+++ b/database/migrations/2024_02_19_233644_add_permission_indexes.php
@@ -1,0 +1,14 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::table('permissions', function (Blueprint $table): void {
+            $table->index(['group_id', 'forum_id', 'read_topic']);
+        });
+    }
+};


### PR DESCRIPTION
On a topic with 180 pages (4500 posts), this covering index sped up the page load time from 4.2 seconds to 0.18 seconds.