### PR TITLE
(Update) Chunk users in autogroup command

### DIFF
--- a/app/Console/Commands/AutoGroup.php
+++ b/app/Console/Commands/AutoGroup.php
@@ -19,8 +19,6 @@ use App\Models\User;
 use App\Services\Unit3dAnnounce;
 use Exception;
 use Illuminate\Console\Command;
-use Illuminate\Support\Carbon;
-use Illuminate\Support\Facades\DB;
 use Throwable;
 
 class AutoGroup extends Command
@@ -47,65 +45,59 @@ class AutoGroup extends Command
     final public function handle(): void
     {
         $now = now();
-        $current = Carbon::now();
+        $timestamp = $now->timestamp;
 
         $groups = Group::query()
             ->where('autogroup', '=', 1)
-            ->orderBy('position')
+            ->orderByDesc('position')
             ->get();
 
-        $users = User::query()
+        User::query()
+            ->withSum('seedingTorrents as seedsize', 'size')
+            ->withCount('torrents as uploads')
+            ->withAvg('history as avg_seedtime', 'seedtime')
             ->whereIntegerInRaw('group_id', $groups->pluck('id'))
-            ->get();
+            ->chunkById(100, function ($users) use ($groups, $timestamp): void {
+                foreach ($users as $user) {
+                    foreach ($groups as $group) {
+                        if (
+                            ($group->min_uploaded === null || $user->uploaded >= $group->min_uploaded)
+                            && ($group->min_ratio === null || $user->ratio >= $group->min_ratio)
+                            && ($group->min_age === null || $timestamp - $user->created_at->timestamp >= $group->min_age)
+                            && ($group->min_avg_seedtime === null || $user->avg_seedtime >= $group->min_avg_seedtime)
+                            && ($group->min_seedsize === null || $user->seedsize >= $group->min_seedsize)
+                            && ($group->min_uploads === null || $user->uploads >= $group->min_uploads)
+                        ) {
+                            $user->group_id = $group->id;
 
-        foreach ($users as $user) {
-            // memoize when necessary
-            $seedtime = null;
-            $seedsize = null;
-            $uploads = null;
+                            // Leech ratio dropped below sites minimum
+                            if ($user->group_id === UserGroup::LEECH->value) {
+                                // Keep these as 0/1 instead of false/true
+                                // because it reduces 6% custom casting overhead
+                                $user->can_request = 0;
+                                $user->can_invite = 0;
+                                $user->can_download = 0;
+                            } else {
+                                $user->can_request = 1;
+                                $user->can_invite = 1;
+                                $user->can_download = 1;
+                            }
 
-            foreach ($groups as $group) {
-                $seedtime ??= DB::table('history')
-                    ->where('user_id', '=', $user->id)
-                    ->avg('seedtime') ?? 0;
+                            $user->save();
 
-                $seedsize ??= $user->seedingTorrents()->sum('size');
+                            if ($user->wasChanged()) {
+                                cache()->forget('user:'.$user->passkey);
 
-                $uploads ??= $user->torrents()->count();
+                                Unit3dAnnounce::addUser($user);
+                            }
 
-                if (
-                    //short circuit when the values are 0 or null
-                    (!$group->min_uploaded || $group->min_uploaded <= $user->uploaded)
-                    && (!$group->min_ratio || $group->min_ratio <= $user->ratio)
-                    && (!$group->min_age || $user->created_at->addSeconds($group->min_age)->isBefore($current))
-                    && (!$group->min_avg_seedtime || $group->min_avg_seedtime <= ($seedtime))
-                    && (!$group->min_seedsize || $group->min_seedsize <= ($seedsize))
-                    && (!$group->min_uploads || $group->min_uploads <= ($uploads))
-                ) {
-                    $user->group_id = $group->id;
-
-                    // Leech ratio dropped below sites minimum
-                    if ($user->group_id === UserGroup::LEECH->value) {
-                        $user->can_request = false;
-                        $user->can_invite = false;
-                        $user->can_download = false;
-                    } else {
-                        $user->can_request = true;
-                        $user->can_invite = true;
-                        $user->can_download = true;
-                    }
-                    $user->save();
-
-                    if ($user->wasChanged()) {
-                        cache()->forget('user:'.$user->passkey);
-
-                        Unit3dAnnounce::addUser($user);
+                            break;
+                        }
                     }
                 }
-            }
-        }
+            });
 
-        $elapsed = now()->diffInSeconds($now);
-        $this->comment('Automated User Group Command Complete ('.$elapsed.')');
+        $elapsed = $now->diffInSeconds(now());
+        $this->comment('Automated User Group Command Complete ('.$elapsed.' s)');
     }
 }


### PR DESCRIPTION
| Change                 | Before | After |
|------------------------|--------|-------|
| Individual to chunking | 355 s  | 56 s  |
| Permission bool to int | 56 s   | 53 s  |
| Timestamp comparison   | 53 s   | 49 s  |

With an empty loop, it takes 33 seconds, the remaining 99% of time is used by the `save()` method (even if values are same as before and no queries are done).