### PR TITLE
Order groups by descending position order

### DIFF
--- a/app/Console/Commands/AutoGroup.php
+++ b/app/Console/Commands/AutoGroup.php
@@ -51,7 +51,7 @@ class AutoGroup extends Command
         $current = Carbon::now();
         $groups = Group::query()
             ->where('autogroup', '=', 1)
-            ->orderBy('position')
+            ->orderBy('position', 'desc')
             ->get();
 
         $users = User::query()


### PR DESCRIPTION
Should allow having groups with widely different requirements.

With the removal of fixed groups and allowing front end editing, there is an oddity in having groups assigned on a first met basis, meaning that groups in a higher position with widely different requirements would be assigned to some lower position group (with that groups requirements having been met), rather than being assigned strictly based on the requirements set in the group editor.

By having the autogroup task run in descending order, this should mean that groups that fit within seedsize requirements, for instance, are assigned based on their seedsize. Since the task runs in descending order, users not meeting some higher class requirements keep getting pushed down the position ladder until autogroup finds the highest class that the user meets. 

Should fix https://github.com/HDInnovations/UNIT3D-Community-Edition/issues/3631