### PR TITLE
(Update) Set default topic state filter per forum

### DIFF
--- a/app/Http/Controllers/Staff/ForumController.php
+++ b/app/Http/Controllers/Staff/ForumController.php
@@ -73,7 +73,7 @@ class ForumController extends Controller
      */
     public function update(UpdateForumRequest $request, Forum $forum): \Illuminate\Http\RedirectResponse
     {
-        $forum->update($request->safe(['name', 'position', 'description', 'slug', 'forum_category_id']));
+        $forum->update($request->validated('forum'));
 
         ForumPermission::upsert(
             array_map(fn ($item) => ['forum_id' => $forum->id] + $item, $request->validated('permissions')),

--- a/app/Http/Livewire/ForumTopicSearch.php
+++ b/app/Http/Livewire/ForumTopicSearch.php
@@ -54,6 +54,7 @@ class ForumTopicSearch extends Component
     {
         $this->forum = $forum;
         $this->subscription = Subscription::where('user_id', '=', auth()->id())->where('forum_id', '=', $forum->id)->first();
+        $this->state = $this->forum->default_topic_state_filter ?: '';
     }
 
     final public function updatingSearch(): void

--- a/app/Http/Requests/Staff/StoreForumRequest.php
+++ b/app/Http/Requests/Staff/StoreForumRequest.php
@@ -16,6 +16,7 @@ namespace App\Http\Requests\Staff;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
+use Illuminate\Validation\Rule;
 
 class StoreForumRequest extends FormRequest
 {
@@ -35,21 +36,26 @@ class StoreForumRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'name' => [
+            'forum.name' => [
                 'required',
             ],
-            'position' => [
+            'forum.position' => [
                 'required',
             ],
-            'slug' => [
+            'forum.slug' => [
                 'required',
             ],
-            'description' => [
+            'forum.description' => [
                 'required',
             ],
-            'forum_category_id' => [
+            'forum.forum_category_id' => [
                 'required',
                 'exists:forum_categories,id',
+            ],
+            'forum.default_topic_state_filter' => [
+                'sometimes',
+                'nullable',
+                Rule::in(['close', 'open', null]),
             ],
             'permissions' => [
                 'required',
@@ -83,8 +89,10 @@ class StoreForumRequest extends FormRequest
      */
     protected function prepareForValidation(): void
     {
-        $this->merge([
-            'slug' => Str::slug($this->name),
-        ]);
+        $data = $this->toArray();
+
+        data_set($data, 'forum.slug', Str::slug($this->input('forum.name')));
+
+        $this->merge($data);
     }
 }

--- a/app/Http/Requests/Staff/UpdateForumRequest.php
+++ b/app/Http/Requests/Staff/UpdateForumRequest.php
@@ -15,6 +15,7 @@ namespace App\Http\Requests\Staff;
 
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Str;
+use Illuminate\Validation\Rule;
 
 class UpdateForumRequest extends FormRequest
 {
@@ -34,21 +35,26 @@ class UpdateForumRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'name' => [
+            'forum.name' => [
                 'required',
             ],
-            'position' => [
+            'forum.position' => [
                 'required',
             ],
-            'slug' => [
+            'forum.slug' => [
                 'required',
             ],
-            'description' => [
+            'forum.description' => [
                 'required',
             ],
-            'forum_category_id' => [
+            'forum.forum_category_id' => [
                 'required',
                 'exists:forum_categories,id',
+            ],
+            'forum.default_topic_state_filter' => [
+                'sometimes',
+                'nullable',
+                Rule::in(['close', 'open', null]),
             ],
             'permissions' => [
                 'required',
@@ -82,8 +88,10 @@ class UpdateForumRequest extends FormRequest
      */
     protected function prepareForValidation(): void
     {
-        $this->merge([
-            'slug' => Str::slug($this->name),
-        ]);
+        $data = $this->toArray();
+
+        data_set($data, 'forum.slug', Str::slug($this->input('forum.name')));
+
+        $this->merge($data);
     }
 }

--- a/database/migrations/2024_03_06_062526_add_open_topics_to_forums.php
+++ b/database/migrations/2024_03_06_062526_add_open_topics_to_forums.php
@@ -1,0 +1,17 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('forums', function (Blueprint $table): void {
+            $table->string('default_topic_state_filter')->nullable();
+        });
+    }
+};

--- a/resources/views/Staff/forum/create.blade.php
+++ b/resources/views/Staff/forum/create.blade.php
@@ -31,7 +31,7 @@
             <form class="form" method="POST" action="{{ route('staff.forums.store') }}">
                 @csrf
                 <p class="form__group">
-                    <input id="name" class="form__text" type="text" name="name" required />
+                    <input id="name" class="form__text" type="text" name="forum[name]" required />
                     <label class="form__label form__label--floating" for="name">Title</label>
                 </p>
                 <p class="form__group">
@@ -39,7 +39,7 @@
                         id="position"
                         class="form__text"
                         inputmode="numeric"
-                        name="position"
+                        name="forum[position]"
                         pattern="[0-9]*"
                         required
                         type="text"
@@ -52,7 +52,7 @@
                     <textarea
                         id="description"
                         class="form__textarea"
-                        name="description"
+                        name="forum[description]"
                         required
                     ></textarea>
                     <label class="form__label form__label--floating" for="description">
@@ -62,7 +62,7 @@
                 <p class="form__group">
                     <select
                         id="forum_category_id"
-                        name="forum_category_id"
+                        name="forum[forum_category_id]"
                         class="form__select"
                         x-data="{ selected: {{ $forumCategoryId }} || '' }"
                         x-model="selected"
@@ -81,6 +81,24 @@
                     </select>
                     <label class="form__label form__label--floating" for="forum_category_id">
                         Forum Category
+                    </label>
+                </p>
+                <p class="form__group">
+                    <select
+                        id="default_topic_state_filter"
+                        name="forum[default_topic_state_filter]"
+                        class="form__select"
+                        required
+                    >
+                        <option default selected>None</option>
+                        <option value="open">{{ __('forum.open') }}</option>
+                        <option value="close">{{ __('forum.closed') }}</option>
+                    </select>
+                    <label
+                        class="form__label form__label--floating"
+                        for="default_topic_state_filter"
+                    >
+                        Default Topic State Filter
                     </label>
                 </p>
                 <div class="form__group">

--- a/resources/views/Staff/forum/edit.blade.php
+++ b/resources/views/Staff/forum/edit.blade.php
@@ -59,7 +59,7 @@
                         id="name"
                         class="form__text"
                         type="text"
-                        name="name"
+                        name="forum[name]"
                         value="{{ $forum->name }}"
                         required
                     />
@@ -70,7 +70,7 @@
                         id="position"
                         class="form__text"
                         inputmode="numeric"
-                        name="position"
+                        name="forum[position]"
                         pattern="[0-9]*"
                         placeholder=" "
                         type="text"
@@ -82,7 +82,12 @@
                     </label>
                 </p>
                 <p class="form__group">
-                    <textarea id="description" name="description" class="form__textarea" required>
+                    <textarea
+                        id="description"
+                        name="forum[description]"
+                        class="form__textarea"
+                        required
+                    >
 {{ $forum->description }}</textarea
                     >
                     <label class="form__label form__label--floating" for="description">
@@ -90,7 +95,11 @@
                     </label>
                 </p>
                 <p class="form__group">
-                    <select id="forum_category_id" name="forum_category_id" class="form__select">
+                    <select
+                        id="forum_category_id"
+                        name="forum[forum_category_id]"
+                        class="form__select"
+                    >
                         @foreach ($categories as $category)
                             <option
                                 value="{{ $category->id }}"
@@ -102,6 +111,33 @@
                     </select>
                     <label class="form__label form__label--floating" for="forum_category_id">
                         Forum Category
+                    </label>
+                </p>
+                <p class="form__group">
+                    <select
+                        id="default_topic_state_filter"
+                        name="forum[default_topic_state_filter]"
+                        class="form__select"
+                    >
+                        <option default selected value="">None</option>
+                        <option
+                            value="open"
+                            @selected($forum->default_topic_state_filter === 'open')
+                        >
+                            {{ __('forum.open') }}
+                        </option>
+                        <option
+                            value="close"
+                            @selected($forum->default_topic_state_filter === 'close')
+                        >
+                            {{ __('forum.closed') }}
+                        </option>
+                    </select>
+                    <label
+                        class="form__label form__label--floating"
+                        for="default_topic_state_filter"
+                    >
+                        Topic State Filter
                     </label>
                 </p>
                 <div class="form__group">

--- a/tests/Unit/Http/Requests/Staff/StoreForumRequestTest.php
+++ b/tests/Unit/Http/Requests/Staff/StoreForumRequestTest.php
@@ -12,6 +12,7 @@
  */
 
 use App\Http\Requests\Staff\StoreForumRequest;
+use Illuminate\Validation\Rule;
 
 beforeEach(function (): void {
     $this->subject = new StoreForumRequest();
@@ -27,21 +28,26 @@ test('rules', function (): void {
     $actual = $this->subject->rules();
 
     $this->assertValidationRules([
-        'name' => [
+        'forum.name' => [
             'required',
         ],
-        'position' => [
+        'forum.position' => [
             'required',
         ],
-        'slug' => [
+        'forum.slug' => [
             'required',
         ],
-        'description' => [
+        'forum.description' => [
             'required',
         ],
-        'forum_category_id' => [
+        'forum.forum_category_id' => [
             'required',
             'exists:forum_categories,id',
+        ],
+        'forum.default_topic_state_filter' => [
+            'sometimes',
+            'nullable',
+            Rule::in(['close', 'open', null]),
         ],
         'permissions' => [
             'required',

--- a/tests/Unit/Http/Requests/Staff/UpdateForumRequestTest.php
+++ b/tests/Unit/Http/Requests/Staff/UpdateForumRequestTest.php
@@ -12,6 +12,7 @@
  */
 
 use App\Http\Requests\Staff\UpdateForumRequest;
+use Illuminate\Validation\Rule;
 
 beforeEach(function (): void {
     $this->subject = new UpdateForumRequest();
@@ -27,21 +28,26 @@ test('rules', function (): void {
     $actual = $this->subject->rules();
 
     $this->assertValidationRules([
-        'name' => [
+        'forum.name' => [
             'required',
         ],
-        'position' => [
+        'forum.position' => [
             'required',
         ],
-        'slug' => [
+        'forum.slug' => [
             'required',
         ],
-        'description' => [
+        'forum.description' => [
             'required',
         ],
-        'forum_category_id' => [
+        'forum.forum_category_id' => [
             'required',
             'exists:forum_categories,id',
+        ],
+        'forum.default_topic_state_filter' => [
+            'sometimes',
+            'nullable',
+            Rule::in(['close', 'open', null]),
         ],
         'permissions' => [
             'required',


### PR DESCRIPTION
Useful for forums dedicated to fixing bugs or adding suggestions. This way, topics can be closed when bugs are fixed or suggestions are implemented, and opening the forum only shows relevant bugs/suggestions by default. Topics with different states can be accessed by changing the filter back to `Any`.