### PR TITLE
(Update) timeElapsed now returns used values only

### DIFF
--- a/app/Helpers/StringHelper.php
+++ b/app/Helpers/StringHelper.php
@@ -59,6 +59,7 @@ class StringHelper
 
         foreach (self::secondsPer as $unit => $secondsPer) {
             $magnitude = intdiv($seconds, $secondsPer);
+
             if ($magnitude > 0) {
                 $units[] = $magnitude.trans('common.abbrev-'.$unit.'s');
                 $seconds -= $magnitude * $secondsPer;

--- a/app/Helpers/StringHelper.php
+++ b/app/Helpers/StringHelper.php
@@ -59,8 +59,10 @@ class StringHelper
 
         foreach (self::secondsPer as $unit => $secondsPer) {
             $magnitude = intdiv($seconds, $secondsPer);
-            $seconds -= $magnitude * $secondsPer;
-            $units[$unit] = $magnitude.trans('common.abbrev-'.$unit.'s');
+            if ($magnitude > 0) {
+                $units[] = $magnitude.trans('common.abbrev-'.$unit.'s');
+                $seconds -= $magnitude * $secondsPer;
+            }
         }
 
         return implode($units);


### PR DESCRIPTION
Return a string with date measures that are not 0, only include unit measures that are used, helping to improve readability.

Before:
![image](https://github.com/HDInnovations/UNIT3D-Community-Edition/assets/17742182/865f90cc-3299-44a4-a379-1f00774b3e9a)
![image](https://github.com/HDInnovations/UNIT3D-Community-Edition/assets/17742182/a53b1145-8983-4ab4-b956-337d508253f8)

After:
![image](https://github.com/HDInnovations/UNIT3D-Community-Edition/assets/17742182/9fc12df3-e499-4846-95f1-398f5b397954)
![image](https://github.com/HDInnovations/UNIT3D-Community-Edition/assets/17742182/84adc309-5249-4f08-a7ea-c577640258a4)
