### PR TITLE
(Update) Remove user avatar from playlist card

### DIFF
--- a/resources/sass/components/_playlist.scss
+++ b/resources/sass/components/_playlist.scss
@@ -102,7 +102,7 @@
     gap: 8px;
     text-align: center;
     font-size: 14px;
-    padding: 8px;
+    padding: 20px 8px;
 }
 
 .playlists__playlist-link {

--- a/resources/views/livewire/playlist-search.blade.php
+++ b/resources/views/livewire/playlist-search.blade.php
@@ -60,16 +60,6 @@
                     </a>
                 @endif
                 <div class="playlists__playlist-author">
-                    <a
-                        class="playlists__playlist-author-link"
-                        href="{{ route('users.show', ['user' => $playlist->user]) }}"
-                    >
-                        <img
-                            class="playlists__playlist-avatar"
-                            src="{{ url($playlist->user->image ? 'files/img/' . $playlist->user->image : 'img/profile.png') }}"
-                            alt="{{ $playlist->user->username }}"
-                        />
-                    </a>
                     <x-user_tag :user="$playlist->user" :anon="false" />
                 </div>
                 <a


### PR DESCRIPTION
The card looks much better without it, and it fixes spacing for users that don't have an avatar.