### PR TITLE
(Fix) Encode settings overflowing out of torrent code box

### DIFF
--- a/resources/sass/components/_bbcode-rendered.scss
+++ b/resources/sass/components/_bbcode-rendered.scss
@@ -406,7 +406,7 @@
     padding: 0;
     overflow: visible;
     line-height: inherit;
-    word-wrap: normal;
+    overflow-wrap: anywhere;
     background-color: transparent;
     border: 0;
   }


### PR DESCRIPTION
Used to only be a chrome issue and worked fine in firefox, but now it's broken in firefox too...