### PR TITLE
(Fix) Strict types

### DIFF
--- a/app/Helpers/TorrentTools.php
+++ b/app/Helpers/TorrentTools.php
@@ -28,7 +28,7 @@ class TorrentTools
      */
     public static function normalizeTorrent(UploadedFile $torrentFile)
     {
-        $result = Bencode::bdecode_file($torrentFile);
+        $result = Bencode::bdecode_file($torrentFile->getRealPath());
 
         // Whitelisted keys
         $result = array_intersect_key($result, [

--- a/app/Models/Torrent.php
+++ b/app/Models/Torrent.php
@@ -100,6 +100,7 @@ class Torrent extends Model
     protected function casts(): array
     {
         return [
+            'tmdb'         => 'integer',
             'igdb'         => 'integer',
             'bumped_at'    => 'datetime',
             'fl_until'     => 'datetime',

--- a/app/Models/TorrentRequest.php
+++ b/app/Models/TorrentRequest.php
@@ -82,6 +82,7 @@ class TorrentRequest extends Model
         return [
             'filled_when'   => 'datetime',
             'approved_when' => 'datetime',
+            'tmdb'          => 'integer',
             'igdb'          => 'integer',
             'bounty'        => 'decimal:2',
         ];

--- a/resources/views/components/partials/_torrent-group-row.blade.php
+++ b/resources/views/components/partials/_torrent-group-row.blade.php
@@ -19,7 +19,20 @@
                         @break
                     @case('tv')
                         {{-- Removes the following patterns from the name: S01, S01E01, S01E01E02, S01E01E02E03, S01E01-E03, 2000-, 2000 --}}
-                        {{ \preg_replace('/^.*( S\d{2,4}(?:-?E\d{2,4})*? | ' . implode(' | ', range($torrent->release_year - 1, $torrent->release_year + 1)) . ' | ' . implode('-| ', range(substr($media->first_air_date, 0, 4) - 1, substr($media->last_air_date, 0, 4) + 1)) . '-)/i', '', $torrent->name) }}
+                        @php
+                            if (
+                                $media->first_air_date !== null &&
+                                preg_match('/^[0-9]{4}/', $media->first_air_date) &&
+                                $media->last_air_date &&
+                                preg_match('/^[0-9]{4}/', $media->last_air_date)
+                            ) {
+                                $range = range((int) substr($media->first_air_date, 0, 4) - 1, (int) substr($media->last_air_date, 0, 4) + 1);
+                            } else {
+                                $range = [];
+                            }
+                        @endphp
+
+                        {{ \preg_replace('/^.*( S\d{2,4}(?:-?E\d{2,4})*? | ' . implode(' | ', range($torrent->release_year - 1, $torrent->release_year + 1)) . ' | ' . implode('-| ', $range) . '-)/i', '', $torrent->name) }}
 
                         @break
                 @endswitch


### PR DESCRIPTION
1. Need to use the path of a file and not the object.
2. When a torrent is uploaded, the upload form sends a string for the tmdb and the model is saved with a string and it's the database that does the conversion. We need to cast the string to an int if we want to reuse the model without rehydrating.
3. Some of the first_air_date and last_air_date are null and need to be checked to make sure they follow the correct format.

fixes regressions from #3855