### PR TITLE
(Update) TopTorrents.php

### DIFF
--- a/app/Http/Livewire/TopTorrents.php
+++ b/app/Http/Livewire/TopTorrents.php
@@ -87,21 +87,39 @@ class TopTorrents extends Component
                 END as meta
             ")
             ->withCount(['thanks', 'comments'])
-            ->when($this->tab === 'newest', fn ($query) => $query->orderByDesc('id'))
-            ->when($this->tab === 'seeded', fn ($query) => $query->orderByDesc('seeders'))
+            ->when(
+                $this->tab === 'newest',
+                fn ($query) => $query
+                    ->orderByDesc('id')
+            )
+            ->when(
+                $this->tab === 'seeded',
+                fn ($query) => $query
+                    ->orderByDesc('seeders')
+            )
             ->when(
                 $this->tab === 'dying',
                 fn ($query) => $query
-                    ->where('seeders', '=', 1)
+                    ->where('seeders', '>=', 1)
                     ->where('times_completed', '>=', 1)
-                    ->orderByDesc('leechers')
+                    ->orderBy('seeders', 'asc')
+                    ->orderBy('leechers', 'desc')
+                    ->orderBy('times_completed', 'desc')
             )
-            ->when($this->tab === 'leeched', fn ($query) => $query->orderByDesc('leechers'))
+            ->when(
+                $this->tab === 'leeched',
+                fn ($query) => $query
+                    ->orderBy('leechers', 'desc')
+                    ->orderBy('seeders', 'desc')
+                    ->orderBy('times_completed', 'desc')
+            )
             ->when(
                 $this->tab === 'dead',
                 fn ($query) => $query
                     ->where('seeders', '=', 0)
-                    ->orderByDesc('leechers')
+                    ->orderBy('leechers', 'desc')
+                    ->orderBy('times_completed','desc')
+                    ->orderBy('id','asc')
             )
             ->take(5)
             ->get();


### PR DESCRIPTION
This Update Improves the listings to be a little bit more intelligent about swarm health. with better subsorts and better handling of edge cases that more noticeable on smaller trackers.

1. expanded out the db queries for readability

2. dying section  
*using >=1 "and" sort order to handle edge cases better. 
*all things being equal subsort by snatched (most rescuable)

3. Leeched section. 
*if leech count is equal subsort seeders to promote healthier swarms

4. Dead section 
*if leech count is equal subsort by snatched, (most revivable) 
*if snatched is also equal then oldest gets a slight boost