### PR TITLE
(Fix) Footer size when configured meta description is too long

### DIFF
--- a/resources/sass/layout/_footer.scss
+++ b/resources/sass/layout/_footer.scss
@@ -38,7 +38,6 @@ html, body {
 
 .footer__section {
     flex: 1 1 0;
-    min-width: max-content;
 }
 
 .footer__section:first-child {


### PR DESCRIPTION
I can't remember why I added this property in #3835. Upon removal, the footer still looks the same at various resolutions (if the configured meta description is short enough).