### PR TITLE
(Fix) Torrent row with null meta

### DIFF
--- a/resources/views/components/torrent/row.blade.php
+++ b/resources/views/components/torrent/row.blade.php
@@ -174,7 +174,9 @@
     </td>
 
     @if ($torrent->category->game_meta)
-        <td class="torrent-search--list__rating {{ rating_color($meta->rating ?? 0) ?? 'text-white' }}">
+        <td
+            class="torrent-search--list__rating {{ rating_color($meta->rating ?? 0) ?? 'text-white' }}"
+        >
             <span>{{ round($meta->rating ?? 0) }}%</span>
         </td>
     @elseif ($torrent->category->movie_meta || $torrent->category->tv_meta)

--- a/resources/views/components/torrent/row.blade.php
+++ b/resources/views/components/torrent/row.blade.php
@@ -174,7 +174,7 @@
     </td>
 
     @if ($torrent->category->game_meta)
-        <td class="torrent-search--list__rating {{ rating_color($meta->rating) ?? 'text-white' }}">
+        <td class="torrent-search--list__rating {{ rating_color($meta->rating ?? 0) ?? 'text-white' }}">
             <span>{{ round($meta->rating ?? 0) }}%</span>
         </td>
     @elseif ($torrent->category->movie_meta || $torrent->category->tv_meta)


### PR DESCRIPTION
Fixes: 

Attempt to read property "rating" on null (View: /var/www/html/resources/views/components/torrent/row.blade.php)