### PR TITLE
(Fix) Escape more text in blade templates

### DIFF
--- a/resources/views/Staff/poll/edit.blade.php
+++ b/resources/views/Staff/poll/edit.blade.php
@@ -30,7 +30,11 @@
                 class="form"
                 method="POST"
                 action="{{ route('staff.polls.update', ['poll' => $poll]) }}"
-                x-data="{ extraOptions: {!! $poll->options->map(fn ($item) => $item->only(['id', 'name'])) !!} }"
+                x-data="{
+                    extraOptions: JSON.parse(
+                        atob('{{ base64_encode(json_encode($poll->options->select('id', 'name'))) }}')
+                    ),
+                }"
             >
                 @csrf
                 @method('PATCH')

--- a/resources/views/requests/create.blade.php
+++ b/resources/views/requests/create.blade.php
@@ -23,7 +23,7 @@
             class="panelV2"
             x-data="{
                 cat: {{ (int) $category_id }},
-                cats: JSON.parse(atob('{!! base64_encode(json_encode($categories)) !!}'))
+                cats: JSON.parse(atob('{{ base64_encode(json_encode($categories)) }}')),
             }"
         >
             <h2 class="panel__heading">{{ __('request.add-request') }}</h2>

--- a/resources/views/rss/show.blade.php
+++ b/resources/views/rss/show.blade.php
@@ -9,7 +9,7 @@
         <title>{{ config('other.title') }}: {{ $rss->name }}</title>
         <link>{{ config('app.url') }}</link>
         <description>
-            {!! __('This feed contains your secure rsskey, please do not share with anyone.') !!}
+            {{ __('This feed contains your secure rsskey, please do not share with anyone.') }}
         </description>
         <atom:link href="{{ route('rss.show.rsskey', ['id' => $rss->id, 'rsskey' => $user->rsskey]) }}"
                    type="application/rss+xml" rel="self"></atom:link>

--- a/resources/views/torrent/create.blade.php
+++ b/resources/views/torrent/create.blade.php
@@ -45,9 +45,9 @@
     <section
         class="upload panelV2"
         x-data="{
-                cat: {{(int)$category_id}},
-                cats: JSON.parse(atob('{!! base64_encode(json_encode($categories)) !!}'))
-            }"
+            cat: {{ (int) $category_id }},
+            cats: JSON.parse(atob('{{ base64_encode(json_encode($categories)) }}')),
+        }"
     >
         <h2 class="upload-title panel__heading">
             <i class="{{ config('other.font-awesome') }} fa-file"></i>

--- a/resources/views/torrent/edit.blade.php
+++ b/resources/views/torrent/edit.blade.php
@@ -20,10 +20,10 @@
     <section
         class="panelV2"
         x-data="{
-            cat: {{(int)$torrent->category_id}},
-            cats: JSON.parse(atob('{!! base64_encode(json_encode($categories)) !!}')),
-            type: {{ (int)$torrent->type_id }},
-            types: JSON.parse(atob('{!! base64_encode(json_encode($types)) !!}'))
+            cat: {{ (int) $torrent->category_id }},
+            cats: JSON.parse(atob('{{ base64_encode(json_encode($categories)) }}')),
+            type: {{ (int) $torrent->type_id }},
+            types: JSON.parse(atob('{{ base64_encode(json_encode($types)) }}')),
         }"
     >
         <h2 class="panel__heading">{{ __('common.edit') }}: {{ $torrent->name }}</h2>


### PR DESCRIPTION
Some of these are very easy to reduce surface area. There are still a few more unsafe translations but they require editing the translation content.