### PR TITLE
Update torrent-search.blade.php

### DIFF
--- a/resources/views/livewire/torrent-search.blade.php
+++ b/resources/views/livewire/torrent-search.blade.php
@@ -76,30 +76,25 @@
                 </div>
                 <div class="form__group--short-horizontal">
                     <p class="form__group">
-                        <input
-                            id="startYear"
-                            wire:model.live="startYear"
-                            class="form__text"
-                            inputmode="numeric"
-                            pattern="[0-9]*"
-                            placeholder=" "
-                        />
-                        <label class="form__label form__label--floating" for="startYear">
-                            {{ __('torrent.start-year') }}
-                        </label>
+                        <label :class="{'label-float': selectedStartYear}" for="startYear">{{ __('torrent.start-year') }}</label>
+                        <select id="startYear" wire:model.live="startYear" class="form__select">
+                            <option value="">{{ __('') }}</option>
+                            @php
+                            $currentYear = date('Y');
+                            @endphp
+                            @for ($year = $currentYear; $year >= 1888; $year--)
+                            <option value="{{ $year }}">{{ $year }}</option>
+                            @endfor
+                        </select>
                     </p>
                     <p class="form__group">
-                        <input
-                            id="endYear"
-                            wire:model.live="endYear"
-                            class="form__text"
-                            inputmode="numeric"
-                            pattern="[0-9]*"
-                            placeholder=" "
-                        />
-                        <label class="form__label form__label--floating" for="endYear">
-                            {{ __('torrent.end-year') }}
-                        </label>
+                        <label :class="{'label-float': selectedendYear}" for="endYear">{{ __('torrent.end-year') }}</label>
+                        <select id="endYear" wire:model.live="endYear" class="form__select">
+                            <option value="">{{ __('') }}</option>
+                            @for ($year = $currentYear; $year >= 1888; $year--)
+                            <option value="{{ $year }}">{{ $year }}</option>
+                            @endfor
+                        </select>
                     </p>
                     <div class="form__group--short-horizontal">
                         <p class="form__group">


### PR DESCRIPTION
A Drop Down box seems to make more sense for the year. 1888 being the oldest film posible.

Further possible improvements:
1. You might be able remove any field validation code regarding the year.
2. the drop down list could be made sensitive to the other field so your startyear is not after your endyear. giving you a cropped list to choose from.