### PR TITLE
(Update) Use unsigned 32-bit integer for migration create

### DIFF
--- a/stubs/migration.create.stub
+++ b/stubs/migration.create.stub
@@ -22,7 +22,7 @@ return new class () extends Migration {
     public function up(): viod
     {
         Schema::create('{{ table }}', function (Blueprint $table): void {
-            $table->increments('id');
+            $table->unsignedInteger('id');
             $table->timestamps();
         });
     }


### PR DESCRIPTION
For 99% of cases it's not necessary to support more than 4 billion rows.