### PR TITLE
(Update) Allow saving default torrent sort column

### DIFF
--- a/app/Http/Livewire/TorrentSearch.php
+++ b/app/Http/Livewire/TorrentSearch.php
@@ -25,6 +25,7 @@ use App\Traits\CastLivewireProperties;
 use App\Traits\LivewireSort;
 use App\Traits\TorrentMeta;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Http\Request;
 use Livewire\Attributes\Computed;
 use Livewire\Attributes\Url;
 use Livewire\Component;
@@ -208,7 +209,7 @@ class TorrentSearch extends Component
     #[Url(history: true)]
     public int $perPage = 25;
 
-    #[Url(history: true)]
+    #[Url(except: 'bumped_at')]
     public string $sortField = 'bumped_at';
 
     #[Url(history: true)]
@@ -216,6 +217,13 @@ class TorrentSearch extends Component
 
     #[Url(history: true)]
     public string $view = 'list';
+
+    final public function mount(Request $request): void
+    {
+        if ($request->missing('sortField')) {
+            $this->sortField = auth()->user()->settings?->torrent_sort_field ?? 'bumped_at';
+        }
+    }
 
     final public function updating(string $field, mixed &$value): void
     {

--- a/app/Http/Requests/UpdateGeneralSettingRequest.php
+++ b/app/Http/Requests/UpdateGeneralSettingRequest.php
@@ -46,6 +46,10 @@ class UpdateGeneralSettingRequest extends FormRequest
                 'required',
                 Rule::in([0, 1, 2, 3]),
             ],
+            'torrent_sort_field' => [
+                'required',
+                Rule::in(['created_at', 'bumped_at']),
+            ],
             'show_poster' => [
                 'required',
                 'boolean',

--- a/database/migrations/2024_05_29_075428_add_torrent_sort_field_to_user_settings.php
+++ b/database/migrations/2024_05_29_075428_add_torrent_sort_field_to_user_settings.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * NOTICE OF LICENSE.
+ *
+ * UNIT3D Community Edition is open-sourced software licensed under the GNU Affero General Public License v3.0
+ * The details is bundled with this project in the file LICENSE.txt.
+ *
+ * @project    UNIT3D Community Edition
+ *
+ * @author     Roardom <roardom@protonmail.com>
+ * @license    https://www.gnu.org/licenses/agpl-3.0.en.html/ GNU Affero General Public License v3.0
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('user_settings', function (Blueprint $table): void {
+            $table->string('torrent_sort_field')->after('show_poster');
+        });
+
+        Schema::table('torrents', function (Blueprint $table): void {
+            $table->index(['status', 'sticky', 'created_at']);
+        });
+    }
+};

--- a/resources/views/user/general_setting/edit.blade.php
+++ b/resources/views/user/general_setting/edit.blade.php
@@ -259,6 +259,32 @@
                         </label>
                     </p>
                     <p class="form__group">
+                        <select
+                            id="torrent_sort_field"
+                            class="form__select"
+                            name="torrent_sort_field"
+                            required
+                        >
+                            <option
+                                class="form__option"
+                                value="bumped_at"
+                                @selected($user->settings === null || $user->settings?->torrent_sort_field === 'bumped_at')
+                            >
+                                Most recently bumped
+                            </option>
+                            <option
+                                class="form__option"
+                                value="created_at"
+                                @selected($user->settings?->torrent_sort_field === 'created_at')
+                            >
+                                Most recently uploaded
+                            </option>
+                        </select>
+                        <label class="form__label form__label--floating" for="torrent_sort_field">
+                            Default torrent sort field
+                        </label>
+                    </p>
+                    <p class="form__group">
                         <label class="form__label">
                             <input type="hidden" name="show_poster" value="0" />
                             <input


### PR DESCRIPTION
After 10+ hours of debugging and searching through livewire issues, it turns out that the query string doesn't update if you have `history: true` in the `#[Url()]` attribute.