### PR TITLE
(Update) Add double upload and user group criteria to automatic torrent freeleeches

### DIFF
--- a/app/Http/Controllers/Staff/AutomaticTorrentFreeleechController.php
+++ b/app/Http/Controllers/Staff/AutomaticTorrentFreeleechController.php
@@ -18,6 +18,7 @@ use App\Http\Requests\Staff\StoreAutomaticTorrentFreeleechRequest;
 use App\Http\Requests\Staff\UpdateAutomaticTorrentFreeleechRequest;
 use App\Models\AutomaticTorrentFreeleech;
 use App\Models\Category;
+use App\Models\Group;
 use App\Models\Resolution;
 use App\Models\Type;
 
@@ -36,6 +37,7 @@ class AutomaticTorrentFreeleechController extends Controller
             'categories'  => Category::orderBy('position')->get(),
             'resolutions' => Resolution::orderBy('position')->get(),
             'types'       => Type::orderBy('position')->get(),
+            'groups'      => Group::orderBy('position')->get(),
         ]);
     }
 
@@ -54,6 +56,7 @@ class AutomaticTorrentFreeleechController extends Controller
             'categories'                => Category::orderBy('position')->get(),
             'resolutions'               => Resolution::orderBy('position')->get(),
             'types'                     => Type::orderBy('position')->get(),
+            'groups'                    => Group::orderBy('position')->get(),
         ]);
     }
 

--- a/app/Http/Requests/Staff/StoreAutomaticTorrentFreeleechRequest.php
+++ b/app/Http/Requests/Staff/StoreAutomaticTorrentFreeleechRequest.php
@@ -39,7 +39,9 @@ class StoreAutomaticTorrentFreeleechRequest extends FormRequest
             'category_id'          => ['nullable', 'integer', 'exists:categories,id'],
             'type_id'              => ['nullable', 'integer', 'exists:types,id'],
             'resolution_id'        => ['nullable', 'integer', 'exists:resolutions,id'],
+            'group_id'             => ['nullable', 'integer', 'exists:groups,id'],
             'freeleech_percentage' => ['required', 'integer', 'max:100', 'min:0'],
+            'is_double_upload'     => ['required', 'boolean'],
         ];
     }
 }

--- a/app/Http/Requests/Staff/UpdateAutomaticTorrentFreeleechRequest.php
+++ b/app/Http/Requests/Staff/UpdateAutomaticTorrentFreeleechRequest.php
@@ -39,7 +39,9 @@ class UpdateAutomaticTorrentFreeleechRequest extends FormRequest
             'category_id'          => ['nullable', 'integer', 'exists:categories,id'],
             'type_id'              => ['nullable', 'integer', 'exists:types,id'],
             'resolution_id'        => ['nullable', 'integer', 'exists:resolutions,id'],
+            'group_id'             => ['nullable', 'integer', 'exists:groups,id'],
             'freeleech_percentage' => ['required', 'integer', 'max:100', 'min:0'],
+            'is_double_upload'     => ['required', 'boolean'],
         ];
     }
 }

--- a/app/Models/AutomaticTorrentFreeleech.php
+++ b/app/Models/AutomaticTorrentFreeleech.php
@@ -51,4 +51,14 @@ class AutomaticTorrentFreeleech extends Model
     {
         return $this->belongsTo(Resolution::class);
     }
+
+    /**
+     * Belongs To A Group.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo<Group, self>
+     */
+    public function group(): \Illuminate\Database\Eloquent\Relations\BelongsTo
+    {
+        return $this->belongsTo(Group::class);
+    }
 }

--- a/database/migrations/2024_04_06_121239_add_group_and_doubleupload_to_autofreeleech.php
+++ b/database/migrations/2024_04_06_121239_add_group_and_doubleupload_to_autofreeleech.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * NOTICE OF LICENSE.
+ *
+ * UNIT3D Community Edition is open-sourced software licensed under the GNU Affero General Public License v3.0
+ * The details is bundled with this project in the file LICENSE.txt.
+ *
+ * @project    UNIT3D Community Edition
+ *
+ * @author     VinceJV <vincejv@proton.me>
+ * @license    https://www.gnu.org/licenses/agpl-3.0.en.html/ GNU Affero General Public License v3.0
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('automatic_torrent_freeleeches', function (Blueprint $table): void {
+            $table->unsignedInteger('group_id')->nullable()->after('resolution_id');
+            $table->boolean('is_double_upload')->default('0')->after('freeleech_percentage');
+        });
+    }
+};

--- a/resources/views/Staff/automatic-torrent-freeleech/create.blade.php
+++ b/resources/views/Staff/automatic-torrent-freeleech/create.blade.php
@@ -124,6 +124,22 @@
                     </label>
                 </p>
                 <p class="form__group">
+                    <select id="group_id" name="group_id" class="form__select">
+                        <option hidden disabled selected value="">Any</option>
+                        @foreach ($groups as $group)
+                            <option
+                                value="{{ $group->id }}"
+                                @selected(old('group_id') == $group->id)
+                            >
+                                {{ $group->name }}
+                            </option>
+                        @endforeach
+                    </select>
+                    <label class="form__label form__label--floating" for="group_id">
+                        {{ __('common.group') }}
+                    </label>
+                </p>
+                <p class="form__group">
                     <input
                         type="text"
                         name="freeleech_percentage"
@@ -136,6 +152,19 @@
                     />
                     <label class="form__label form__label--floating" for="freeleech_percentage">
                         Freeleech Percentage
+                    </label>
+                </p>
+                <p class="form__group">
+                    <input name="is_double_upload" type="hidden" value="0" />
+                    <input
+                        id="is_double_upload"
+                        class="form__checkbox"
+                        name="is_double_upload"
+                        type="checkbox"
+                        value="1"
+                    />
+                    <label class="form__label" for="is_double_upload">
+                        Double Upload
                     </label>
                 </p>
                 <p class="form__group">
@@ -153,7 +182,7 @@
         <h2 class="panel__heading">{{ __('common.info') }}</h2>
         <div class="panel__body">
             When a torrent is uploaded that meets the given criteria, the specified freeleech
-            percentage will be automatically applied.
+            percentage and double upload will be automatically applied.
         </div>
     </section>
 @endsection

--- a/resources/views/Staff/automatic-torrent-freeleech/edit.blade.php
+++ b/resources/views/Staff/automatic-torrent-freeleech/edit.blade.php
@@ -130,6 +130,22 @@
                     </label>
                 </p>
                 <p class="form__group">
+                    <select id="group_id" name="group_id" class="form__select">
+                        <option hidden disabled selected value="">Any</option>
+                        @foreach ($groups as $group)
+                            <option
+                                value="{{ $group->id }}"
+                                @selected($automaticTorrentFreeleech->group_id === $group->id)
+                            >
+                                {{ $group->name }}
+                            </option>
+                        @endforeach
+                    </select>
+                    <label class="form__label form__label--floating" for="group_id">
+                        {{ __('common.group') }}
+                    </label>
+                </p>
+                <p class="form__group">
                     <input
                         type="text"
                         name="freeleech_percentage"
@@ -142,6 +158,20 @@
                     />
                     <label class="form__label form__label--floating" for="freeleech_percentage">
                         Freeleech Percentage
+                    </label>
+                </p>
+                <p class="form__group">
+                    <input name="is_double_upload" type="hidden" value="0" />
+                    <input
+                        id="is_double_upload"
+                        class="form__checkbox"
+                        name="is_double_upload"
+                        type="checkbox"
+                        value="1"
+                        @checked($automaticTorrentFreeleech->is_double_upload)
+                    />
+                    <label class="form__label" for="is_double_upload">
+                        Double Upload
                     </label>
                 </p>
                 <p class="form__group">
@@ -159,7 +189,7 @@
         <h2 class="panel__heading">{{ __('common.info') }}</h2>
         <div class="panel__body">
             When a torrent is uploaded that meets the given criteria, the specified freeleech
-            percentage will be automatically applied.
+            percentage and double upload will be automatically applied.
         </div>
     </section>
 @endsection

--- a/resources/views/Staff/automatic-torrent-freeleech/index.blade.php
+++ b/resources/views/Staff/automatic-torrent-freeleech/index.blade.php
@@ -34,7 +34,9 @@
                         <th>{{ __('common.category') }}</th>
                         <th>{{ __('common.type') }}</th>
                         <th>{{ __('common.resolution') }}</th>
+                        <th>{{ __('common.group') }}</th>
                         <th>Freeleech Percentage</th>
+                        <th>Double Upload</th>
                         <th>{{ __('common.created_at') }}</th>
                         <th>{{ __('torrent.updated_at') }}</th>
                         <th>{{ __('common.actions') }}</th>
@@ -51,7 +53,19 @@
                             <td>{{ $automaticTorrentFreeleech->category?->name ?? 'Any' }}</td>
                             <td>{{ $automaticTorrentFreeleech->type?->name ?? 'Any' }}</td>
                             <td>{{ $automaticTorrentFreeleech->resolution?->name ?? 'Any' }}</td>
+                            <td>{{ $automaticTorrentFreeleech->group?->name ?? 'Any' }}</td>
                             <td>{{ $automaticTorrentFreeleech->freeleech_percentage }}</td>
+                            <td>
+                                @if ($automaticTorrentFreeleech->is_double_upload)
+                                    <i
+                                        class="{{ config('other.font-awesome') }} fa-check text-green"
+                                    ></i>
+                                @else
+                                    <i
+                                        class="{{ config('other.font-awesome') }} fa-times text-red"
+                                    ></i>
+                                @endif
+                            </td>
                             <td>
                                 <time
                                     datetime="{{ $automaticTorrentFreeleech->created_at }}"
@@ -114,7 +128,7 @@
         <h2 class="panel__heading">{{ __('common.info') }}</h2>
         <div class="panel__body">
             When a torrent is uploaded that meets the given criteria, the specified freeleech
-            percentage will be automatically applied.
+            percentage and double upload will be automatically applied.
         </div>
     </section>
 @endsection


### PR DESCRIPTION
Add double upload auto tagging and user group criteria to automatic freeleech feature

- Double Upload auto tagging
- By user group criteria

Original PR: https://github.com/HDInnovations/UNIT3D-Community-Edition/pull/3727

Recreated due to
> Create feature branches - Don't ask us to pull from your master branch.
