### PR TITLE
(Fix) Force redirect `/index.php/` requests

### DIFF
--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -40,6 +40,8 @@ class RouteServiceProvider extends ServiceProvider
     {
         $this->configureRateLimiting();
 
+        $this->removeIndexPhpFromUrl();
+
         $this->routes(function (): void {
             Route::prefix('api')
                 ->middleware(['chat'])
@@ -73,5 +75,18 @@ class RouteServiceProvider extends ServiceProvider
         RateLimiter::for('announce', fn (Request $request) => Limit::perMinute(500)->by('announce'.$request->ip()));
         RateLimiter::for('chat', fn (Request $request) => Limit::perMinute(60)->by('chat'.($request->user()?->id ?? $request->ip())));
         RateLimiter::for('rss', fn (Request $request) => Limit::perMinute(30)->by('rss'.$request->ip()));
+    }
+
+    protected function removeIndexPhpFromUrl(): void
+    {
+        if (str_contains(request()->getRequestUri(), '/index.php/')) {
+            $url = str_replace('index.php/', '', request()->getRequestUri());
+
+            if ($url !== '') {
+                header("Location: {$url}", true, 301);
+
+                exit;
+            }
+        }
     }
 }


### PR DESCRIPTION
This was never intended, and was recently discovered when an old site was migrated to UNIT3D and its users had browser bookmarks to https://domain.tld/index.php. Users browsing from this url have all their links generated with the `index.php` included, include the announce urls in their torrents, which isn't great and causes issues with unit3d-announce.