### PR TITLE
(Fix) Only include visible peers when sending to external tracker

### DIFF
--- a/app/Services/Unit3dAnnounce.php
+++ b/app/Services/Unit3dAnnounce.php
@@ -173,7 +173,7 @@ class Unit3dAnnounce
 
         $peers = Peer::query()
             ->where('user_id', '=', $user->id)
-            ->selectRaw('SUM(seeder = 1 AND active = 1) as num_seeding, SUM(seeder = 0 AND active = 1) as num_leeching')
+            ->selectRaw('SUM(seeder = 1 AND active = 1 AND visible = 1) as num_seeding, SUM(seeder = 0 AND active = 1 AND visible = 1) as num_leeching')
             ->first();
 
         return self::put('users', [


### PR DESCRIPTION
Without this, the external tracker's `num_seeding` and `num_leeching` stats go out of sync.

cc @ungoogled1