### PR TITLE
(Fix) Edge case resulting in double announce traffic stats

### DIFF
--- a/app/Jobs/ProcessAnnounce.php
+++ b/app/Jobs/ProcessAnnounce.php
@@ -55,7 +55,7 @@ class ProcessAnnounce implements ShouldQueue
      */
     public function middleware(): array
     {
-        return [(new WithoutOverlapping($this->user->id.':'.$this->torrent->id))->releaseAfter(30)];
+        return [new WithoutOverlapping($this->user->id.':'.$this->torrent->id)];
     }
 
     /**


### PR DESCRIPTION
When a user

1) completes a torrent (downloaded = x),
2) immediately stops it (downloaded = x),
3) resumes it (downloaded = 0) within the next 30 seconds,

then, during (1), the downloaded delta will be x, but (2) is considered overlapping (1), so it is delayed 30 seconds, by which time (3) will get processed first, having a delta of 0. After the 30 seconds are up, (2) will be processed, but since the previous processed announce (3) had a downloaded of 0, its delta will be x, causing the download to be doubled.

The same happens with upload.