### PR TITLE
(Fix) Duplicate emails in password resets

### DIFF
--- a/database/migrations/2024_02_19_100212_add_primary_keys.php
+++ b/database/migrations/2024_02_19_100212_add_primary_keys.php
@@ -7,6 +7,13 @@ use Illuminate\Support\Facades\Schema;
 return new class () extends Migration {
     public function up(): void
     {
+        DB::table('password_resets as p1')
+            ->join('password_resets as p2', function ($join): void {
+                $join->on('p1.token', '<', 'p2.token')
+                    ->whereColumn('p1.email', '=', 'p2.email');
+            })
+            ->delete();
+
         Schema::table('password_resets', function (Blueprint $table): void {
             $table->string('email')->primary()->change();
         });


### PR DESCRIPTION
Laravel deletes all previous password resets when adding a new reset, however, this is a race condition and it's possible for duplicate emails to exist in the table.