### PR TITLE
(Fix) AuditLogSearch.php

### DIFF
--- a/app/Http/Livewire/AuditLogSearch.php
+++ b/app/Http/Livewire/AuditLogSearch.php
@@ -61,7 +61,7 @@ class AuditLogSearch extends Component
     final public function getModelNamesProperty()
     {
         $modelList = [];
-        $path = app_path()."/Models";
+        $path = app_path().'/Models';
         $results = scandir($path);
 
         foreach ($results as $result) {
@@ -82,7 +82,7 @@ class AuditLogSearch extends Component
     final public function getAuditsProperty(): \Illuminate\Contracts\Pagination\LengthAwarePaginator
     {
         $audits = Audit::with('user')
-            ->whereRelation('user', 'username', '=', $this->username)
+            ->when($this->username, fn ($query) => $query->whereRelation('user', 'username', '=', $this->username))
             ->when($this->modelName, fn ($query) => $query->where('model_name', '=', $this->modelName))
             ->when($this->modelId, fn ($query) => $query->where('model_entry_id', '=', $this->modelId))
             ->when($this->action, fn ($query) => $query->where('action', '=', $this->action))


### PR DESCRIPTION
The change involves the way we handle the `username` filter in our audit logs search.

## Problem

Previously, the `username` filter was applied directly to the query using the `whereRelation` method:

```php
->whereRelation('user', 'username', '=', $this->username)
```

This approach had the limitation that it would always apply the `username` filter, even if `$this->username` was empty or not set.

## Solution

The solution was to use`when` to conditionally apply the `username` filter only when `$this->username` is set and not empty:

```php
->when($this->username, fn ($query) => $query->whereRelation('user', 'username', '=', $this->username))
```

## Expected Result

With this change, the `username` filter in the audit logs search will only be applied when `$this->username` is set and not empty.