### PR TITLE
(Update) Improve hierarchy files

### DIFF
--- a/resources/views/torrent/partials/buttons.blade.php
+++ b/resources/views/torrent/partials/buttons.blade.php
@@ -206,7 +206,7 @@
                         List
                     </li>
                 </menu>
-                <div class="dialog__form" x-show="tab === 'hierarchy'">
+                <div class="dialog__form" x-show="tab === 'hierarchy'" style="gap: 0">
                     @if ($torrent->folder !== null)
                         <span
                             style="

--- a/resources/views/torrent/partials/buttons.blade.php
+++ b/resources/views/torrent/partials/buttons.blade.php
@@ -237,7 +237,7 @@
                         </span>
                     @endif
 
-                    @foreach ($files = $torrent->files->sortBy('name')->values()->sortBy(fn ($f) => dirname($f->name)."/~~~", SORT_NATURAL)->values() as $file)
+                    @foreach ($files = $torrent->files->sortBy(fn ($file) => (($dir = dirname($file->name)) === '.' ? chr(0xFF) : $dir."/".chr(0xFF)).basename($file->name), SORT_NATURAL)->values() as $file)
                         @php
                             $prevNodes = explode('/', $files[$loop->index - 1]->name ?? ' ')
                         @endphp


### PR DESCRIPTION
A bit of a hack is needed to sort files before directories located in the same directory. For example, if a torrent has two files: `BDMV/STREAM/00000.m2ts` and `BDMV/index.bdmv`, users will expect `BDMV/STREAM/` to be ordered before `BDMV/index.bdmv` in hiearchical sorting/grouping. In order to do this, we append a slash and the highest value of the ascii table (`chr(255)`) to the directory of each filepath, so that we e.g. sort `MOVIE_NAME/STREAM/<0xFF>` before `MOVIE_NAME/<0xFF>`, since `0xFF` will always (assuming sane filepaths...) come after `S`. Previously, we used the tilde for this hack, which has an ascii code of 126 which comes after mostly all characters, but let's max it out this time around to `chr(255)`. Also, there was an issue where a file located in the root directory would have `.` returned as its `dirname()`. `.` comes before all letters in the ascii table which breaks sorting when a torrent had both a directory and a file in the root directory, such as there being a `disc.inf` file in the root directory next to the `MOVIE_NAME` directory (In that case, the `disc.inf` file would be sorted before the `MOVIE_NAME` directory).

We need to override the gap defined by the `dialog_form` class for proper appearance.