### PR TITLE
(Add) Perks to the Group requirements page

### DIFF
--- a/app/Http/Controllers/StatsController.php
+++ b/app/Http/Controllers/StatsController.php
@@ -351,7 +351,7 @@ class StatsController extends Controller
             'user_avg_seedtime' => $user_avg_seedtime,
             'user_account_age'  => $user_account_age,
             'user_seed_size'    => $user_seed_size,
-            'groups'            => Group::orderBy('position')->where('is_modo', false)->get(),
+            'groups'            => Group::orderBy('position')->where('autogroup', '=', 1)->get(),
         ]);
     }
 

--- a/app/Http/Controllers/StatsController.php
+++ b/app/Http/Controllers/StatsController.php
@@ -351,7 +351,7 @@ class StatsController extends Controller
             'user_avg_seedtime' => $user_avg_seedtime,
             'user_account_age'  => $user_account_age,
             'user_seed_size'    => $user_seed_size,
-            'groups'            => Group::orderBy('position')->where('autogroup', 1)->get(),
+            'groups'            => Group::orderBy('position')->where('is_modo', False)->get(),
         ]);
     }
 

--- a/app/Http/Controllers/StatsController.php
+++ b/app/Http/Controllers/StatsController.php
@@ -351,7 +351,7 @@ class StatsController extends Controller
             'user_avg_seedtime' => $user_avg_seedtime,
             'user_account_age'  => $user_account_age,
             'user_seed_size'    => $user_seed_size,
-            'groups'            => Group::orderBy('position')->where('is_modo', False)->get(),
+            'groups'            => Group::orderBy('position')->where('is_modo', false)->get(),
         ]);
     }
 

--- a/app/Http/Requests/Staff/StoreGroupRequest.php
+++ b/app/Http/Requests/Staff/StoreGroupRequest.php
@@ -51,6 +51,9 @@ class StoreGroupRequest extends FormRequest
                 'nullable',
                 'integer',
             ],
+            'description' => [
+                'nullable',
+            ],
             'color' => [
                 'required',
             ],

--- a/app/Http/Requests/Staff/UpdateGroupRequest.php
+++ b/app/Http/Requests/Staff/UpdateGroupRequest.php
@@ -58,6 +58,9 @@ class UpdateGroupRequest extends FormRequest
                 'nullable',
                 'integer',
             ],
+            'description' => [
+                'nullable',
+            ],
             'color' => [
                 'required',
             ],

--- a/app/Models/Group.php
+++ b/app/Models/Group.php
@@ -26,6 +26,7 @@ use Illuminate\Database\Eloquent\Model;
  * @property int      $position
  * @property int      $level
  * @property int|null $download_slots
+ * @property string   $description
  * @property string   $color
  * @property string   $icon
  * @property string   $effect

--- a/database/migrations/2024_03_21_145139_add_group_description.php
+++ b/database/migrations/2024_03_21_145139_add_group_description.php
@@ -11,9 +11,9 @@
  * @license    https://www.gnu.org/licenses/agpl-3.0.en.html/ GNU Affero General Public License v3.0
  */
 
- use Illuminate\Database\Migrations\Migration;
- use Illuminate\Database\Schema\Blueprint;
- use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 
 return new class () extends Migration {
     /**
@@ -23,13 +23,6 @@ return new class () extends Migration {
     {
         Schema::table('groups', function (Blueprint $table): void {
             $table->string('description')->nullable()->after('download_slots');
-        });
-    }
-
-    public function down(): void
-    {
-        Schema::table('groups', function (Blueprint $table): void {
-            $table->dropColumn('description');
         });
     }
 };

--- a/database/migrations/2024_03_21_145139_add_group_description.php
+++ b/database/migrations/2024_03_21_145139_add_group_description.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * NOTICE OF LICENSE.
+ *
+ * UNIT3D Community Edition is open-sourced software licensed under the GNU Affero General Public License v3.0
+ * The details is bundled with this project in the file LICENSE.txt.
+ *
+ * @project    UNIT3D Community Edition
+ *
+ * @author     HDVinnie <hdinnovations@protonmail.com>
+ * @license    https://www.gnu.org/licenses/agpl-3.0.en.html/ GNU Affero General Public License v3.0
+ */
+
+ use Illuminate\Database\Migrations\Migration;
+ use Illuminate\Database\Schema\Blueprint;
+ use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('groups', function (Blueprint $table): void {
+            $table->string('description')->nullable()->after('download_slots');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('groups', function (Blueprint $table): void {
+            $table->dropColumn('description');
+        });
+    }
+};

--- a/resources/views/Staff/group/create.blade.php
+++ b/resources/views/Staff/group/create.blade.php
@@ -32,6 +32,18 @@
                 </p>
                 <p class="form__group">
                     <input
+                        id="description"
+                        class="form__text"
+                        type="text"
+                        name="description"
+                        placeholder=" "
+                    />
+                    <label class="form__label form__label--floating" for="description">
+                        {{ __('common.description') }}
+                    </label>
+                </p>
+                <p class="form__group">
+                    <input
                         id="position"
                         class="form__text"
                         type="text"

--- a/resources/views/Staff/group/edit.blade.php
+++ b/resources/views/Staff/group/edit.blade.php
@@ -47,6 +47,19 @@
                 </p>
                 <p class="form__group">
                     <input
+                        id="description"
+                        class="form__text"
+                        type="text"
+                        name="description"
+                        placeholder=" "
+                        value="{{ $group->description }}"
+                    />
+                    <label class="form__label form__label--floating" for="description">
+                        {{ __('common.description') }}
+                    </label>
+                </p>
+                <p class="form__group">
+                    <input
                         id="position"
                         class="form__text"
                         type="text"

--- a/resources/views/stats/groups/groups-requirements.blade.php
+++ b/resources/views/stats/groups/groups-requirements.blade.php
@@ -42,7 +42,10 @@
                             <td style="min-width: 20%">
                                 <a
                                     href="{{ route('group', ['id' => $group->id]) }}"
-                                    style="color: {{ $group->color }};background-image: {{ $group->effect }};"
+                                    style="
+                                        color: {{ $group->color }};
+                                        background-image: {{ $group->effect }};
+                                    "
                                 >
                                     <i class="{{ $group->icon }}"></i>
                                     {{ $group->name }}
@@ -178,10 +181,12 @@
                                                     <i
                                                         class="{{ config('other.font-awesome') }} fa-upload text-success"
                                                     ></i>
-                                                    {{ __('common.upload') }} {{ __('torrent.torrents') }}
+                                                    {{ __('common.upload') }}
+                                                    {{ __('torrent.torrents') }}
                                                 </td>
                                             </tr>
                                         @endif
+
                                         @if ($group->is_freeleech)
                                             <tr>
                                                 <td>
@@ -192,6 +197,7 @@
                                                 </td>
                                             </tr>
                                         @endif
+
                                         @if ($group->is_double_upload)
                                             <tr>
                                                 <td>
@@ -202,16 +208,16 @@
                                                 </td>
                                             </tr>
                                         @endif
+
                                         @if ($group->is_refundable)
                                             <tr>
                                                 <td>
-                                                    <i
-                                                        class="fas fa-percentage"
-                                                    ></i>
+                                                    <i class="fas fa-percentage"></i>
                                                     {{ __('torrent.refundable') }}
                                                 </td>
                                             </tr>
                                         @endif
+
                                         @if ($group->is_immune)
                                             <tr>
                                                 <td>
@@ -222,12 +228,11 @@
                                                 </td>
                                             </tr>
                                         @endif
+
                                         @if ($group->is_trusted)
                                             <tr>
                                                 <td>
-                                                    <i
-                                                        class="fas fa-tasks"
-                                                    ></i>
+                                                    <i class="fas fa-tasks"></i>
                                                     {{ __('staff.torrent-moderation') }} bypass
                                                 </td>
                                             </tr>

--- a/resources/views/stats/groups/groups-requirements.blade.php
+++ b/resources/views/stats/groups/groups-requirements.blade.php
@@ -33,6 +33,7 @@
                     <tr>
                         <th>{{ __('common.group') }}</th>
                         <th>Requirement</th>
+                        <th>Perks</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -41,7 +42,7 @@
                             <td style="min-width: 20%">
                                 <a
                                     href="{{ route('group', ['id' => $group->id]) }}"
-                                    style="color: {{ $group->color }}"
+                                    style="color: {{ $group->color }};background-image: {{ $group->effect }};"
                                 >
                                     <i class="{{ $group->icon }}"></i>
                                     {{ $group->name }}
@@ -156,7 +157,83 @@
                                             </tr>
                                         </tbody>
                                     </table>
+                                @else
+                                    {{ $group->description ?? '' }}
                                 @endif
+                            </td>
+                            <td>
+                                <table class="data-table">
+                                    <tbody>
+                                        <tr>
+                                            <td>
+                                                <i
+                                                    class="{{ config('other.font-awesome') }} fa-arrow-down-short-wide text-blue"
+                                                ></i>
+                                                DL Slots: {{ $group->download_slots ?? '∞' }}
+                                            </td>
+                                        </tr>
+                                        @if ($group->can_upload)
+                                            <tr>
+                                                <td>
+                                                    <i
+                                                        class="{{ config('other.font-awesome') }} fa-upload text-success"
+                                                    ></i>
+                                                    {{ __('common.upload') }} {{ __('torrent.torrents') }}
+                                                </td>
+                                            </tr>
+                                        @endif
+                                        @if ($group->is_freeleech)
+                                            <tr>
+                                                <td>
+                                                    <i
+                                                        class="{{ config('other.font-awesome') }} fa-star text-gold"
+                                                    ></i>
+                                                    {{ __('torrent.freeleech') }}
+                                                </td>
+                                            </tr>
+                                        @endif
+                                        @if ($group->is_double_upload)
+                                            <tr>
+                                                <td>
+                                                    <i
+                                                        class="fas fa-chevron-double-up torrent-icons__double-upload"
+                                                    ></i>
+                                                    {{ __('torrent.double-upload') }}
+                                                </td>
+                                            </tr>
+                                        @endif
+                                        @if ($group->is_refundable)
+                                            <tr>
+                                                <td>
+                                                    <i
+                                                        class="fas fa-percentage"
+                                                    ></i>
+                                                    {{ __('torrent.refundable') }}
+                                                </td>
+                                            </tr>
+                                        @endif
+                                        @if ($group->is_immune)
+                                            <tr>
+                                                <td>
+                                                    <i
+                                                        class="{{ config('other.font-awesome') }} fa-syringe"
+                                                    ></i>
+                                                    Immune to automated HnR warnings
+                                                </td>
+                                            </tr>
+                                        @endif
+                                        @if ($group->is_trusted)
+                                            <tr>
+                                                <td>
+                                                    <i
+                                                        class="fas fa-tasks"
+                                                    ></i>
+                                                    {{ __('staff.torrent-moderation') }} bypass
+                                                </td>
+                                            </tr>
+                                        @endif
+                                    </tbody>
+                                </table>
                             </td>
                         </tr>
                     @endforeach


### PR DESCRIPTION
- Adds perks to the group requirements view, sourced from the already existing database attribute
- Adds group descriptions. Will be shown instead of the default requirements for groups such as Banned, Disabled and others. Is optional