### PR TITLE
Modify BON earnings

### DIFF
--- a/app/Console/Commands/AutoBonAllocation.php
+++ b/app/Console/Commands/AutoBonAllocation.php
@@ -170,17 +170,17 @@ class AutoBonAllocation extends Command
 
         foreach ($legendaryTorrent as $value) {
             if (\array_key_exists($value->user_id, $array)) {
-                $array[$value->user_id] += $value->value * 1.5;
+                $array[$value->user_id] += $value->value * 0.2;
             } else {
-                $array[$value->user_id] = $value->value * 1.5;
+                $array[$value->user_id] = $value->value * 0.2;
             }
         }
 
         foreach ($oldTorrent as $value) {
             if (\array_key_exists($value->user_id, $array)) {
-                $array[$value->user_id] += $value->value * 1;
+                $array[$value->user_id] += $value->value * 0.1;
             } else {
-                $array[$value->user_id] = $value->value * 1;
+                $array[$value->user_id] = $value->value * 0.1;
             }
         }
 

--- a/app/Http/Controllers/User/EarningController.php
+++ b/app/Http/Controllers/User/EarningController.php
@@ -135,8 +135,8 @@ class EarningController extends Controller
 
         //Total points per hour
         $total = 2.00 * $dying
-            + 1.50 * $legendary
-            + 1.00 * $old
+            + 0.20 * $legendary
+            + 0.10 * $old
             + 0.75 * $huge
             + 0.50 * $large
             + 0.25 * $regular

--- a/resources/views/user/earning/index.blade.php
+++ b/resources/views/user/earning/index.blade.php
@@ -63,9 +63,9 @@
                         </td>
                         <td>1.50 &times; {{ $legendary }}</td>
                         <td>{{ $legendary * 1.5 }}</td>
-                        <td x-cloak x-show="isToggledOn">{{ $legendary * 1.5 * 24 }}</td>
-                        <td x-cloak x-show="isToggledOn">{{ $legendary * 1.5 * 24 * 7 }}</td>
-                        <td x-cloak x-show="isToggledOn">{{ $legendary * 1.5 * 24 * 30 }}</td>
+                        <td x-cloak x-show="isToggledOn">{{ $legendary * 0.2 * 24 }}</td>
+                        <td x-cloak x-show="isToggledOn">{{ $legendary * 0.2 * 24 * 7 }}</td>
+                        <td x-cloak x-show="isToggledOn">{{ $legendary * 0.2 * 24 * 30 }}</td>
                     </tr>
                     <tr>
                         <td>{{ __('torrent.old-torrent') }}</td>
@@ -74,9 +74,9 @@
                         </td>
                         <td>1.00 &times; {{ $old }}</td>
                         <td>{{ $old * 1 }}</td>
-                        <td x-cloak x-show="isToggledOn">{{ $old * 1 * 24 }}</td>
-                        <td x-cloak x-show="isToggledOn">{{ $old * 1 * 24 * 7 }}</td>
-                        <td x-cloak x-show="isToggledOn">{{ $old * 1 * 24 * 30 }}</td>
+                        <td x-cloak x-show="isToggledOn">{{ $old * 0.1 * 24 }}</td>
+                        <td x-cloak x-show="isToggledOn">{{ $old * 0.1 * 24 * 7 }}</td>
+                        <td x-cloak x-show="isToggledOn">{{ $old * 0.1 * 24 * 30 }}</td>
                     </tr>
                     <tr>
                         <td>{{ __('common.huge') }} {{ __('torrent.torrents') }}</td>


### PR DESCRIPTION
Adjust the BON earnings of older torrents to hinder abuse caused by users seeding many very small torrents for the primary purpose of earning BON, while still generating minor BON based on the original idea of assisting older torrents.

One well known site for instance, has approximately 110 torrents, less than 100MB and older than 12 months, which would currently generate 165 BON per hour, from the instant they are seeded.

Conversely, someone seeding 110 of the latest internal torrents would only initially receive approximately 55 BON per hour.