### PR TITLE
(Update) don't include `None` when there aren't any genres in api

### DIFF
--- a/app/Http/Resources/TorrentResource.php
+++ b/app/Http/Resources/TorrentResource.php
@@ -34,7 +34,7 @@ class TorrentResource extends JsonResource
             'attributes' => [
                 'meta' => [
                     'poster' => isset($meta->poster) ? tmdb_image('poster_small', $meta->poster) : 'https://via.placeholder.com/90x135',
-                    'genres' => isset($meta->genres) ? $meta->genres->pluck('name')->implode(', ') : 'None',
+                    'genres' => isset($meta->genres) ? $meta->genres->pluck('name')->implode(', ') : '',
                 ],
                 'name'            => $this->name,
                 'release_year'    => $this->release_year,


### PR DESCRIPTION
Makes more sense than using special keywords and is undesired by downstream api consumers: https://github.com/Jackett/Jackett/pull/15106