### PR TITLE
(Update) Show missing values from audit log search

### DIFF
--- a/resources/views/livewire/audit-log-search.blade.php
+++ b/resources/views/livewire/audit-log-search.blade.php
@@ -133,17 +133,9 @@
                                         "
                                     >
                                         {{ $key }}:
-                                        @if (is_array($value['old']))
-                                            @json($value['old'])
-                                        @else
-                                            {{ $value['old'] ?? 'null' }}
-                                        @endif
+                                        @json($value['old'])
                                         &rarr;
-                                        @if (is_array($value['new']))
-                                            @json($value['new'])
-                                        @else
-                                            {{ $value['new'] ?? 'null' }}
-                                        @endif
+                                        @json($value['new'])
                                     </li>
                                 @endforeach
                             </ul>


### PR DESCRIPTION
Boolean false values were showing up as nothing. Encoding it all values as json fixes this.

Found this old commit in my history, not sure why I never submitted it previously. Seems to make sense.