### PR TITLE
(Fix) Autocommit on pull requests from forks

### DIFF
--- a/.github/workflows/larastan.yml
+++ b/.github/workflows/larastan.yml
@@ -1,5 +1,5 @@
 name: PHP Static Analysis (Larastan)
-on: [push, pull_request]
+on: [pull_request, push]
 jobs:
   test:
     strategy:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,5 @@
 name: PHP Lint (Pint)
-on: [push, pull_request]
+on: [pull_request, push]
 jobs:
   phplint:
     strategy:

--- a/.github/workflows/phpunit-test.yml
+++ b/.github/workflows/phpunit-test.yml
@@ -1,5 +1,5 @@
 name: PHPUnit Test (Pest)
-on: [push, pull_request]
+on: [pull_request, push]
 jobs:
   tests:
     strategy:

--- a/.github/workflows/prettier-blade.yml
+++ b/.github/workflows/prettier-blade.yml
@@ -1,5 +1,5 @@
 name: Format Blade Files
-on: [push, pull_request]
+on: [pull_request, push]
 jobs:
   format-blade-files:
     strategy:


### PR DESCRIPTION
The pull_request event runs in the context of the PR's repo, while the push event runs in the context of the current repo. So, we need to order the events so that if a user submits a PR from their fork, that we run in the context of the fork instead of the current repo (which would result in the branch not being found).