### PR TITLE
(Fix) Meta Data Links

### DIFF
--- a/resources/views/torrent/partials/movie_meta.blade.php
+++ b/resources/views/torrent/partials/movie_meta.blade.php
@@ -146,6 +146,7 @@
                     href="https://html.duckduckgo.com/html/?q=\{{ $meta->title ?? '' }}  ({{ substr($meta->release_date ?? '', 0, 4) ?? '' }})+site%3Arottentomatoes.com"
                     title="Rotten Tomatoes: {{ $meta->title ?? '' }}  ({{ substr($meta->release_date ?? '', 0, 4) ?? '' }})"
                     target="_blank"
+                    rel="noreferrer"
                 >
                     <i
                         class="fad fa-tomato"

--- a/resources/views/torrent/partials/tv_meta.blade.php
+++ b/resources/views/torrent/partials/tv_meta.blade.php
@@ -145,6 +145,7 @@
                     href="https://html.duckduckgo.com/html/?q=\{{ $meta->name ?? '' }}  ({{ substr($meta->first_air_date ?? '', 0, 4) ?? '' }})+site%3Arottentomatoes.com"
                     title="Rotten Tomatoes: {{ $meta->name ?? '' }}  ({{ substr($meta->first_air_date ?? '', 0, 4) ?? '' }})"
                     target="_blank"
+                    rel="noreferrer"
                 >
                     <i
                         class="fad fa-tomato"


### PR DESCRIPTION
It looks like I had an oversight in #3791. The HTML version of DDG does not forward requests when a referrer is set. Thus, when simply pasting a link into the browser, it would work, but when clicking on the link from a page, it would show a normal search result. I added the attribute `rel="noreferrer"`, and actually tested it on a deployed frontend, and now it works as expected.