### PR TITLE
(Refactor) Change input type for better 2FA inference

### DIFF
--- a/resources/views/auth/two-factor-challenge.blade.php
+++ b/resources/views/auth/two-factor-challenge.blade.php
@@ -81,7 +81,7 @@
                             inputmode="numeric"
                             name="code"
                             x-bind:required="!recovery"
-                            type="text"
+                            type="tel"
                             value="{{ old('code') }}"
                             x-ref="code"
                         />
@@ -96,7 +96,7 @@
                             autocomplete="one-time-code"
                             name="recovery_code"
                             x-bind:required="recovery"
-                            type="text"
+                            type="tel"
                             x-ref="recovery_code"
                         />
                     </p>


### PR DESCRIPTION
This simple change improves passwd manager detection for 2FA fields, ensuring auto clipboard copying or user prompt popups. It also improves mobile usage by calling the numeric keypad for the tel-set 2FA input field, rather than a full keyboard.
Tested on ProtonPass; with input type set to `text`, no clipboard copying or popup occurs, requiring manual copy-pasting. But with type `tel`, 2FA autofill features are fully activated.