### PR TITLE
(Fix) Prevent duplicated notifications

### DIFF
--- a/app/Console/Commands/AutoWarning.php
+++ b/app/Console/Commands/AutoWarning.php
@@ -93,11 +93,11 @@ class AutoWarning extends Command
                         $usersWithWarnings[$hr->user->id] = $hr->user;
                     }
                 }
+            }
 
-                // Send a single notification for each user with warnings
-                foreach ($usersWithWarnings as $user) {
-                    $user->notify(new UserWarning($user));
-                }
+            // Send a single notification for each user with warnings
+            foreach ($usersWithWarnings as $user) {
+                $user->notify(new UserWarning($user));
             }
 
             // Calculate User Warning Count and Disable DL Priv If Required.


### PR DESCRIPTION
The notifications should be sent only once, therefor they do not need to be within the first loop.
Tested with [mailpit](vendor/spatie/laravel-backup/src/Commands/MonitorCommand.php) and looks promising. Would be good to have someone else run this to verify.