### PR TITLE
(Update) Migrate create stub

### DIFF
--- a/stubs/migration.create.stub
+++ b/stubs/migration.create.stub
@@ -13,7 +13,7 @@ return new class () extends Migration {
     public function up()
     {
         Schema::create('{{ table }}', function (Blueprint $table) {
-            $table->id();
+            $table->increments('id');
             $table->timestamps();
         });
     }


### PR DESCRIPTION
In most cases, using 64-bit integers is completely unnecessary and 32-bit will do just fine. The only tables likely to exceed an id of 4 billion are history and peers.