### PR TITLE
(Fix) Tagging users in posts

### DIFF
--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -155,11 +155,9 @@ class PostController extends Controller
         }
 
         // User Tagged Notification
-        if ($user->id !== $post->user_id) {
-            preg_match_all('/@([\w\-]+)/', (string) $post->content, $matches);
-            $users = User::whereIn('username', $matches[1])->get();
-            Notification::send($users, new NewPostTag($post));
-        }
+        preg_match_all('/@([\w\-]+)/', (string) $post->content, $matches);
+        $users = User::whereIn('username', $matches[1])->where('id', '!=', $user->id)->get();
+        Notification::send($users, new NewPostTag($post));
 
         return redirect()->to($realUrl)
             ->withSuccess(trans('forum.reply-topic-success'));


### PR DESCRIPTION
It looks like the intention of this code was to omit the author of the post from the notifications, but instead it was comparing the author's id to itself, thereby always being false and no notifications ever being sent.