### PR TITLE
(Add) Validate max textarea length

### DIFF
--- a/app/Http/Requests/StoreTorrentRequest.php
+++ b/app/Http/Requests/StoreTorrentRequest.php
@@ -115,7 +115,7 @@ class StoreTorrentRequest extends FormRequest
             'bdinfo' => [
                 'nullable',
                 'sometimes',
-                'max:4294967295',
+                'max:2097152',
             ],
             'category_id' => [
                 'required',

--- a/app/Http/Requests/StoreTorrentRequest.php
+++ b/app/Http/Requests/StoreTorrentRequest.php
@@ -105,17 +105,17 @@ class StoreTorrentRequest extends FormRequest
             ],
             'description' => [
                 'required',
-                'max:2097152'
+                'max:65535'
             ],
             'mediainfo' => [
                 'nullable',
                 'sometimes',
-                'max:2097152',
+                'max:65535',
             ],
             'bdinfo' => [
                 'nullable',
                 'sometimes',
-                'max:2097152',
+                'max:4294967295',
             ],
             'category_id' => [
                 'required',


### PR DESCRIPTION
`Torrent.store` does not validate the length of `description` and `media info`even though they both have a DB limit of 65535 chars (type `text`).

This adds a max length of 65535 characters to the mentioned textareas. It prevents the error 500 when exceeding the DB character limit.

Other views using the same live wire `bbcode-input` (e.g. /users/USER/edit) are not affected and do not have character limit applied.
