### PR TITLE
(Fix) Register page SEO

### DIFF
--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -100,6 +100,10 @@ class FortifyServiceProvider extends ServiceProvider
         $this->app->instance(RegisterViewResponse::class, new class () implements RegisterViewResponse {
             public function toResponse($request): \Illuminate\Http\RedirectResponse|\Illuminate\View\View
             {
+                if ($request->missing('code')) {
+                    return view('auth.register');
+                }
+
                 return view('auth.register', ['code' => $request->query('code')]);
             }
         });


### PR DESCRIPTION
When someone follows the link without the invite code when the site is configured as invite only, we show an error message saying open registration is disabled. Unfortunately, if the code is missing, we redirect the user with a `?code=null` query parameter instead of omitting the code, which prevents the error message on the registration page from being shown. Let's fix this by omitting the query parameter if a code wasn't provided.