### PR TITLE
(Fix) Primary language metadata class

### DIFF
--- a/resources/views/torrent/partials/movie_meta.blade.php
+++ b/resources/views/torrent/partials/movie_meta.blade.php
@@ -250,7 +250,7 @@
                 </article>
             @endif
 
-            <article class="meta__runtime">
+            <article class="meta__language">
                 <a class="meta-chip" href="#">
                     <i class="{{ config('other.font-awesome') }} fa-language meta-chip__icon"></i>
                     <h2 class="meta-chip__name">Primary Language</h2>

--- a/resources/views/torrent/partials/tv_meta.blade.php
+++ b/resources/views/torrent/partials/tv_meta.blade.php
@@ -247,7 +247,7 @@
                 </article>
             @endif
 
-            <article class="meta__runtime">
+            <article class="meta__language">
                 <a class="meta-chip" href="#">
                     <i class="{{ config('other.font-awesome') }} fa-language meta-chip__icon"></i>
                     <h2 class="meta-chip__name">Primary Language</h2>


### PR DESCRIPTION
Primary language meta class changed from "runtime" to "language"