### PR TITLE
(Fix) Ticket attachment upload

### DIFF
--- a/app/Http/Livewire/AttachmentUpload.php
+++ b/app/Http/Livewire/AttachmentUpload.php
@@ -40,7 +40,7 @@ class AttachmentUpload extends Component
         $this->ticket = $id;
     }
 
-    final public function upload(): void
+    final public function updatedAttachment(): void
     {
         $this->validate();
 

--- a/resources/views/livewire/attachment-upload.blade.php
+++ b/resources/views/livewire/attachment-upload.blade.php
@@ -9,7 +9,6 @@
                         class="form__file"
                         type="file"
                         wire:model.live="attachment"
-                        wire:change="upload"
                         style="display: none"
                     />
                     <label class="form__button form__button--text" for="attachment">


### PR DESCRIPTION
This PR fixes the issue that nothing happens when selecting a file to attach to a ticket.

When looking in the browser console:
![grafik](https://github.com/HDInnovations/UNIT3D-Community-Edition/assets/34812414/bddb0b80-4dec-46ac-aac9-0a738a4fa606)

After applying the changes it's working again (for me).

Please check if the bug is reproducible.

Maybe using `upload()` was the main issue, as according to Livewire Docs:
![grafik](https://github.com/HDInnovations/UNIT3D-Community-Edition/assets/34812414/95cd9f29-c968-4bbe-b946-959de6670325)
https://livewire.laravel.com/docs/uploads#storing-uploaded-files