### PR TITLE
(Fix) Connectivity check on external tracker

### DIFF
--- a/app/Http/Controllers/TorrentPeerController.php
+++ b/app/Http/Controllers/TorrentPeerController.php
@@ -30,7 +30,7 @@ class TorrentPeerController extends Controller
             'torrent' => $torrent,
             'peers'   => Peer::query()
                 ->with('user')
-                ->select(['torrent_id', 'user_id', 'uploaded', 'downloaded', 'left', 'port', 'agent', 'created_at', 'updated_at', 'seeder', 'active', 'visible'])
+                ->select(['torrent_id', 'user_id', 'uploaded', 'downloaded', 'left', 'port', 'agent', 'created_at', 'updated_at', 'seeder', 'active', 'visible', 'connectable'])
                 ->selectRaw('INET6_NTOA(ip) as ip')
                 ->where('torrent_id', '=', $id)
                 ->orderByDesc('active')

--- a/app/Http/Controllers/User/UserController.php
+++ b/app/Http/Controllers/User/UserController.php
@@ -90,7 +90,7 @@ class UserController extends Controller
             'invitedBy' => Invite::where('accepted_by', '=', $user->id)->first(),
             'clients'   => $user->peers()
                 ->select('agent', 'port')
-                ->selectRaw('INET6_NTOA(ip) as ip, MIN(created_at) as created_at, MAX(updated_at) as updated_at, COUNT(*) as num_peers')
+                ->selectRaw('INET6_NTOA(ip) as ip, MIN(created_at) as created_at, MAX(updated_at) as updated_at, COUNT(*) as num_peers, MAX(connectable) as connectable')
                 ->groupBy(['ip', 'port', 'agent'])
                 ->where('active', '=', true)
                 ->get(),

--- a/resources/views/livewire/user-active.blade.php
+++ b/resources/views/livewire/user-active.blade.php
@@ -294,7 +294,9 @@
                                 <td class="user-active__connectable">
                                     @php
                                         $connectable = null;
-                                        if (cache()->has('peers:connectable:' . $active->ip . '-' . $active->port . '-' . $active->agent)) {
+                                        if (config('announce.external_tracker.is_enabled')) {
+                                            $connectable = $active->connectable;
+                                        } elseif (cache()->has('peers:connectable:' . $active->ip . '-' . $active->port . '-' . $active->agent)) {
                                             $connectable = cache()->get('peers:connectable:' . $active->ip . '-' . $active->port . '-' . $active->agent);
                                         }
                                     @endphp

--- a/resources/views/torrent/peers.blade.php
+++ b/resources/views/torrent/peers.blade.php
@@ -106,7 +106,9 @@
                             @if (\config('announce.connectable_check') == true)
                                 @php
                                     $connectable = false;
-                                    if (cache()->has('peers:connectable:' . $peer->ip . '-' . $peer->port . '-' . $peer->agent)) {
+                                    if (config('announce.external_tracker.is_enabled')) {
+                                        $connectable = $peer->connectable;
+                                    } elseif (cache()->has('peers:connectable:' . $peer->ip . '-' . $peer->port . '-' . $peer->agent)) {
                                         $connectable = cache()->get('peers:connectable:' . $peer->ip . '-' . $peer->port . '-' . $peer->agent);
                                     }
                                 @endphp

--- a/resources/views/user/profile/show.blade.php
+++ b/resources/views/user/profile/show.blade.php
@@ -303,7 +303,9 @@
                                     @if (\config('announce.connectable_check') == true)
                                         @php
                                             $connectable = false;
-                                            if (cache()->has('peers:connectable:' . $client->ip . '-' . $client->port . '-' . $client->agent)) {
+                                            if (config('announce.external_tracker.is_enabled')) {
+                                                $connectable = $client->connectable;
+                                            } elseif (cache()->has('peers:connectable:' . $client->ip . '-' . $client->port . '-' . $client->agent)) {
                                                 $connectable = cache()->get('peers:connectable:' . $client->ip . '-' . $client->port . '-' . $client->agent);
                                             }
                                         @endphp


### PR DESCRIPTION
The external tracker updates the peer row and doesn't touch the redis cache.