### PR TITLE
(Fix) Groups stats advance calculations for date values

### DIFF
--- a/resources/views/stats/groups/groups-requirements.blade.php
+++ b/resources/views/stats/groups/groups-requirements.blade.php
@@ -116,7 +116,7 @@
                                                             class="{{ config('other.font-awesome') }} fa-x text-red"
                                                         ></i>
                                                         |
-                                                        {{ \App\Helpers\StringHelper::timeElapsed($group->min_age - $user_account_age) }}
+                                                        {{ \App\Helpers\StringHelper::timeElapsed($group->min_age + $user_account_age) }}
                                                     @endif
                                                 </td>
                                             </tr>
@@ -154,7 +154,7 @@
                                                             class="{{ config('other.font-awesome') }} fa-x text-red"
                                                         ></i>
                                                         |
-                                                        {{ \App\Helpers\StringHelper::formatBytes($group->min_seedsize - $user_seed_size) }}
+                                                        {{ \App\Helpers\StringHelper::formatBytes($group->min_seedsize + $user_seed_size) }}
                                                     @endif
                                                 </td>
                                             </tr>


### PR DESCRIPTION
This should fix the "to advance" values being more than the actual requirement.

Account created at is 29 days ago, now shows the correct  ~24h to advance:
![SCR-20240502-ledz](https://github.com/HDInnovations/UNIT3D-Community-Edition/assets/73784120/29e16477-5641-490c-bd22-0329b607681d)

