### PR TITLE
(Add) Refundable option to API

### DIFF
--- a/app/Http/Controllers/API/TorrentController.php
+++ b/app/Http/Controllers/API/TorrentController.php
@@ -163,6 +163,7 @@ class TorrentController extends BaseController
         $torrent->internal = $user->group->is_modo || $user->group->is_internal ? $request->input('internal') : 0;
         $torrent->featured = $user->group->is_modo || $user->group->is_internal ? $request->input('featured') : 0;
         $torrent->doubleup = $user->group->is_modo || $user->group->is_internal ? $request->input('doubleup') : 0;
+        $torrent->refundable = $user->group->is_modo || $user->group->is_internal ? $request->input('refundable') : 0;
         $du_until = $request->input('du_until');
 
         if (($user->group->is_modo || $user->group->is_internal) && isset($du_until)) {
@@ -231,6 +232,7 @@ class TorrentController extends BaseController
             'featured'         => 'required',
             'free'             => 'required|between:0,100',
             'doubleup'         => 'required',
+            'refundable'       => 'required',
             'sticky'           => 'required',
         ]);
 
@@ -434,6 +436,7 @@ class TorrentController extends BaseController
                 ->when($request->filled('adult'), fn ($query) => $query->ofAdult($request->boolean('adult')))
                 ->when($request->filled('free'), fn ($query) => $query->ofFreeleech($request->free))
                 ->when($request->filled('doubleup'), fn ($query) => $query->doubleup())
+                ->when($request->filled('refundable'), fn ($query) => $query->ofRefundable($request->boolean('refundable')))
                 ->when($request->filled('featured'), fn ($query) => $query->featured())
                 ->when($request->filled('stream'), fn ($query) => $query->streamOptimized())
                 ->when($request->filled('sd'), fn ($query) => $query->sd())

--- a/app/Http/Resources/TorrentResource.php
+++ b/app/Http/Resources/TorrentResource.php
@@ -51,6 +51,7 @@ class TorrentResource extends JsonResource
                 'num_file'        => $this->num_file,
                 'freeleech'       => $this->free.'%',
                 'double_upload'   => $this->doubleup,
+                'refundable'      => $this->refundable,
                 'internal'        => $this->internal,
                 'uploader'        => $this->anon ? 'Anonymous' : $this->user->username,
                 'seeders'         => $this->seeders,

--- a/app/Traits/TorrentFilter.php
+++ b/app/Traits/TorrentFilter.php
@@ -309,6 +309,14 @@ trait TorrentFilter
     /**
      * @param Builder<Torrent> $query
      */
+    public function scopeOfRefundable(Builder $query, int $refundable): void
+    {
+        $query->where('refundable', '=', $refundable);
+    }
+
+    /**
+     * @param Builder<Torrent> $query
+     */
     public function scopeStreamOptimized(Builder $query): void
     {
         $query->where('stream', '=', 1);


### PR DESCRIPTION
Allows to:
- Set refundable on upload
- Query API for refundable uploads
- Query API for non-refundable uploads

Allows to select or deselect refundable. If refundable is not added to GET requests, it will be ignored.