### PR TITLE
(Refactor) Use whereRelation when possible

### DIFF
--- a/app/Http/Controllers/StatsController.php
+++ b/app/Http/Controllers/StatsController.php
@@ -84,17 +84,17 @@ class StatsController extends Controller
             'disabled_user' => cache()->remember(
                 'disabled_user',
                 $this->carbon,
-                fn () => User::whereIn('group_id', Group::select('id')->where('slug', '=', 'disabled'))->count()
+                fn () => User::whereRelation('group', 'slug', '=', 'disabled')->count()
             ),
             'pruned_user' => cache()->remember(
                 'pruned_user',
                 $this->carbon,
-                fn () => User::onlyTrashed()->whereIn('group_id', Group::select('id')->where('slug', '=', 'pruned'))->count()
+                fn () => User::onlyTrashed()->whereRelation('group', 'slug', '=', 'pruned')->count()
             ),
             'banned_user' => cache()->remember(
                 'banned_user',
                 $this->carbon,
-                fn () => User::whereIn('group_id', Group::select('id')->where('slug', '=', 'banned'))->count()
+                fn () => User::whereRelation('group', 'slug', '=', 'banned')->count()
             ),
             'num_torrent'       => $numTorrent,
             'categories'        => Category::withCount('torrents')->orderBy('position')->get(),

--- a/app/Http/Livewire/AuditLogSearch.php
+++ b/app/Http/Livewire/AuditLogSearch.php
@@ -14,7 +14,6 @@
 namespace App\Http\Livewire;
 
 use App\Models\Audit;
-use App\Models\User;
 use Livewire\Component;
 use Livewire\WithPagination;
 
@@ -83,7 +82,7 @@ class AuditLogSearch extends Component
     final public function getAuditsProperty(): \Illuminate\Contracts\Pagination\LengthAwarePaginator
     {
         $audits = Audit::with('user')
-            ->when($this->username, fn ($query) => $query->whereIn('user_id', User::select('id')->where('username', '=', $this->username)))
+            ->whereRelation('user', 'username', '=', $this->username)
             ->when($this->modelName, fn ($query) => $query->where('model_name', '=', $this->modelName))
             ->when($this->modelId, fn ($query) => $query->where('model_entry_id', '=', $this->modelId))
             ->when($this->action, fn ($query) => $query->where('action', '=', $this->action))

--- a/app/Http/Livewire/GiftLogSearch.php
+++ b/app/Http/Livewire/GiftLogSearch.php
@@ -14,7 +14,6 @@
 namespace App\Http\Livewire;
 
 use App\Models\Gift;
-use App\Models\User;
 use App\Traits\LivewireSort;
 use Livewire\Component;
 use Livewire\WithPagination;
@@ -63,8 +62,8 @@ class GiftLogSearch extends Component
             'sender'    => fn ($query) => $query->withTrashed()->with('group'),
             'recipient' => fn ($query) => $query->withTrashed()->with('group'),
         ])
-            ->when($this->sender, fn ($query) => $query->whereIn('sender_id', User::select('id')->where('username', '=', $this->sender)))
-            ->when($this->receiver, fn ($query) => $query->whereIn('recipient_id', User::select('id')->where('username', '=', $this->receiver)))
+            ->when($this->sender, fn ($query) => $query->whereRelation('sender', 'username', '=', $this->sender))
+            ->when($this->receiver, fn ($query) => $query->whereRelation('recipient', 'username', '=', $this->receiver))
             ->when($this->comment, fn ($query) => $query->where('comment', 'LIKE', '%'.$this->comment.'%'))
             ->orderBy($this->sortField, $this->sortDirection)
             ->paginate($this->perPage);

--- a/app/Http/Livewire/HistorySearch.php
+++ b/app/Http/Livewire/HistorySearch.php
@@ -14,8 +14,6 @@
 namespace App\Http\Livewire;
 
 use App\Models\History;
-use App\Models\Torrent;
-use App\Models\User;
 use App\Traits\LivewireSort;
 use Illuminate\Support\Facades\DB;
 use Livewire\Component;
@@ -145,14 +143,8 @@ class HistorySearch extends Component
                         'immune',
                     ])
             )
-            ->when($this->torrent !== '', fn ($query) => $query->whereIn(
-                'history.torrent_id',
-                Torrent::select('id')->where('name', 'LIKE', '%'.str_replace(' ', '%', $this->torrent).'%')
-            ))
-            ->when($this->user !== '', fn ($query) => $query->whereIn(
-                'history.user_id',
-                User::select('id')->where('username', 'LIKE', $this->user)
-            ))
+            ->when($this->torrent !== '', fn ($query) => $query->whereRelation('torrent', 'name', 'LIKE', '%'.str_replace(' ', '%', $this->torrent).'%'))
+            ->when($this->user !== '', fn ($query) => $query->whereRelation('user', 'username', 'LIKE', $this->user))
             ->when($this->agent !== '', fn ($query) => $query->where('history.agent', 'LIKE', $this->agent.'%'))
             ->when($this->active === 'include', fn ($query) => $query->where('active', '=', true))
             ->when($this->active === 'exclude', fn ($query) => $query->where('active', '=', false))

--- a/app/Http/Livewire/InviteLogSearch.php
+++ b/app/Http/Livewire/InviteLogSearch.php
@@ -14,7 +14,6 @@
 namespace App\Http\Livewire;
 
 use App\Models\Invite;
-use App\Models\User;
 use App\Traits\LivewireSort;
 use Illuminate\Support\Facades\DB;
 use Livewire\Component;
@@ -90,10 +89,10 @@ class InviteLogSearch extends Component
     {
         return Invite::withTrashed()
             ->with(['sender.group', 'receiver.group'])
-            ->when($this->sender, fn ($query) => $query->whereIn('user_id', User::select('id')->where('username', '=', $this->sender)))
+            ->when($this->sender, fn ($query) => $query->whereRelation('sender', 'username', '=', $this->sender))
             ->when($this->email, fn ($query) => $query->where('email', 'LIKE', '%'.$this->email.'%'))
             ->when($this->code, fn ($query) => $query->where('code', 'LIKE', '%'.$this->code.'%'))
-            ->when($this->receiver, fn ($query) => $query->whereIn('accepted_by', User::select('id')->where('username', '=', $this->receiver)))
+            ->when($this->receiver, fn ($query) => $query->whereRelation('sender', 'username', '=', $this->receiver))
             ->when($this->custom, fn ($query) => $query->where('custom', 'LIKE', '%'.$this->custom.'%'))
             ->when(
                 $this->groupBy === 'user_id',

--- a/app/Http/Livewire/PeerSearch.php
+++ b/app/Http/Livewire/PeerSearch.php
@@ -14,7 +14,6 @@
 namespace App\Http\Livewire;
 
 use App\Models\Peer;
-use App\Models\Torrent;
 use App\Traits\LivewireSort;
 use Illuminate\Support\Facades\DB;
 use Livewire\Component;
@@ -207,10 +206,7 @@ class PeerSearch extends Component
             ->when($this->ip !== '', fn ($query) => $query->where(DB::raw('INET6_NTOA(ip)'), 'LIKE', $this->ip.'%'))
             ->when($this->port !== '', fn ($query) => $query->where('peers.port', 'LIKE', $this->port))
             ->when($this->agent !== '', fn ($query) => $query->where('peers.agent', 'LIKE', $this->agent.'%'))
-            ->when($this->torrent !== '', fn ($query) => $query->whereIn(
-                'peers.torrent_id',
-                Torrent::select('id')->where('name', 'LIKE', '%'.str_replace(' ', '%', $this->torrent).'%')
-            ))
+            ->when($this->torrent !== '', fn ($query) => $query->whereRelation('torrent', 'name', 'LIKE', '%'.str_replace(' ', '%', $this->torrent).'%'))
             ->when($this->connectivity === 'connectable', fn ($query) => $query->where('connectable', '=', true))
             ->when($this->connectivity === 'unconnectable', fn ($query) => $query->where('connectable', '=', false))
             ->when($this->active === 'include', fn ($query) => $query->where('active', '=', true))

--- a/app/Http/Livewire/WarningLogSearch.php
+++ b/app/Http/Livewire/WarningLogSearch.php
@@ -13,8 +13,6 @@
 
 namespace App\Http\Livewire;
 
-use App\Models\Torrent;
-use App\Models\User;
 use App\Models\Warning;
 use App\Traits\LivewireSort;
 use Livewire\Component;
@@ -73,9 +71,9 @@ class WarningLogSearch extends Component
     {
         return Warning::query()
             ->with(['warneduser.group', 'staffuser.group', 'torrenttitle'])
-            ->when($this->sender, fn ($query) => $query->whereIn('warned_by', User::select('id')->where('username', '=', $this->sender)))
-            ->when($this->receiver, fn ($query) => $query->whereIn('user_id', User::select('id')->where('username', '=', $this->receiver)))
-            ->when($this->torrent, fn ($query) => $query->whereIn('torrent', Torrent::select('id')->where('name', 'LIKE', '%'.$this->torrent.'%')))
+            ->when($this->sender, fn ($query) => $query->whereRelation('staffuser', 'username', '=', $this->sender))
+            ->when($this->receiver, fn ($query) => $query->whereRelation('warneduser', 'username', '=', $this->receiver))
+            ->when($this->torrent, fn ($query) => $query->whereRelation('torrenttitle', 'name', 'LIKE', '%'.$this->torrent.'%'))
             ->when($this->reason, fn ($query) => $query->where('reason', 'LIKE', '%'.$this->reason.'%'))
             ->when($this->show === true, fn ($query) => $query->onlyTrashed())
             ->orderBy($this->sortField, $this->sortDirection)

--- a/app/Traits/TorrentFilter.php
+++ b/app/Traits/TorrentFilter.php
@@ -73,7 +73,7 @@ trait TorrentFilter
         $authenticatedUser ??= auth()->user();
 
         $query
-            ->whereIn('user_id', User::select('id')->where('username', '=', $username))
+            ->whereRelation('user', 'username', '=', $username)
             ->when(
                 $authenticatedUser === null,
                 fn ($query) => $query->where('anon', '=', false),


### PR DESCRIPTION
All changes were tested for performance regressions. None of the included changes were affected. However, the code that uses `whereIn('category_id', Category::select('id')->where('movie_meta', '=', 1)` saw a ~10% performance loss so should not be changed.