### PR TITLE
(Fix) Quicksearch hardcoded category ids

### DIFF
--- a/resources/views/livewire/quick-search-dropdown.blade.php
+++ b/resources/views/livewire/quick-search-dropdown.blade.php
@@ -69,7 +69,7 @@
                             @case('movies')
                                 <a
                                     class="quick-search__result-link"
-                                    href="{{ route('torrents.similar', ['category_id' => '1', 'tmdb' => $search_result->id]) }}"
+                                    href="{{ route('torrents.similar', ['category_id' => $search_result->category_id, 'tmdb' => $search_result->id]) }}"
                                 >
                                     <img
                                         class="quick-search__image"
@@ -92,7 +92,7 @@
                             @case('series')
                                 <a
                                     class="quick-search__result-link"
-                                    href="{{ route('torrents.similar', ['category_id' => '2', 'tmdb' => $search_result->id]) }}"
+                                    href="{{ route('torrents.similar', ['category_id' => $search_result->category_id, 'tmdb' => $search_result->id]) }}"
                                 >
                                     <img
                                         class="quick-search__image"


### PR DESCRIPTION
Also 60x query speed improvement from 900ms to 15ms for ~200k torrents on untuned config.

fixes: #3413