### PR TITLE
(Update) Torrent group monthly season pack naming

### DIFF
--- a/app/Http/Livewire/TorrentSearch.php
+++ b/app/Http/Livewire/TorrentSearch.php
@@ -453,6 +453,7 @@ class TorrentSearch extends Component
                 'sticky',
                 'sd',
                 'internal',
+                'release_year',
                 'created_at',
                 'bumped_at',
                 'type_id',

--- a/resources/views/components/partials/_torrent-group-row.blade.php
+++ b/resources/views/components/partials/_torrent-group-row.blade.php
@@ -14,12 +14,12 @@
             <a href="{{ route('torrents.show', ['id' => $torrent->id]) }}">
                 @switch($media->meta)
                     @case('movie')
-                        {{ \preg_replace('/^.*( ' . (substr($media->release_date ?? '0', 0, 4) - 1) . ' | ' . substr($media->release_date ?? '0', 0, 4) . ' | ' . (substr($media->release_date ?? '0', 0, 4) + 1) . ' )/i', '', $torrent->name) }}
+                        {{ \preg_replace('/^.*( ' . implode(' | ', range($torrent->release_year - 1, $torrent->release_year + 1)) . ' )/i', '', $torrent->name) }}
 
                         @break
                     @case('tv')
-                        {{-- Removes the following patterns from the name: S01, S01E01, S01E01E02, S01E01E02E03, S01E01-E03, 2000-01-01, 2000-01-01 --}}
-                        {{ \preg_replace('/^.*( S\d{2,4}(?:-?E\d{2,4})*? | \d{4}(?:-\d{2}){1,2} | ' . (substr($media->first_air_date ?? '0', 0, 4) - 1) . ' | ' . substr($media->first_air_date ?? '0', 0, 4) . ' | ' . (substr($media->first_air_date ?? '0', 0, 4) + 1) . ' )/i', '', $torrent->name) }}
+                        {{-- Removes the following patterns from the name: S01, S01E01, S01E01E02, S01E01E02E03, S01E01-E03, 2000-, 2000 --}}
+                        {{ \preg_replace('/^.*( S\d{2,4}(?:-?E\d{2,4})*? | ' . implode(' | ', range($torrent->release_year - 1, $torrent->release_year + 1)) . ' | ' . implode('-| ', range(substr($media->first_air_date, 0, 4) - 1, substr($media->last_air_date, 0, 4) + 1)) . '-)/i', '', $torrent->name) }}
 
                         @break
                 @endswitch


### PR DESCRIPTION
For shows that are packed by month, with a torrent title following the format `TV Show Name 2024-05 1080p H.264`, the year is saved as the season and there is not way to disambiguate between the months within. So instead of the row saying `1080p H.264` with no context as to which month it is, it becomes `05 1080p H.264`. We also now match between all years between the first air date and the last end date plus/minus 1 instead of matching any date format within the title.