### PR TITLE
(Fix) Conversation creation

### DIFF
--- a/app/Http/Controllers/Staff/ModerationController.php
+++ b/app/Http/Controllers/Staff/ModerationController.php
@@ -19,6 +19,7 @@ namespace App\Http\Controllers\Staff;
 use App\Helpers\TorrentHelper;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Staff\UpdateModerationRequest;
+use App\Models\Conversation;
 use App\Models\PrivateMessage;
 use App\Models\Scopes\ApprovedScope;
 use App\Models\Torrent;
@@ -113,11 +114,14 @@ class ModerationController extends Controller
                     'moderated_by' => $staff->id,
                 ]);
 
+                $conversation = Conversation::create(['subject' => 'Your upload, '.$torrent->name.' ,has been rejected by '.$staff->username]);
+
+                $conversation->users()->sync([$staff->id, $torrent->user_id]);
+
                 PrivateMessage::create([
-                    'sender_id'   => $staff->id,
-                    'receiver_id' => $torrent->user_id,
-                    'subject'     => 'Your upload, '.$torrent->name.' ,has been rejected by '.$staff->username,
-                    'message'     => "Greetings, \n\nYour upload ".$torrent->name." has been rejected. Please see below the message from the staff member.\n\n".$request->message,
+                    'conversation_id' => $conversation->id,
+                    'sender_id'       => $staff->id,
+                    'message'         => "Greetings, \n\nYour upload ".$torrent->name." has been rejected. Please see below the message from the staff member.\n\n".$request->message,
                 ]);
 
                 cache()->forget('announce-torrents:by-infohash:'.$torrent->info_hash);
@@ -134,11 +138,14 @@ class ModerationController extends Controller
                     'moderated_by' => $staff->id,
                 ]);
 
+                $conversation = Conversation::create(['subject' => 'Your upload, '.$torrent->name.' ,has been postponed by '.$staff->username]);
+
+                $conversation->users()->sync([$staff->id, $torrent->user_id]);
+
                 PrivateMessage::create([
-                    'sender_id'   => $staff->id,
-                    'receiver_id' => $torrent->user_id,
-                    'subject'     => 'Your upload, '.$torrent->name.' ,has been postponed by '.$staff->username,
-                    'message'     => "Greetings, \n\nYour upload, ".$torrent->name." ,has been postponed. Please see below the message from the staff member.\n\n".$request->message,
+                    'conversation_id' => $conversation->id,
+                    'sender_id'       => $staff->id,
+                    'message'         => "Greetings, \n\nYour upload, ".$torrent->name." ,has been postponed. Please see below the message from the staff member.\n\n".$request->message,
                 ]);
 
                 cache()->forget('announce-torrents:by-infohash:'.$torrent->info_hash);

--- a/app/Http/Controllers/Staff/ReportController.php
+++ b/app/Http/Controllers/Staff/ReportController.php
@@ -18,6 +18,7 @@ namespace App\Http\Controllers\Staff;
 
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Staff\UpdateReportRequest;
+use App\Models\Conversation;
 use App\Models\PrivateMessage;
 use App\Models\Report;
 
@@ -63,12 +64,14 @@ class ReportController extends Controller
 
         $report->update(['solved' => 1, 'staff_id' => $staff->id] + $request->validated());
 
-        // Send Private Message
+        $conversation = Conversation::create(['subject' => 'Your Report Has A New Verdict']);
+
+        $conversation->users()->sync([$staff->id, $report->reporter_id]);
+
         PrivateMessage::create([
-            'sender_id'   => $staff->id,
-            'receiver_id' => $report->reporter_id,
-            'subject'     => 'Your Report Has A New Verdict',
-            'message'     => '[b]REPORT TITLE:[/b] '.$report->title."\n\n[b]ORIGINAL MESSAGE:[/b] ".$report->message."\n\n[b]VERDICT:[/b] ".$report->verdict,
+            'conversation_id' => $conversation->id,
+            'sender_id'       => $staff->id,
+            'message'         => '[b]REPORT TITLE:[/b] '.$report->title."\n\n[b]ORIGINAL MESSAGE:[/b] ".$report->message."\n\n[b]VERDICT:[/b] ".$report->verdict,
         ]);
 
         return to_route('staff.reports.index')

--- a/app/Http/Controllers/User/WarningController.php
+++ b/app/Http/Controllers/User/WarningController.php
@@ -17,7 +17,6 @@ declare(strict_types=1);
 namespace App\Http\Controllers\User;
 
 use App\Http\Controllers\Controller;
-use App\Models\PrivateMessage;
 use App\Models\User;
 use App\Models\Warning;
 use Illuminate\Http\Request;
@@ -66,12 +65,10 @@ class WarningController extends Controller
 
         $staff = $request->user();
 
-        PrivateMessage::create([
-            'sender_id'   => $staff->id,
-            'receiver_id' => $user->id,
-            'subject'     => 'Hit and Run Warning Deleted',
-            'message'     => $staff->username.' has decided to delete your warning for torrent '.$warning->torrent.' You lucked out! [color=red][b]THIS IS AN AUTOMATED SYSTEM MESSAGE, PLEASE DO NOT REPLY![/b][/color]',
-        ]);
+        $user->sendSystemNotification(
+            subject: 'Hit and Run Warning Deleted',
+            message: $staff->username.' has decided to delete your warning for torrent '.$warning->torrent.' You lucked out!',
+        );
 
         $warning->update([
             'deleted_by' => $staff->id,
@@ -98,12 +95,10 @@ class WarningController extends Controller
 
         $user->warnings()->delete();
 
-        PrivateMessage::create([
-            'sender_id'   => $staff->id,
-            'receiver_id' => $user->id,
-            'subject'     => 'All Hit and Run Warnings Deleted',
-            'message'     => $staff->username.' has decided to delete all of your warnings. You lucked out! [color=red][b]THIS IS AN AUTOMATED SYSTEM MESSAGE, PLEASE DO NOT REPLY![/b][/color]',
-        ]);
+        $user->sendSystemNotification(
+            subject: 'All Hit and Run Warnings Deleted',
+            message: $staff->username.' has decided to delete all of your warnings. You lucked out!',
+        );
 
         return to_route('users.show', ['user' => $user])
             ->withSuccess('All Warnings Were Successfully Deleted');

--- a/app/Http/Livewire/UserWarnings.php
+++ b/app/Http/Livewire/UserWarnings.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace App\Http\Livewire;
 
-use App\Models\PrivateMessage;
 use App\Models\User;
 use App\Models\Warning;
 use App\Traits\LivewireSort;
@@ -143,12 +142,10 @@ class UserWarnings extends Component
             'active'     => false,
         ]);
 
-        PrivateMessage::create([
-            'sender_id'   => $staff->id,
-            'receiver_id' => $this->user->id,
-            'subject'     => 'Hit and Run Warning Deleted',
-            'message'     => $staff->username.' has decided to deactivate your warning for torrent '.$warning->torrent.' You lucked out! [color=red][b]THIS IS AN AUTOMATED SYSTEM MESSAGE, PLEASE DO NOT REPLY![/b][/color]',
-        ]);
+        $this->user->sendSystemNotification(
+            subject: 'Hit and Run Warning Deleted',
+            message: $staff->username.' has decided to deactivate your warning for torrent '.$warning->torrent.' You lucked out!',
+        );
 
         $this->dispatch('success', type: 'success', message: 'Warning Was Successfully Deactivated');
     }
@@ -185,12 +182,10 @@ class UserWarnings extends Component
                 'active'     => false,
             ]);
 
-        PrivateMessage::create([
-            'sender_id'   => $staff->id,
-            'receiver_id' => $this->user->id,
-            'subject'     => 'All Hit and Run Warnings Deleted',
-            'message'     => $staff->username.' has decided to deactivate all of your warnings. You lucked out! [color=red][b]THIS IS AN AUTOMATED SYSTEM MESSAGE, PLEASE DO NOT REPLY![/b][/color]',
-        ]);
+        $this->user->sendSystemNotification(
+            subject: 'All Hit and Run Warnings Deleted',
+            message: $staff->username.' has decided to deactivate all of your warnings. You lucked out!',
+        );
 
         $this->dispatch('success', type: 'success', message: 'All Warnings Were Successfully Deactivated');
     }
@@ -212,12 +207,10 @@ class UserWarnings extends Component
 
         $warning->delete();
 
-        PrivateMessage::create([
-            'sender_id'   => $staff->id,
-            'receiver_id' => $this->user->id,
-            'subject'     => 'Hit and Run Warning Deleted',
-            'message'     => $staff->username.' has decided to delete your warning for torrent '.$warning->torrent.' You lucked out! [color=red][b]THIS IS AN AUTOMATED SYSTEM MESSAGE, PLEASE DO NOT REPLY![/b][/color]',
-        ]);
+        $this->user->sendSystemNotification(
+            subject: 'Hit and Run Warning Deleted',
+            message: $staff->username.' has decided to delete your warning for torrent '.$warning->torrent.' You lucked out!',
+        );
 
         $this->dispatch('success', type: 'success', message: 'Warning Was Successfully Deleted');
     }
@@ -239,12 +232,10 @@ class UserWarnings extends Component
 
         $this->user->warnings()->delete();
 
-        PrivateMessage::create([
-            'sender_id'   => $staff->id,
-            'receiver_id' => $this->user->id,
-            'subject'     => 'All Hit and Run Warnings Deleted',
-            'message'     => $staff->username.' has decided to delete all of your warnings. You lucked out! [color=red][b]THIS IS AN AUTOMATED SYSTEM MESSAGE, PLEASE DO NOT REPLY![/b][/color]',
-        ]);
+        $this->user->sendSystemNotification(
+            subject: 'All Hit and Run Warnings Deleted',
+            message: $staff->username.' has decided to delete all of your warnings. You lucked out!',
+        );
 
         $this->dispatch('success', type: 'success', message: 'All Warnings Were Successfully Deleted');
     }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -927,7 +927,7 @@ class User extends Authenticatable implements MustVerifyEmail
 
         PrivateMessage::create([
             'conversation_id' => $conversation->id,
-            'user_id'         => $this->id,
+            'sender_id'       => $this->id,
             'message'         => $message
         ]);
     }
@@ -940,7 +940,7 @@ class User extends Authenticatable implements MustVerifyEmail
 
         PrivateMessage::create([
             'conversation_id' => $conversation->id,
-            'user_id'         => $userId,
+            'sender_id'       => $userId,
             'message'         => $message
         ]);
     }


### PR DESCRIPTION
Should use `sender_id`, not `user_id`. Also need to create conversations for all non-system pms.