### PR TITLE
(Add) Peer support IPv4 & IPv6 at the same time

### DIFF
--- a/app/Console/Commands/AutoUpsertPeers.php
+++ b/app/Console/Commands/AutoUpsertPeers.php
@@ -71,6 +71,7 @@ class AutoUpsertPeers extends Command
                     [
                         'peer_id',
                         'ip',
+                        'ipv6',
                         'port',
                         'agent',
                         'uploaded',

--- a/app/DTO/AnnounceQueryDTO.php
+++ b/app/DTO/AnnounceQueryDTO.php
@@ -19,6 +19,7 @@ readonly class AnnounceQueryDTO
     private string $infoHash;
     private string $peerId;
     private string $ip;
+    private string $ipReported;
 
     public function __construct(
         public int $port,
@@ -33,11 +34,13 @@ readonly class AnnounceQueryDTO
         string $infoHash,
         string $peerId,
         string $ip,
+        string $ipReported,
     ) {
         $this->agent = bin2hex($agent);
         $this->infoHash = bin2hex($infoHash);
         $this->peerId = bin2hex($peerId);
         $this->ip = bin2hex($ip);
+        $this->ipReported = bin2hex($ipReported);
     }
 
     public function getAgent(): string
@@ -62,5 +65,21 @@ readonly class AnnounceQueryDTO
     {
         /** @var string */
         return hex2bin($this->ip);
+    }
+
+    public function getReportedIp(): string
+    {
+        /** @var string */
+        return hex2bin($this->ipReported);
+    }
+
+    public function isIPv6(): bool
+    {
+        return (bool) (filter_var(inet_ntop(hex2bin($this->ip)), FILTER_VALIDATE_IP, FILTER_FLAG_IPV6));
+    }
+
+    public function isReportedIPv4(): bool
+    {
+        return (bool) (filter_var(inet_ntop(hex2bin($this->ipReported)), FILTER_VALIDATE_IP, FILTER_FLAG_IPV4));
     }
 }

--- a/app/DTO/AnnounceQueryDTO.php
+++ b/app/DTO/AnnounceQueryDTO.php
@@ -79,15 +79,33 @@ readonly class AnnounceQueryDTO
             return false;
         }
 
-        return (bool) (filter_var(inet_ntop(hex2bin($this->ip)), FILTER_VALIDATE_IP, FILTER_FLAG_IPV6));
+        return (bool) (filter_var(inet_ntop(hex2bin((string) $this->ip)), FILTER_VALIDATE_IP, FILTER_FLAG_IPV6));
     }
 
     public function isReportedIPv4(): bool
     {
+        if (!config('announce.parse_extra_ip_field')) {
+            return false;
+        }
+
         if (!$this->ipReported) {
             return false;
         }
 
-        return (bool) (filter_var(inet_ntop(hex2bin($this->ipReported)), FILTER_VALIDATE_IP, FILTER_FLAG_IPV4));
+        $ip = inet_ntop(hex2bin((string) $this->ipReported));
+
+        if (!filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE)) {
+            return false;
+        }
+
+        if (!filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_RES_RANGE)) {
+            return false;
+        }
+
+        if (!filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/app/DTO/AnnounceQueryDTO.php
+++ b/app/DTO/AnnounceQueryDTO.php
@@ -75,11 +75,19 @@ readonly class AnnounceQueryDTO
 
     public function isIPv6(): bool
     {
+        if (!$this->ip) {
+            return false;
+        }
+
         return (bool) (filter_var(inet_ntop(hex2bin($this->ip)), FILTER_VALIDATE_IP, FILTER_FLAG_IPV6));
     }
 
     public function isReportedIPv4(): bool
     {
+        if (!$this->ipReported) {
+            return false;
+        }
+
         return (bool) (filter_var(inet_ntop(hex2bin($this->ipReported)), FILTER_VALIDATE_IP, FILTER_FLAG_IPV4));
     }
 }

--- a/app/DTO/AnnounceQueryDTO.php
+++ b/app/DTO/AnnounceQueryDTO.php
@@ -79,7 +79,10 @@ readonly class AnnounceQueryDTO
             return false;
         }
 
-        return (bool) (filter_var(inet_ntop(hex2bin((string) $this->ip)), FILTER_VALIDATE_IP, FILTER_FLAG_IPV6));
+        $ip = inet_ntop((string) hex2bin((string) $this->ip));
+
+        return ! (!filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6))
+        ;
     }
 
     public function isReportedIPv4(): bool
@@ -92,20 +95,17 @@ readonly class AnnounceQueryDTO
             return false;
         }
 
-        $ip = inet_ntop(hex2bin((string) $this->ipReported));
-
-        if (!filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE)) {
-            return false;
-        }
-
-        if (!filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_RES_RANGE)) {
-            return false;
-        }
+        $ip = inet_ntop((string) hex2bin((string) $this->ipReported));
 
         if (!filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)) {
             return false;
         }
 
-        return true;
+        if (!filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE)) {
+            return false;
+        }
+
+        return ! (!filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_RES_RANGE))
+        ;
     }
 }

--- a/app/Http/Controllers/AnnounceController.php
+++ b/app/Http/Controllers/AnnounceController.php
@@ -289,7 +289,7 @@ final class AnnounceController extends Controller
         // Part.4 Get request ip and convert it to packed form
         /** @var string $ip */
         $ip = inet_pton($request->getClientIp());
-        $ipReported = $request->query->get('ip') ? (string) inet_pton($request->query->get('ip')) : '';
+        $ipReported = $request->query->get('ip') ? (string) inet_pton((string) $request->query->get('ip')) : '';
 
         return new AnnounceQueryDTO(
             (int) $queries['port'],

--- a/app/Http/Controllers/AnnounceController.php
+++ b/app/Http/Controllers/AnnounceController.php
@@ -289,6 +289,7 @@ final class AnnounceController extends Controller
         // Part.4 Get request ip and convert it to packed form
         /** @var string $ip */
         $ip = inet_pton($request->getClientIp());
+        $ipReported = $request->query->get('ip') ? inet_pton($request->query->get('ip')) : '';
 
         return new AnnounceQueryDTO(
             (int) $queries['port'],
@@ -303,6 +304,7 @@ final class AnnounceController extends Controller
             (string) $queries['info_hash'],
             (string) $queries['peer_id'],
             $ip,
+            $ipReported,
         );
     }
 
@@ -411,7 +413,7 @@ final class AnnounceController extends Controller
         // If we use eager loading, then laravel will use `where torrent_id in (123)` instead of `where torrent_id = ?`
         $torrent->setRelation(
             'peers',
-            Peer::select(['id', 'torrent_id', 'peer_id', 'user_id', 'downloaded', 'uploaded', 'left', 'seeder', 'active', 'visible', 'ip', 'port', 'updated_at'])
+            Peer::select(['id', 'torrent_id', 'peer_id', 'user_id', 'downloaded', 'uploaded', 'left', 'seeder', 'active', 'visible', 'ip', 'ipv6', 'port', 'updated_at'])
                 ->where('torrent_id', '=', $torrent->id)
                 ->get()
         );
@@ -581,15 +583,14 @@ final class AnnounceController extends Controller
                         continue;
                     }
 
-                    switch (\strlen((string) $peer['ip'])) {
-                        case 4:
-                            $peersIpv4 .= $peer['ip'].pack('n', (int) $peer['port']);
-                            $peerCount++;
+                    if (\strlen((string) $peer['ip']) === 4) {
+                        $peersIpv4 .= $peer['ip'].pack('n', (int) $peer['port']);
+                        $peerCount++;
+                    }
 
-                            break;
-                        case 16:
-                            $peersIpv6 .= $peer['ip'].pack('n', (int) $peer['port']);
-                            $peerCount++;
+                    if (\strlen((string) $peer['ipv6']) === 16) {
+                        $peersIpv6 .= $peer['ipv6'].pack('n', (int) $peer['port']);
+                        $peerCount++;
                     }
 
                     if ($peerCount >= $limit) {
@@ -611,15 +612,14 @@ final class AnnounceController extends Controller
                         continue;
                     }
 
-                    switch (\strlen((string) $peer['ip'])) {
-                        case 4:
-                            $peersIpv4 .= $peer['ip'].pack('n', (int) $peer['port']);
-                            $peerCount++;
+                    if (\strlen((string) $peer['ip']) === 4) {
+                        $peersIpv4 .= $peer['ip'].pack('n', (int) $peer['port']);
+                        $peerCount++;
+                    }
 
-                            break;
-                        case 16:
-                            $peersIpv6 .= $peer['ip'].pack('n', (int) $peer['port']);
-                            $peerCount++;
+                    if (\strlen((string) $peer['ipv6']) === 16) {
+                        $peersIpv6 .= $peer['ipv6'].pack('n', (int) $peer['port']);
+                        $peerCount++;
                     }
 
                     if ($peerCount >= $limit) {

--- a/app/Http/Controllers/AnnounceController.php
+++ b/app/Http/Controllers/AnnounceController.php
@@ -289,7 +289,7 @@ final class AnnounceController extends Controller
         // Part.4 Get request ip and convert it to packed form
         /** @var string $ip */
         $ip = inet_pton($request->getClientIp());
-        $ipReported = $request->query->get('ip') ? inet_pton($request->query->get('ip')) : '';
+        $ipReported = $request->query->get('ip') ? (string) inet_pton($request->query->get('ip')) : '';
 
         return new AnnounceQueryDTO(
             (int) $queries['port'],

--- a/app/Http/Controllers/AnnounceController.php
+++ b/app/Http/Controllers/AnnounceController.php
@@ -458,10 +458,12 @@ final class AnnounceController extends Controller
 
         $now = (int) now()->timestamp;
 
+        $ip = $queries->isIPv6() ? 'ipv6' : 'ipv4';
+
         // Detect broken (namely qBittorrent) clients sending duplicate announces
         // and eliminate them from screwing up stats.
 
-        $duplicateAnnounceKey = config('cache.prefix').'announce-lock:'.$user->id.'-'.$torrent->id.'-'.$queries->getPeerId().'-'.$event;
+        $duplicateAnnounceKey = config('cache.prefix').'announce-lock:'.$user->id.'-'.$torrent->id.'-'.$queries->getPeerId().'-'.$event.'-'.$ip;
 
         $lastAnnouncedAt = Redis::connection('announce')->command('SET', [$duplicateAnnounceKey, $now, ['NX', 'GET', 'EX' => 30]]);
 
@@ -471,7 +473,7 @@ final class AnnounceController extends Controller
 
         // Block clients disrespecting the min interval
 
-        $lastAnnouncedKey = config('cache.prefix').'peer-last-announced:'.$user->id.'-'.$torrent->id.'-'.$queries->getPeerId();
+        $lastAnnouncedKey = config('cache.prefix').'peer-last-announced:'.$user->id.'-'.$torrent->id.'-'.$queries->getPeerId().'-'.$ip;
 
         $randomMinInterval = random_int(intdiv(self::MIN * 85, 100), intdiv(self::MIN * 95, 100));
 

--- a/app/Http/Controllers/TorrentPeerController.php
+++ b/app/Http/Controllers/TorrentPeerController.php
@@ -32,6 +32,7 @@ class TorrentPeerController extends Controller
                 ->with('user')
                 ->select(['torrent_id', 'user_id', 'uploaded', 'downloaded', 'left', 'port', 'agent', 'created_at', 'updated_at', 'seeder', 'active', 'visible'])
                 ->selectRaw('INET6_NTOA(ip) as ip')
+                ->selectRaw('INET6_NTOA(ipv6) as ipv6')
                 ->where('torrent_id', '=', $id)
                 ->orderByDesc('active')
                 ->orderByDesc('seeder')

--- a/app/Http/Controllers/User/UserController.php
+++ b/app/Http/Controllers/User/UserController.php
@@ -90,8 +90,8 @@ class UserController extends Controller
             'invitedBy' => Invite::where('accepted_by', '=', $user->id)->first(),
             'clients'   => $user->peers()
                 ->select('agent', 'port')
-                ->selectRaw('INET6_NTOA(ip) as ip, MIN(created_at) as created_at, MAX(updated_at) as updated_at, COUNT(*) as num_peers')
-                ->groupBy(['ip', 'port', 'agent'])
+                ->selectRaw('INET6_NTOA(ip) as ip, INET6_NTOA(ipv6) as ipv6, MIN(created_at) as created_at, MAX(updated_at) as updated_at, COUNT(*) as num_peers')
+                ->groupBy(['ip', 'ipv6', 'port', 'agent'])
                 ->where('active', '=', true)
                 ->get(),
             'achievements' => AchievementProgress::with('details')

--- a/app/Http/Livewire/PeerSearch.php
+++ b/app/Http/Livewire/PeerSearch.php
@@ -41,6 +41,9 @@ class PeerSearch extends Component
     public string $ip = '';
 
     #[Url(history: true)]
+    public string $ipv6 = '';
+
+    #[Url(history: true)]
     public string $port = '';
 
     #[Url(history: true)]
@@ -116,6 +119,7 @@ class PeerSearch extends Component
                         'peers.connectable',
                     ])
                     ->selectRaw('INET6_NTOA(peers.ip) as ip')
+                    ->selectRaw('INET6_NTOA(peers.ipv6) as ipv6')
                     ->with(['user', 'user.group', 'torrent:id,name,size'])
             )
             ->when(
@@ -124,6 +128,7 @@ class PeerSearch extends Component
                     ->select(['peers.user_id', 'peers.port', 'peers.agent'])
                     ->selectRaw('COUNT(DISTINCT(peers.torrent_id)) as torrent_id')
                     ->selectRaw('INET6_NTOA(peers.ip) as ip')
+                    ->selectRaw('INET6_NTOA(peers.ipv6) as ipv6')
                     ->selectRaw('SUM(peers.uploaded) as uploaded')
                     ->selectRaw('SUM(peers.downloaded) as downloaded')
                     ->selectRaw('SUM(peers.`left`) as `left`')
@@ -134,7 +139,7 @@ class PeerSearch extends Component
                     ->selectRaw('SUM(peers.connectable = 0) as unconnectable_count')
                     ->selectRaw('SUM(peers.active = 1) as active_count')
                     ->selectRaw('SUM(peers.active = 0) as inactive_count')
-                    ->groupBy(['peers.user_id', 'peers.agent', 'peers.ip', 'peers.port'])
+                    ->groupBy(['peers.user_id', 'peers.agent', 'peers.ip', 'peers.ipv6', 'peers.port'])
                     ->with(['user', 'user.group'])
             )
             ->when(
@@ -144,6 +149,7 @@ class PeerSearch extends Component
                     ->selectRaw('COUNT(DISTINCT(peers.torrent_id)) as torrent_id')
                     ->selectRaw('COUNT(DISTINCT(peers.agent)) as agent')
                     ->selectRaw('INET6_NTOA(peers.ip) as ip')
+                    ->selectRaw('INET6_NTOA(peers.ipv6) as ipv6')
                     ->selectRaw('COUNT(DISTINCT(peers.port)) as port')
                     ->selectRaw('SUM(peers.uploaded) as uploaded')
                     ->selectRaw('SUM(peers.downloaded) as downloaded')
@@ -155,7 +161,7 @@ class PeerSearch extends Component
                     ->selectRaw('SUM(peers.connectable = 0) as unconnectable_count')
                     ->selectRaw('SUM(peers.active = 1) as active_count')
                     ->selectRaw('SUM(peers.active = 0) as inactive_count')
-                    ->groupBy(['peers.user_id', 'peers.ip'])
+                    ->groupBy(['peers.user_id', 'peers.ip', 'peers.ipv6'])
                     ->with(['user', 'user.group'])
             )
             ->when(
@@ -165,6 +171,7 @@ class PeerSearch extends Component
                     ->selectRaw('COUNT(DISTINCT(peers.torrent_id)) as torrent_id')
                     ->selectRaw('COUNT(DISTINCT(peers.agent)) as agent')
                     ->selectRaw('COUNT(DISTINCT(peers.ip)) as ip')
+                    ->selectRaw('COUNT(DISTINCT(peers.ipv6)) as ipv6')
                     ->selectRaw('COUNT(DISTINCT(peers.port)) as port')
                     ->selectRaw('SUM(peers.uploaded) as uploaded')
                     ->selectRaw('SUM(peers.downloaded) as downloaded')
@@ -208,6 +215,7 @@ class PeerSearch extends Component
                     )
             )
             ->when($this->ip !== '', fn ($query) => $query->where(DB::raw('INET6_NTOA(ip)'), 'LIKE', $this->ip.'%'))
+            ->when($this->ipv6 !== '', fn ($query) => $query->where(DB::raw('INET6_NTOA(ipv6)'), 'LIKE', $this->ipv6.'%'))
             ->when($this->port !== '', fn ($query) => $query->where('peers.port', 'LIKE', $this->port))
             ->when($this->agent !== '', fn ($query) => $query->where('peers.agent', 'LIKE', $this->agent.'%'))
             ->when($this->torrent !== '', fn ($query) => $query->whereRelation('torrent', 'name', 'LIKE', '%'.str_replace(' ', '%', $this->torrent).'%'))

--- a/app/Http/Livewire/UserActive.php
+++ b/app/Http/Livewire/UserActive.php
@@ -43,6 +43,9 @@ class UserActive extends Component
     public string $ip = '';
 
     #[Url(history: true)]
+    public string $ipv6 = '';
+
+    #[Url(history: true)]
     public string $port = '';
 
     #[Url(history: true)]
@@ -105,6 +108,7 @@ class UserActive extends Component
                 'torrents.times_completed',
             )
             ->selectRaw('INET6_NTOA(ip) as ip')
+            ->selectRaw('INET6_NTOA(ipv6) as ipv6')
             ->selectRaw('(1 - (peers.left / NULLIF(torrents.size, 0))) AS progress')
             ->where('peers.user_id', '=', $this->user->id)
             ->when(
@@ -113,6 +117,7 @@ class UserActive extends Component
                     ->where('name', 'like', '%'.str_replace(' ', '%', $this->name).'%')
             )
             ->when($this->ip !== '', fn ($query) => $query->having('ip', '=', $this->ip))
+            ->when($this->ipv6 !== '', fn ($query) => $query->having('ipv6', '=', $this->ipv6))
             ->when($this->port !== '', fn ($query) => $query->where('port', '=', $this->port))
             ->when($this->client !== '', fn ($query) => $query->where('agent', '=', $this->client))
             ->when($this->seeding === 'include', fn ($query) => $query->where('seeder', '=', 1))

--- a/app/Jobs/ProcessAnnounce.php
+++ b/app/Jobs/ProcessAnnounce.php
@@ -305,7 +305,7 @@ class ProcessAnnounce implements ShouldQueue
 
         // Either Client does not have IPv4 or
         // IPv4 announce will come in next request (qBittorrent)
-        return hex2bin('');
+        return (string) hex2bin('');
     }
 
     /**
@@ -324,6 +324,6 @@ class ProcessAnnounce implements ShouldQueue
             return $peer->ipv6;
         }
 
-        return hex2bin('');
+        return (string) hex2bin('');
     }
 }

--- a/config/announce.php
+++ b/config/announce.php
@@ -127,4 +127,30 @@ return [
     */
 
     'log_announces' => false,
+
+    /*
+    |--------------------------------------------------------------------------
+    | IPv4 Announce Field !!! Read carefully !!!
+    |--------------------------------------------------------------------------
+    |
+    | The announce supports both IPv4 and IPv6 within the same peer.
+    | According to Bittorrent spec, each IP should be announced in seperated requests
+    | -> See: https://github.com/bittorrent/bittorrent.org/pull/101
+    | Older torrent clients (ruTorrent) which have not implemented this, will use an
+    | extra `ip` field for the IPv4 address within the request.
+    |
+    | !!! The `ip` field can be spoofed / changed easily and thus be used for DDoS !!!
+    |
+    | This setting is ONLY relevant for you, if:
+    | 1. Your tracker supports both IPv4 and IPv6
+    | 2. You trust your users to not abuse this
+    | 3. You want to allow ruTorrent clients to have an IPv4 address, IF they use IPv6
+    |
+    | It's safer to ask the user to switch to qBittorrent or any other modern client
+    | which supports seperated requests for each IP.
+    |
+    | !!! KEEP `false` if you don't understand. !!!
+    */
+
+    'parse_extra_ip_field' => false,
 ];

--- a/database/migrations/2023_10_26_112551_add_ipv6_to_peers_table.php
+++ b/database/migrations/2023_10_26_112551_add_ipv6_to_peers_table.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * NOTICE OF LICENSE.
+ *
+ * UNIT3D Community Edition is open-sourced software licensed under the GNU Affero General Public License v3.0
+ * The details is bundled with this project in the file LICENSE.txt.
+ *
+ * @project    UNIT3D Community Edition
+ *
+ * @author     HDVinnie <hdinnovations@protonmail.com>
+ * @license    https://www.gnu.org/licenses/agpl-3.0.en.html/ GNU Affero General Public License v3.0
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::table('peers', function (Blueprint $table): void {
+            $table->string('ipv6')->after('ip')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('peers', function (Blueprint $table): void {
+            $table->dropColumn('ipv6');
+        });
+    }
+};

--- a/database/migrations/2024_04_02_001249_update_peers_table_ipv6_support.php
+++ b/database/migrations/2024_04_02_001249_update_peers_table_ipv6_support.php
@@ -21,5 +21,10 @@ return new class () extends Migration {
     public function up(): void
     {
         DB::statement('ALTER TABLE `peers` MODIFY `ipv6` VARBINARY(16) NOT NULL');
+
+        // Migrate existing IPv6 addresses to new column
+        DB::statement('UPDATE `peers` SET `ipv6` = `ip` WHERE LENGTH(`ip`) = 16');
+        // Remove old IPv6 addresses from old column
+        DB::statement('UPDATE `peers` SET `ip` = "" WHERE LENGTH(`ip`) = 16');
     }
 };

--- a/database/migrations/2024_04_02_001249_update_peers_table_ipv6_support.php
+++ b/database/migrations/2024_04_02_001249_update_peers_table_ipv6_support.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * NOTICE OF LICENSE.
+ *
+ * UNIT3D Community Edition is open-sourced software licensed under the GNU Affero General Public License v3.0
+ * The details is bundled with this project in the file LICENSE.txt.
+ *
+ * @project    UNIT3D Community Edition
+ *
+ * @author     HDVinnie <hdinnovations@protonmail.com>
+ * @license    https://www.gnu.org/licenses/agpl-3.0.en.html/ GNU Affero General Public License v3.0
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        DB::statement('ALTER TABLE `peers` MODIFY `ipv6` VARBINARY(16) NOT NULL');
+    }
+};

--- a/lang/en/common.php
+++ b/lang/en/common.php
@@ -107,6 +107,7 @@ return [
     'info'                 => 'Info',
     'internal'             => 'Internal',
     'ip'                   => 'IP',
+    'ipv6'                 => 'IPv6',
     'is-allowed'           => 'is allowed',
     'language'             => 'Language',
     'languages'            => 'Languages',

--- a/resources/views/livewire/peer-search.blade.php
+++ b/resources/views/livewire/peer-search.blade.php
@@ -22,6 +22,12 @@
                         <label class="form__label form__label--floating" for="ip">IP Address</label>
                     </p>
                     <p class="form__group">
+                        <input id="ip" wire:model.live="ipv6" class="form__text" placeholder=" " />
+                        <label class="form__label form__label--floating" for="ip">
+                            IPv6 Address
+                        </label>
+                    </p>
+                    <p class="form__group">
                         <input
                             id="port"
                             wire:model.live="port"
@@ -156,6 +162,18 @@
                                 IPs
                             @endif
                             @include('livewire.includes._sort-icon', ['field' => 'ip'])
+                        </th>
+                        <th
+                            wire:click="sortBy('ipv6')"
+                            role="columnheader button"
+                            style="text-align: right"
+                        >
+                            @if ($groupBy === 'none' || $groupBy === 'user_ip' || $groupBy === 'user_session')
+                                IPv6
+                            @else
+                                IPv6s
+                            @endif
+                            @include('livewire.includes._sort-icon', ['field' => 'ipv6'])
                         </th>
                         <th
                             wire:click="sortBy('port')"
@@ -347,6 +365,9 @@
                             @endif
                             <td style="text-align: right">
                                 {{ $peer->ip }}
+                            </td>
+                            <td style="text-align: right">
+                                {{ $peer->ipv6 }}
                             </td>
                             <td style="text-align: right">
                                 {{ $peer->port }}

--- a/resources/views/livewire/user-active.blade.php
+++ b/resources/views/livewire/user-active.blade.php
@@ -158,6 +158,14 @@
                         @include('livewire.includes._sort-icon', ['field' => 'ip'])
                     </th>
                     <th
+                        class="user-active__ip-header"
+                        wire:click="sortBy('ipv6')"
+                        role="columnheader button"
+                    >
+                        {{ __('common.ipv6') }}
+                        @include('livewire.includes._sort-icon', ['field' => 'ipv6'])
+                    </th>
+                    <th
                         class="user-active__port-header"
                         wire:click="sortBy('port')"
                         role="columnheader button"
@@ -286,6 +294,9 @@
                             </td>
                             <td class="user-active__ip">
                                 {{ $active->ip ?: __('common.unknown') }}
+                            </td>
+                            <td class="user-active__ip">
+                                {{ $active->ipv6 ?: __('common.unknown') }}
                             </td>
                             <td class="user-active__port">
                                 {{ $active->port ?: __('common.unknown') }}

--- a/resources/views/torrent/peers.blade.php
+++ b/resources/views/torrent/peers.blade.php
@@ -61,6 +61,7 @@
                         <th>{{ __('torrent.left') }}</th>
                         <th>{{ __('torrent.client') }}</th>
                         <th>{{ __('common.ip') }}</th>
+                        <th>{{ __('common.ipv6') }}</th>
                         <th>{{ __('common.port') }}</th>
                         @if (\config('announce.connectable_check') == true)
                             <th>Connectable</th>
@@ -95,12 +96,55 @@
                             </td>
                             <td>{{ \App\Helpers\StringHelper::formatBytes($peer->left, 2) }}</td>
                             <td>{{ $peer->agent }}</td>
-
                             @if (auth()->user()->group->is_modo || auth()->id() == $peer->user_id)
-                                <td>{{ $peer->ip }}</td>
+                                <td>
+                                    @if ($peer->ip)
+                                        <i
+                                            class="{{ config('other.font-awesome') }} text-green fa-check"
+                                        ></i>
+                                        {{ $peer->ip }}
+                                    @else
+                                        <i
+                                            class="{{ config('other.font-awesome') }} text-red fa-x"
+                                        ></i>
+                                    @endif
+                                </td>
+                                <td>
+                                    @if ($peer->ipv6)
+                                        <i
+                                            class="{{ config('other.font-awesome') }} text-green fa-check"
+                                        ></i>
+                                        {{ $peer->ipv6 }}
+                                    @else
+                                        <i
+                                            class="{{ config('other.font-awesome') }} text-red fa-x"
+                                        ></i>
+                                    @endif
+                                </td>
                                 <td>{{ $peer->port }}</td>
                             @else
-                                <td>---</td>
+                                <td>
+                                    @if ($peer->ip)
+                                        <i
+                                            class="{{ config('other.font-awesome') }} text-green fa-check"
+                                        ></i>
+                                    @else
+                                        <i
+                                            class="{{ config('other.font-awesome') }} text-red fa-x"
+                                        ></i>
+                                    @endif
+                                </td>
+                                <td>
+                                    @if ($peer->ipv6)
+                                        <i
+                                            class="{{ config('other.font-awesome') }} text-green fa-check"
+                                        ></i>
+                                    @else
+                                        <i
+                                            class="{{ config('other.font-awesome') }} text-red fa-x"
+                                        ></i>
+                                    @endif
+                                </td>
                                 <td>---</td>
                             @endif
                             @if (\config('announce.connectable_check') == true)

--- a/resources/views/user/profile/show.blade.php
+++ b/resources/views/user/profile/show.blade.php
@@ -252,6 +252,7 @@
                             <tr>
                                 <th>{{ __('torrent.client') }}</th>
                                 <th>{{ __('common.ip') }}</th>
+                                <th>{{ __('common.ipv6') }}</th>
                                 <th>{{ __('common.port') }}</th>
                                 <th>{{ __('torrent.started') }}</th>
                                 <th>{{ __('torrent.last-update') }}</th>
@@ -267,13 +268,32 @@
                                     <td>{{ $client->agent }}</td>
                                     <td>
                                         @if (auth()->user()->group->is_modo)
-                                            <a
-                                                href="{{ route('staff.peers.index', ['ip' => $client->ip, 'groupBy' => 'user_ip']) }}"
-                                            >
-                                                {{ $client->ip }}
-                                            </a>
+                                            @if ($client->ip)
+                                                <a
+                                                    href="{{ route('staff.peers.index', ['ip' => $client->ip, 'groupBy' => 'user_ip']) }}"
+                                                >
+                                                    {{ $client->ip }}
+                                                </a>
+                                            @else
+                                                {{ __('common.unknown') }}
+                                            @endif
                                         @elseif (auth()->id() === $user->id)
-                                            {{ $client->ip }}
+                                            {{ $client->ip ?: __('common.unknown') }}
+                                        @endif
+                                    </td>
+                                    <td>
+                                        @if (auth()->user()->group->is_modo)
+                                            @if ($client->ipv6)
+                                                <a
+                                                    href="{{ route('staff.peers.index', ['ipv6' => $client->ipv6, 'groupBy' => 'user_ip']) }}"
+                                                >
+                                                    {{ $client->ipv6 }}
+                                                </a>
+                                            @else
+                                                {{ __('common.unknown') }}
+                                            @endif
+                                        @elseif (auth()->id() === $user->id)
+                                            {{ $client->ipv6 ?: __('common.unknown') }}
                                         @endif
                                     </td>
                                     <td>{{ $client->port }}</td>
@@ -295,7 +315,7 @@
                                     </td>
                                     <td>
                                         <a
-                                            href="{{ route('users.peers.index', ['user' => $user, 'ip' => $client->ip, 'port' => $client->port, 'client' => $client->agent]) }}"
+                                            href="{{ route('users.peers.index', ['user' => $user, 'ip' => $client->ip, 'ipv6' => $client->ipv6, 'port' => $client->port, 'client' => $client->agent]) }}"
                                         >
                                             {{ $client->num_peers }}
                                         </a>


### PR DESCRIPTION
Draft - Proof of concept

Not sure if this should be merged - might have implications which I have not caught.

**Notes:**
- ~~`checkMinInterval` has to be changed or disabled~~
- `supervisor` config has to have at least `--tries=2` (tested with `--tries=3`)
- No incorrect stats (download/upload) has been seen during testing
- Maybe we want to only give `ipv6` peers to peers who also have `ipv6`

**Missing (will be added to this PR):**
- ~~Views~~
- ~~Livewire~~

**How does it work:**
- **qBittorrent:**
1. Each Client IP generates a seperate request
2. All requests land into the queue with the `WithoutOverlapping` lock, so that only one get's processed at a time
3. The other requests will time out and re-run after ~10-15s, each job will find the same "old" peer and add the missing ip addresses (IPv4/IPv6)

- **ruTorrent:**
1. The IPv4 header will be send into a seperate `ip` field, when announcing via IPv6
2. Same as qBittorrent, only that a single job will run, as the request has both IP addresses (IPv6 via client ip / IPv4 via `ip` field)