### PR TITLE
(Update) SyncPeers command

### DIFF
--- a/app/Console/Commands/SyncPeers.php
+++ b/app/Console/Commands/SyncPeers.php
@@ -62,7 +62,7 @@ class SyncPeers extends Command
                     'leechers'   => DB::raw('COALESCE(seeders_leechers.updated_leechers, 0)'),
                     'updated_at' => DB::raw('updated_at')
                 ]);
-        });
+        }, 5);
 
         DB::transaction(function (): void {
             DB::statement("

--- a/app/Console/Commands/SyncPeers.php
+++ b/app/Console/Commands/SyncPeers.php
@@ -13,7 +13,6 @@
 
 namespace App\Console\Commands;
 
-use App\Models\History;
 use App\Models\Peer;
 use App\Models\Scopes\ApprovedScope;
 use App\Models\Torrent;

--- a/app/Console/Commands/SyncPeers.php
+++ b/app/Console/Commands/SyncPeers.php
@@ -73,7 +73,7 @@ class SyncPeers extends Command
                         WHERE `completed_at` IS NOT NULL AND torrent_id = torrents.id
                     )
             ");
-        });
+        }, 5);
 
         $this->info('Torrent Seeders/Leechers/Times Completed Count Synced Successfully!');
     }


### PR DESCRIPTION
- reverts query style to how it was while also adding a new query to handle history times_completed. While this is slow as history table can be one of the biggest tables it is wrapped in a transaction to avoid deadlocks and this is needed.