### PR TITLE
(Fix) Connectable status on user actives page

### DIFF
--- a/app/Http/Livewire/UserActive.php
+++ b/app/Http/Livewire/UserActive.php
@@ -98,6 +98,7 @@ class UserActive extends Component
                 'peers.user_id',
                 'peers.active',
                 'peers.visible',
+                'peers.connectable',
                 'torrents.name',
                 'torrents.size',
                 'torrents.seeders',


### PR DESCRIPTION
The column needs to be selected when using the external tracker.