### PR TITLE
(Fix) Allow `0000000`, etc. for id entry

### DIFF
--- a/app/Http/Requests/StoreTorrentRequest.php
+++ b/app/Http/Requests/StoreTorrentRequest.php
@@ -138,7 +138,8 @@ class StoreTorrentRequest extends FormRequest
             'imdb' => [
                 Rule::when($category->movie_meta || $category->tv_meta, [
                     'required',
-                    'numeric',
+                    'decimal:0',
+                    'min:0',
                 ]),
                 Rule::when(!($category->movie_meta || $category->tv_meta), [
                     Rule::in([0]),
@@ -147,8 +148,8 @@ class StoreTorrentRequest extends FormRequest
             'tvdb' => [
                 Rule::when($category->tv_meta, [
                     'required',
-                    'numeric',
-                    'integer',
+                    'decimal:0',
+                    'min:0',
                 ]),
                 Rule::when(!$category->tv_meta, [
                     Rule::in([0]),
@@ -157,8 +158,8 @@ class StoreTorrentRequest extends FormRequest
             'tmdb' => [
                 Rule::when($category->movie_meta || $category->tv_meta, [
                     'required',
-                    'numeric',
-                    'integer',
+                    'decimal:0',
+                    'min:0',
                 ]),
                 Rule::when(!($category->movie_meta || $category->tv_meta), [
                     Rule::in([0]),
@@ -167,8 +168,8 @@ class StoreTorrentRequest extends FormRequest
             'mal' => [
                 Rule::when($category->movie_meta || $category->tv_meta, [
                     'required',
-                    'numeric',
-                    'integer',
+                    'decimal:0',
+                    'min:0',
                 ]),
                 Rule::when(!($category->movie_meta || $category->tv_meta), [
                     Rule::in([0]),
@@ -177,8 +178,8 @@ class StoreTorrentRequest extends FormRequest
             'igdb' => [
                 Rule::when($category->game_meta, [
                     'required',
-                    'numeric',
-                    'integer',
+                    'decimal:0',
+                    'min:0',
                 ]),
                 Rule::when(!$category->game_meta, [
                     Rule::in([0]),
@@ -187,16 +188,16 @@ class StoreTorrentRequest extends FormRequest
             'season_number' => [
                 Rule::when($category->tv_meta, [
                     'required',
-                    'numeric',
-                    'integer',
+                    'decimal:0',
+                    'min:0',
                 ]),
                 Rule::prohibitedIf(!$category->tv_meta),
             ],
             'episode_number' => [
                 Rule::when($category->tv_meta, [
                     'required',
-                    'numeric',
-                    'integer',
+                    'decimal:0',
+                    'min:0',
                 ]),
                 Rule::prohibitedIf(!$category->tv_meta),
             ],

--- a/app/Http/Requests/StoreTorrentRequestRequest.php
+++ b/app/Http/Requests/StoreTorrentRequestRequest.php
@@ -45,7 +45,8 @@ class StoreTorrentRequestRequest extends FormRequest
             'imdb' => [
                 Rule::when($category->movie_meta || $category->tv_meta, [
                     'required',
-                    'numeric',
+                    'decimal:0',
+                    'min:0',
                 ]),
                 Rule::when(!($category->movie_meta || $category->tv_meta), [
                     Rule::in([0]),
@@ -54,8 +55,8 @@ class StoreTorrentRequestRequest extends FormRequest
             'tvdb' => [
                 Rule::when($category->tv_meta, [
                     'required',
-                    'numeric',
-                    'integer',
+                    'decimal:0',
+                    'min:0',
                 ]),
                 Rule::when(!$category->tv_meta, [
                     Rule::in([0]),
@@ -64,8 +65,8 @@ class StoreTorrentRequestRequest extends FormRequest
             'tmdb' => [
                 Rule::when($category->movie_meta || $category->tv_meta, [
                     'required',
-                    'numeric',
-                    'integer',
+                    'decimal:0',
+                    'min:0',
                 ]),
                 Rule::when(!($category->movie_meta || $category->tv_meta), [
                     Rule::in([0]),
@@ -74,8 +75,8 @@ class StoreTorrentRequestRequest extends FormRequest
             'mal' => [
                 Rule::when($category->movie_meta || $category->tv_meta, [
                     'required',
-                    'numeric',
-                    'integer',
+                    'decimal:0',
+                    'min:0',
                 ]),
                 Rule::when(!($category->movie_meta || $category->tv_meta), [
                     Rule::in([0]),
@@ -84,8 +85,8 @@ class StoreTorrentRequestRequest extends FormRequest
             'igdb' => [
                 Rule::when($category->game_meta, [
                     'required',
-                    'numeric',
-                    'integer',
+                    'decimal:0',
+                    'min:0',
                 ]),
                 Rule::when(!$category->game_meta, [
                     Rule::in([0]),

--- a/app/Http/Requests/UpdateTorrentRequest.php
+++ b/app/Http/Requests/UpdateTorrentRequest.php
@@ -85,33 +85,40 @@ class UpdateTorrentRequest extends FormRequest
             ],
             'imdb' => [
                 'required',
-                'numeric',
+                'decimal:0',
+                'min:0',
             ],
             'tvdb' => [
                 'required',
-                'numeric',
+                'decimal:0',
+                'min:0',
             ],
             'tmdb' => [
                 'required',
-                'numeric',
+                'decimal:0',
+                'min:0',
             ],
             'mal' => [
                 'required',
-                'numeric',
+                'decimal:0',
+                'min:0',
             ],
             'igdb' => [
                 'required',
-                'numeric',
+                'decimal:0',
+                'min:0',
             ],
             'season_number' => [
                 Rule::when($category->tv_meta, 'required'),
                 Rule::when(!$category->tv_meta, 'nullable'),
-                'numeric',
+                'decimal:0',
+                'min:0',
             ],
             'episode_number' => [
                 Rule::when($category->tv_meta, 'required'),
                 Rule::when(!$category->tv_meta, 'nullable'),
-                'numeric',
+                'decimal:0',
+                'min:0',
             ],
             'anon' => [
                 'required',

--- a/app/Http/Requests/UpdateTorrentRequestRequest.php
+++ b/app/Http/Requests/UpdateTorrentRequestRequest.php
@@ -39,23 +39,28 @@ class UpdateTorrentRequestRequest extends FormRequest
             ],
             'imdb' => [
                 'required',
-                'numeric',
+                'decimal:0',
+                'min:0',
             ],
             'tvdb' => [
                 'required',
-                'numeric',
+                'decimal:0',
+                'min:0',
             ],
             'tmdb' => [
                 'required',
-                'numeric',
+                'decimal:0',
+                'min:0',
             ],
             'mal' => [
                 'required',
-                'numeric',
+                'decimal:0',
+                'min:0',
             ],
             'igdb' => [
                 'required',
-                'numeric',
+                'decimal:0',
+                'min:0',
             ],
             'category_id' => [
                 'required',

--- a/resources/views/requests/create.blade.php
+++ b/resources/views/requests/create.blade.php
@@ -105,7 +105,7 @@
                         </label>
                     </p>
                     <div
-                        class="form__group--short-horizontal"
+                        class="form__group--horizontal"
                         x-show="cats[cat].type === 'movie' || cats[cat].type === 'tv' || cats[cat].type === 'game'"
                     >
                         <p
@@ -127,6 +127,7 @@
                             <label class="form__label form__label--floating" for="autotmdb">
                                 TMDB ID
                             </label>
+                            <span class="form__hint">Numeric digits only.</span>
                         </p>
                         <p
                             class="form__group"
@@ -147,6 +148,7 @@
                             <label class="form__label form__label--floating" for="autoimdb">
                                 IMDB ID
                             </label>
+                            <span class="form__hint">Numeric digits only.</span>
                         </p>
                         <p class="form__group" x-show="cats[cat].type === 'tv'">
                             <input type="hidden" name="tvdb" value="0" />
@@ -164,6 +166,7 @@
                             <label class="form__label form__label--floating" for="autotvdb">
                                 TVDB ID
                             </label>
+                            <span class="form__hint">Numeric digits only.</span>
                         </p>
                         <p
                             class="form__group"
@@ -184,6 +187,9 @@
                             <label class="form__label form__label--floating" for="automal">
                                 MAL ID ({{ __('torrent.required-anime') }})
                             </label>
+                            <span class="form__hint">
+                                Numeric digits only. Required for anime. Use 0 otherwise.
+                            </span>
                         </p>
                         <p class="form__group" x-show="cats[cat].type === 'game'">
                             <input

--- a/resources/views/torrent/create.blade.php
+++ b/resources/views/torrent/create.blade.php
@@ -327,7 +327,7 @@
                         <label class="form__label form__label--floating" for="autoimdb">
                             IMDB ID
                         </label>
-                        <span class="form__hint">Numeric digits only. No leading zeros.</span>
+                        <span class="form__hint">Numeric digits only.</span>
                     </p>
                     <p class="form__group" x-show="cats[cat].type === 'tv'">
                         <input type="hidden" name="tvdb" value="0" />


### PR DESCRIPTION
Fail less often for valid scenarios for users not familiar with the system.