### PR TITLE
(Fix) Broken bookmarks button

### DIFF
--- a/resources/views/components/torrent/row.blade.php
+++ b/resources/views/components/torrent/row.blade.php
@@ -19,6 +19,7 @@
     data-category-id="{{ $torrent->category_id }}"
     data-type-id="{{ $torrent->type_id }}"
     data-resolution-id="{{ $torrent->resolution_id }}"
+    wire:key="torrent-search-row-{{ $torrent->id }}"
 >
     @if (auth()->user()->show_poster == 1)
         <td class="torrent-search--list__poster">
@@ -141,7 +142,7 @@
                 </a>
             @endif
 
-            {{-- @livewire('small-bookmark-button', ['torrent' => $torrent, 'isBookmarked' => $torrent->bookmarks_exists, 'user' => auth()->user()], key('torrent-'.$torrent->id)) --}}
+            @livewire('small-bookmark-button', ['torrent' => $torrent, 'isBookmarked' => $torrent->bookmarks_exists, 'user' => auth()->user()], key('bookmark-torrent-'.$torrent->id))
 
             @if (config('torrent.download_check_page'))
                 <a

--- a/resources/views/livewire/small-bookmark-button.blade.php
+++ b/resources/views/livewire/small-bookmark-button.blade.php
@@ -1,17 +1,17 @@
-@if ($this->isBookmarked)
-    <button
+<button
+    @if ($this->isBookmarked)
         wire:click="destroy({{ $torrent->id }})"
         class="form__standard-icon-button"
         title="Unbookmark"
-    >
-        <i class="{{ config('other.font-awesome') }} fa-bookmark-slash"></i>
-    </button>
-@else
-    <button
+    @else
         wire:click="store({{ $torrent->id }})"
         class="form__standard-icon-button"
         title="Bookmark"
-    >
+    @endif
+>
+    @if ($this->isBookmarked)
+        <i class="{{ config('other.font-awesome') }} fa-bookmark-slash"></i>
+    @else
         <i class="{{ config('other.font-awesome') }} fa-bookmark"></i>
-    </button>
-@endif
+    @endif
+</button>


### PR DESCRIPTION
This must have been broken for a long time. This also fixes the issue when ticking checkboxes too quickly the state being reset. It required both making sure `small-bookmark-button.blade.php` was surrounded by an element completely, as well as adding wire:key to the inner row loop. Adding wire:key to the component itself doesn't work because the attributes aren't passed through...