### PR TITLE
(Fix) Img alt tags

### DIFF
--- a/resources/views/Staff/category/index.blade.php
+++ b/resources/views/Staff/category/index.blade.php
@@ -57,10 +57,7 @@
                             </td>
                             <td>
                                 @if ($category->image != null)
-                                    <img
-                                        alt="{{ $category->name }}"
-                                        src="{{ url('files/img/' . $category->image) }}"
-                                    />
+                                    <img alt="" src="{{ url('files/img/' . $category->image) }}" />
                                 @else
                                     <span>N/A</span>
                                 @endif

--- a/resources/views/blocks/top_users.blade.php
+++ b/resources/views/blocks/top_users.blade.php
@@ -108,13 +108,13 @@
                     @if ($uploader->user->private_profile)
                         <img
                             class="user-stat-card__avatar"
-                            alt="avatar"
+                            alt=""
                             src="{{ url('img/profile.png') }}"
                         />
                     @else
                         <img
                             class="user-stat-card__avatar"
-                            alt="avatar"
+                            alt=""
                             src="{{ url($uploader->user->image === null ? 'img/profile.png' : 'files/img/' . $uploader->user->image) }}"
                         />
                     @endif
@@ -138,13 +138,13 @@
                     @if ($downloader->user->private_profile)
                         <img
                             class="user-stat-card__avatar"
-                            alt="avatar"
+                            alt=""
                             src="{{ url('img/profile.png') }}"
                         />
                     @else
                         <img
                             class="user-stat-card__avatar"
-                            alt="avatar"
+                            alt=""
                             src="{{ url($downloader->user->image === null ? 'img/profile.png' : 'files/img/' . $downloader->user->image) }}"
                         />
                     @endif
@@ -167,13 +167,13 @@
                     @if ($upload->private_profile)
                         <img
                             class="user-stat-card__avatar"
-                            alt="avatar"
+                            alt=""
                             src="{{ url('img/profile.png') }}"
                         />
                     @else
                         <img
                             class="user-stat-card__avatar"
-                            alt="avatar"
+                            alt=""
                             src="{{ url($upload->image === null ? 'img/profile.png' : 'files/img/' . $upload->image) }}"
                         />
                     @endif
@@ -197,13 +197,13 @@
                     @if ($download->private_profile)
                         <img
                             class="user-stat-card__avatar"
-                            alt="avatar"
+                            alt=""
                             src="{{ url('img/profile.png') }}"
                         />
                     @else
                         <img
                             class="user-stat-card__avatar"
-                            alt="avatar"
+                            alt=""
                             src="{{ url($download->image === null ? 'img/profile.png' : 'files/img/' . $download->image) }}"
                         />
                     @endif
@@ -227,13 +227,13 @@
                     @if ($seeder->user->private_profile)
                         <img
                             class="user-stat-card__avatar"
-                            alt="avatar"
+                            alt=""
                             src="{{ url('img/profile.png') }}"
                         />
                     @else
                         <img
                             class="user-stat-card__avatar"
-                            alt="avatar"
+                            alt=""
                             src="{{ url($seeder->user->image === null ? 'img/profile.png' : 'files/img/' . $seeder->user->image) }}"
                         />
                     @endif
@@ -257,13 +257,13 @@
                     @if ($seedtime->private_profile)
                         <img
                             class="user-stat-card__avatar"
-                            alt="avatar"
+                            alt=""
                             src="{{ url('img/profile.png') }}"
                         />
                     @else
                         <img
                             class="user-stat-card__avatar"
-                            alt="avatar"
+                            alt=""
                             src="{{ url($seedtime->image === null ? 'img/profile.png' : 'files/img/' . $seedtime->image) }}"
                         />
                     @endif
@@ -286,13 +286,13 @@
                     @if ($serve->private_profile)
                         <img
                             class="user-stat-card__avatar"
-                            alt="avatar"
+                            alt=""
                             src="{{ url('img/profile.png') }}"
                         />
                     @else
                         <img
                             class="user-stat-card__avatar"
-                            alt="avatar"
+                            alt=""
                             src="{{ url($serve->image === null ? 'img/profile.png' : 'files/img/' . $serve->image) }}"
                         />
                     @endif
@@ -316,13 +316,13 @@
                     @if ($commenter->user->private_profile)
                         <img
                             class="user-stat-card__avatar"
-                            alt="avatar"
+                            alt=""
                             src="{{ url('img/profile.png') }}"
                         />
                     @else
                         <img
                             class="user-stat-card__avatar"
-                            alt="avatar"
+                            alt=""
                             src="{{ url($commenter->user->image === null ? 'img/profile.png' : 'files/img/' . $commenter->user->image) }}"
                         />
                     @endif
@@ -346,13 +346,13 @@
                     @if ($poster->user->private_profile)
                         <img
                             class="user-stat-card__avatar"
-                            alt="avatar"
+                            alt=""
                             src="{{ url('img/profile.png') }}"
                         />
                     @else
                         <img
                             class="user-stat-card__avatar"
-                            alt="avatar"
+                            alt=""
                             src="{{ url($poster->user->image === null ? 'img/profile.png' : 'files/img/' . $poster->user->image) }}"
                         />
                     @endif
@@ -376,13 +376,13 @@
                     @if ($thanker->user->private_profile)
                         <img
                             class="user-stat-card__avatar"
-                            alt="avatar"
+                            alt=""
                             src="{{ url('img/profile.png') }}"
                         />
                     @else
                         <img
                             class="user-stat-card__avatar"
-                            alt="avatar"
+                            alt=""
                             src="{{ url($thanker->user->image === null ? 'img/profile.png' : 'files/img/' . $thanker->user->image) }}"
                         />
                     @endif
@@ -406,13 +406,13 @@
                     @if ($personal->user->private_profile)
                         <img
                             class="user-stat-card__avatar"
-                            alt="avatar"
+                            alt=""
                             src="{{ url('img/profile.png') }}"
                         />
                     @else
                         <img
                             class="user-stat-card__avatar"
-                            alt="avatar"
+                            alt=""
                             src="{{ url($personal->user->image === null ? 'img/profile.png' : 'files/img/' . $personal->user->image) }}"
                         />
                     @endif

--- a/resources/views/components/movie/card.blade.php
+++ b/resources/views/components/movie/card.blade.php
@@ -12,7 +12,7 @@
             >
                 <img
                     src="{{ isset($media->poster) ? tmdb_image('poster_small', $media->poster) : 'https://via.placeholder.com/90x135' }}"
-                    alt="{{ __('torrent.poster') }}"
+                    alt="{{ __('torrent.similar') }}"
                     loading="lazy"
                 />
             </a>

--- a/resources/views/components/movie/poster.blade.php
+++ b/resources/views/components/movie/poster.blade.php
@@ -12,7 +12,7 @@
         >
             <img
                 src="{{ isset($movie->poster) ? tmdb_image('poster_mid', $movie->poster) : 'https://via.placeholder.com/90x135' }}"
-                alt="{{ __('torrent.poster') }}"
+                alt="{{ __('torrent.similar') }}"
                 loading="lazy"
             />
         </a>

--- a/resources/views/components/torrent/card.blade.php
+++ b/resources/views/components/torrent/card.blade.php
@@ -63,7 +63,7 @@
                             @break
                     @endswitch
 
-                    alt="{{ __('torrent.poster') }}"
+                    alt="{{ __('torrent.similar') }}"
                 />
             </figure>
         </a>

--- a/resources/views/components/torrent/row.blade.php
+++ b/resources/views/components/torrent/row.blade.php
@@ -30,7 +30,7 @@
                         src="{{ isset($meta->poster) ? tmdb_image('poster_small', $meta->poster) : 'https://via.placeholder.com/90x135' }}"
                         class="torrent-search--list__poster-img"
                         loading="lazy"
-                        alt="{{ __('torrent.poster') }}"
+                        alt="{{ __('torrent.similar') }}"
                     />
                 @endif
 
@@ -40,7 +40,7 @@
                         src="{{ isset($meta->cover) ? 'https://images.igdb.com/igdb/image/upload/t_cover_small_2x/' . $meta->cover['image_id'] . '.png' : 'https://via.placeholder.com/90x135' }}"
                         class="torrent-search--list__poster-img"
                         loading="lazy"
-                        alt="{{ __('torrent.poster') }}"
+                        alt="{{ __('torrent.similar') }}"
                     />
                 @endif
 
@@ -49,7 +49,7 @@
                         src="https://via.placeholder.com/90x135"
                         class="torrent-search--list__poster-img"
                         loading="lazy"
-                        alt="{{ __('torrent.poster') }}"
+                        alt="{{ __('torrent.similar') }}"
                     />
                 @endif
 
@@ -59,14 +59,14 @@
                             src="{{ url('files/img/torrent-cover_' . $torrent->id . '.jpg') }}"
                             class="torrent-search--list__poster-img"
                             loading="lazy"
-                            alt="{{ __('torrent.poster') }}"
+                            alt="{{ __('torrent.similar') }}"
                         />
                     @else
                         <img
                             src="https://via.placeholder.com/400x600"
                             class="torrent-search--list__poster-img"
                             loading="lazy"
-                            alt="{{ __('torrent.poster') }}"
+                            alt="{{ __('torrent.similar') }}"
                         />
                     @endif
                 @endif

--- a/resources/views/components/tv/card.blade.php
+++ b/resources/views/components/tv/card.blade.php
@@ -12,7 +12,7 @@
             >
                 <img
                     src="{{ isset($media->poster) ? tmdb_image('poster_small', $media->poster) : 'https://via.placeholder.com/90x135' }}"
-                    alt="{{ __('torrent.poster') }}"
+                    alt="{{ __('torrent.similar') }}"
                     loading="lazy"
                 />
             </a>

--- a/resources/views/components/tv/poster.blade.php
+++ b/resources/views/components/tv/poster.blade.php
@@ -12,7 +12,7 @@
         >
             <img
                 src="{{ isset($tv->poster) ? tmdb_image('poster_mid', $tv->poster) : 'https://via.placeholder.com/90x135' }}"
-                alt="{{ __('torrent.poster') }}"
+                alt="{{ __('torrent.similar') }}"
                 loading="lazy"
             />
         </a>

--- a/resources/views/livewire/company-search.blade.php
+++ b/resources/views/livewire/company-search.blade.php
@@ -32,7 +32,7 @@
                                 <img
                                     class="mediahub-card__image"
                                     src="{{ tmdb_image('logo_mid', $company->logo) }}"
-                                    alt="Logo"
+                                    alt="{{ $company->name }}"
                                 />
                             @else
                                 {{ $company->name }}

--- a/resources/views/livewire/user-search.blade.php
+++ b/resources/views/livewire/user-search.blade.php
@@ -177,7 +177,7 @@
                                 <td>
                                     <img
                                         src="{{ url($user->image === null ? 'img/profile.png' : 'files/img/' . $user->image) }}"
-                                        alt="{{ $user->username }}"
+                                        alt=""
                                         class="user-search__avatar"
                                     />
                                 </td>

--- a/resources/views/mediahub/collection/show.blade.php
+++ b/resources/views/mediahub/collection/show.blade.php
@@ -30,7 +30,7 @@
             <img
                 class="meta__backdrop"
                 src="{{ tmdb_image('back_big', $collection->backdrop) }}"
-                alt="Backdrop"
+                alt=""
             />
         @endif
 

--- a/resources/views/mediahub/person/show.blade.php
+++ b/resources/views/mediahub/person/show.blade.php
@@ -25,7 +25,7 @@
         <h2 class="panel__heading">{{ $person->name }}</h2>
         <img
             src="{{ isset($person->still) ? tmdb_image('cast_big', $person->still) : 'https://via.placeholder.com/300x450' }}"
-            alt="{{ $person->name }}"
+            alt=""
             style="max-width: 100%"
         />
         <dl class="key-value">

--- a/resources/views/mediahub/tv/season/show.blade.php
+++ b/resources/views/mediahub/tv/season/show.blade.php
@@ -77,7 +77,7 @@
         <h2 class="panel__heading">{{ $season->name }} ({{ $season->air_date }})</h2>
         <img
             src="{{ isset($season->poster) ? tmdb_image('cast_big', $season->poster) : 'https://via.placeholder.com/300x450' }}"
-            alt="{{ $show->name }}"
+            alt=""
         />
         <div class="panel__body">
             {{ $season->overview }}

--- a/resources/views/mediahub/tv/show.blade.php
+++ b/resources/views/mediahub/tv/show.blade.php
@@ -128,7 +128,7 @@
         <h2 class="panel__heading">{{ $show->name }}</h2>
         <img
             src="{{ isset($show->poster) ? tmdb_image('cast_big', $show->poster) : 'https://via.placeholder.com/300x450' }}"
-            alt="{{ $show->name }}"
+            alt=""
         />
         <dl class="key-value">
             <dt>Seasons</dt>

--- a/resources/views/partials/top_nav.blade.php
+++ b/resources/views/partials/top_nav.blade.php
@@ -425,14 +425,14 @@
                 >
                     <img
                         src="{{ url(auth()->user()->image ? 'files/img/' . auth()->user()->image : 'img/profile.png') }}"
-                        alt="{{ auth()->user()->username }}"
+                        alt="{{ __('user.my-profile') }}"
                         class="top-nav__profile-image"
                     />
                 </a>
                 <a class="top-nav__dropdown--touch" tabindex="0">
                     <img
                         src="{{ url(auth()->user()->image ? 'files/img/' . auth()->user()->image : 'img/profile.png') }}"
-                        alt="{{ auth()->user()->username }}"
+                        alt="{{ __('user.my-profile') }}"
                         class="top-nav__profile-image"
                     />
                 </a>

--- a/resources/views/playlist/index.blade.php
+++ b/resources/views/playlist/index.blade.php
@@ -30,7 +30,7 @@
                             <img
                                 class="playlists__playlist-image"
                                 src="{{ url('files/img/' . $playlist->cover_image) }}"
-                                alt="Cover Image"
+                                alt=""
                             />
                         </a>
                     @else

--- a/resources/views/stats/yearly_overviews/show.blade.php
+++ b/resources/views/stats/yearly_overviews/show.blade.php
@@ -141,7 +141,7 @@
                     </h4>
                     <img
                         class="user-stat-card__avatar"
-                        alt="avatar"
+                        alt=""
                         src="{{ url($uploader->user->image === null ? 'img/profile.png' : 'files/img/' . $uploader->user->image) }}"
                     />
                 </article>
@@ -161,7 +161,7 @@
                     </h4>
                     <img
                         class="user-stat-card__avatar"
-                        alt="avatar"
+                        alt=""
                         src="{{ url($requester->user->image === null ? 'img/profile.png' : 'files/img/' . $requester->user->image) }}"
                     />
                 </article>
@@ -181,7 +181,7 @@
                     </h4>
                     <img
                         class="user-stat-card__avatar"
-                        alt="avatar"
+                        alt=""
                         src="{{ url($filler->filler->image === null ? 'img/profile.png' : 'files/img/' . $filler->filler->image) }}"
                     />
                 </article>
@@ -201,7 +201,7 @@
                     </h4>
                     <img
                         class="user-stat-card__avatar"
-                        alt="avatar"
+                        alt=""
                         src="{{ url($commenter->user->image === null ? 'img/profile.png' : 'files/img/' . $commenter->user->image) }}"
                     />
                 </article>
@@ -221,7 +221,7 @@
                     </h4>
                     <img
                         class="user-stat-card__avatar"
-                        alt="avatar"
+                        alt=""
                         src="{{ url($poster->user->image === null ? 'img/profile.png' : 'files/img/' . $poster->user->image) }}"
                     />
                 </article>
@@ -241,7 +241,7 @@
                     </h4>
                     <img
                         class="user-stat-card__avatar"
-                        alt="avatar"
+                        alt=""
                         src="{{ url($thanker->user->image === null ? 'img/profile.png' : 'files/img/' . $thanker->user->image) }}"
                     />
                 </article>

--- a/resources/views/torrent/partials/game_meta.blade.php
+++ b/resources/views/torrent/partials/game_meta.blade.php
@@ -3,7 +3,7 @@
         <img
             class="meta__backdrop"
             src="https://images.igdb.com/igdb/image/upload/t_screenshot_big/{{ $meta->artworks[0]['image_id'] }}.jpg"
-            alt="Backdrop"
+            alt=""
         />
     @endif
 
@@ -105,7 +105,7 @@
                                 class="meta-chip__image"
                                 style="object-fit: scale-down"
                                 src="https://images.igdb.com/igdb/image/upload/t_logo_med/{{ $company['company']['logo']['image_id'] }}.png"
-                                alt="logo"
+                                alt=""
                             />
                         @else
                             <i

--- a/resources/views/torrent/partials/movie_meta.blade.php
+++ b/resources/views/torrent/partials/movie_meta.blade.php
@@ -1,10 +1,6 @@
 <section class="meta">
     @if ($meta?->backdrop)
-        <img
-            class="meta__backdrop"
-            src="{{ tmdb_image('back_big', $meta->backdrop) }}"
-            alt="Backdrop"
-        />
+        <img class="meta__backdrop" src="{{ tmdb_image('back_big', $meta->backdrop) }}" alt="" />
     @endif
 
     <a
@@ -293,7 +289,7 @@
                                 class="meta-chip__image"
                                 style="object-fit: scale-down"
                                 src="{{ tmdb_image('logo_small', $company->logo) }}"
-                                alt="logo"
+                                alt=""
                             />
                         @else
                             <i

--- a/resources/views/torrent/partials/no_meta.blade.php
+++ b/resources/views/torrent/partials/no_meta.blade.php
@@ -3,7 +3,7 @@
         <img
             class="meta__backdrop"
             src="{{ url('/files/img/torrent-banner_' . $torrent->id . '.jpg') }}"
-            alt="Backdrop"
+            alt=""
         />
     @endif
 

--- a/resources/views/torrent/partials/playlists.blade.php
+++ b/resources/views/torrent/partials/playlists.blade.php
@@ -9,7 +9,7 @@
                     <img
                         class="playlists__playlist-image"
                         src="{{ url('files/img/' . $playlist->cover_image) }}"
-                        alt="Cover Image"
+                        alt=""
                     />
                 </a>
             @else

--- a/resources/views/torrent/partials/tv_meta.blade.php
+++ b/resources/views/torrent/partials/tv_meta.blade.php
@@ -1,10 +1,6 @@
 <section class="meta">
     @if ($meta?->backdrop)
-        <img
-            class="meta__backdrop"
-            src="{{ tmdb_image('back_big', $meta->backdrop) }}"
-            alt="Backdrop"
-        />
+        <img class="meta__backdrop" src="{{ tmdb_image('back_big', $meta->backdrop) }}" alt="" />
     @endif
 
     <a
@@ -292,7 +288,7 @@
                                 class="meta-chip__image"
                                 style="object-fit: scale-down"
                                 src="{{ tmdb_image('logo_small', $network->logo) }}"
-                                alt="logo"
+                                alt=""
                             />
                         @else
                             <i
@@ -316,7 +312,7 @@
                                 class="meta-chip__image"
                                 style="object-fit: scale-down"
                                 src="{{ tmdb_image('logo_small', $company->logo) }}"
-                                alt="logo"
+                                alt=""
                             />
                         @else
                             <i

--- a/resources/views/user/follower/index.blade.php
+++ b/resources/views/user/follower/index.blade.php
@@ -38,7 +38,7 @@
                                 <td>
                                     <img
                                         src="{{ url($follower->image === null ? 'img/profile.png' : 'files/img/' . $follower->image) }}"
-                                        alt="{{ $follower->username }}"
+                                        alt=""
                                         class="user-search__avatar"
                                     />
                                 </td>

--- a/resources/views/user/following/index.blade.php
+++ b/resources/views/user/following/index.blade.php
@@ -38,7 +38,7 @@
                                 <td>
                                     <img
                                         src="{{ url($following->image === null ? 'img/profile.png' : 'files/img/' . $following->image) }}"
-                                        alt="{{ $following->username }}"
+                                        alt=""
                                         class="user-search__avatar"
                                     />
                                 </td>

--- a/resources/views/user/profile/show.blade.php
+++ b/resources/views/user/profile/show.blade.php
@@ -152,7 +152,7 @@
                     </time>
                     <img
                         src="{{ url($user->image === null ? 'img/profile.png' : 'files/img/' . $user->image) }}"
-                        alt="{{ $user->username }}"
+                        alt=""
                         class="profile__avatar"
                     />
                     @if (auth()->user()->isAllowed($user, 'profile', 'show_profile_title') && $user->title)


### PR DESCRIPTION
Decorative images that serve no function, or where the surrounding content provides the context, should have an empty alt tag. Alt tags should not be generic. Alt tags on images inside of links should provide the context of the link if there is no other context provided inside the link. https://webaim.org/techniques/alttext/