### PR TITLE
(Update) Rate limit IP's

### DIFF
--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -142,15 +142,15 @@ class FortifyServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        RateLimiter::for('login', fn (Request $request) => Limit::perMinute(5)->by('fortify-login'.$request->ip()));
-        RateLimiter::for('fortify-login-get', fn (Request $request) => Limit::perMinute(5)->by('fortify-login'.$request->ip()));
-        RateLimiter::for('fortify-register-get', fn (Request $request) => Limit::perMinute(5)->by('fortify-register'.$request->ip()));
-        RateLimiter::for('fortify-register-post', fn (Request $request) => Limit::perMinute(5)->by('fortify-register'.$request->ip()));
-        RateLimiter::for('fortify-forgot-password-get', fn (Request $request) => Limit::perMinute(5)->by('fortify-forgot-password'.$request->ip()));
-        RateLimiter::for('fortify-forgot-password-post', fn (Request $request) => Limit::perMinute(5)->by('fortify-forgot-password'.$request->ip()));
-        RateLimiter::for('fortify-reset-password-get', fn (Request $request) => Limit::perMinute(5)->by('fortify-reset-password'.$request->ip()));
-        RateLimiter::for('fortify-reset-password-post', fn (Request $request) => Limit::perMinute(5)->by('fortify-reset-password'.$request->ip()));
-        RateLimiter::for('two-factor', fn (Request $request) => Limit::perMinute(5)->by('fortify-two-factor'.$request->session()->get('login.id')));
+        RateLimiter::for('login', fn (Request $request) => Limit::perMinute(1)->by('fortify-login'.$request->ip()));
+        RateLimiter::for('fortify-login-get', fn (Request $request) => Limit::perMinute(1)->by('fortify-login'.$request->ip()));
+        RateLimiter::for('fortify-register-get', fn (Request $request) => Limit::perMinute(1)->by('fortify-register'.$request->ip()));
+        RateLimiter::for('fortify-register-post', fn (Request $request) => Limit::perMinute(1)->by('fortify-register'.$request->ip()));
+        RateLimiter::for('fortify-forgot-password-get', fn (Request $request) => Limit::perMinute(1)->by('fortify-forgot-password'.$request->ip()));
+        RateLimiter::for('fortify-forgot-password-post', fn (Request $request) => Limit::perMinute(1)->by('fortify-forgot-password'.$request->ip()));
+        RateLimiter::for('fortify-reset-password-get', fn (Request $request) => Limit::perMinute(1)->by('fortify-reset-password'.$request->ip()));
+        RateLimiter::for('fortify-reset-password-post', fn (Request $request) => Limit::perMinute(1)->by('fortify-reset-password'.$request->ip()));
+        RateLimiter::for('two-factor', fn (Request $request) => Limit::perMinute(1)->by('fortify-two-factor'.$request->session()->get('login.id')));
 
         Fortify::loginView(fn () => view('auth.login'));
         Fortify::requestPasswordResetLinkView(fn () => view('auth.passwords.email'));


### PR DESCRIPTION
Limit to 1 per minute.

Slowing down legitimate users seems appropriate also, as they may take their time instead of spamming the wrong values. Ideally the rate limiting would further reduce the limits per minute with continued failed attempts.