### PR TITLE
(Fix) Laravel 11 migration syntax

### DIFF
--- a/database/migrations/2017_12_10_020753_create_bon_transactions_table.php
+++ b/database/migrations/2017_12_10_020753_create_bon_transactions_table.php
@@ -26,7 +26,7 @@ return new class () extends Migration {
             $table->integer('id', true);
             $table->integer('itemID')->unsigned()->default(0);
             $table->string('name')->default('');
-            $table->float('cost', 22)->default(0.00);
+            $table->double('cost')->default(0.00);
             $table->integer('sender')->unsigned()->default(0);
             $table->integer('receiver')->unsigned()->default(0);
             $table->integer('torrent_id')->nullable();

--- a/database/migrations/2017_12_10_020753_create_request_bounty_table.php
+++ b/database/migrations/2017_12_10_020753_create_request_bounty_table.php
@@ -25,7 +25,7 @@ return new class () extends Migration {
         Schema::create('request_bounty', function (Blueprint $table): void {
             $table->integer('id', true);
             $table->integer('user_id')->index('addedby');
-            $table->float('seedbonus', 12)->unsigned()->default(0.00);
+            $table->double('seedbonus')->unsigned()->default(0.00);
             $table->integer('requests_id')->index('request_id');
             $table->timestamps();
         });

--- a/database/migrations/2017_12_10_020753_create_requests_table.php
+++ b/database/migrations/2017_12_10_020753_create_requests_table.php
@@ -33,7 +33,7 @@ return new class () extends Migration {
             $table->string('mal')->nullable()->index('mal');
             $table->text('description');
             $table->integer('user_id')->index('requests_user_id_foreign');
-            $table->float('bounty', 22);
+            $table->double('bounty');
             $table->integer('votes')->default(0);
             $table->boolean('claimed')->nullable();
             $table->timestamps();

--- a/database/migrations/2017_12_10_020753_create_torrents_table.php
+++ b/database/migrations/2017_12_10_020753_create_torrents_table.php
@@ -32,7 +32,7 @@ return new class () extends Migration {
             $table->string('info_hash')->index('info_hash');
             $table->string('file_name');
             $table->integer('num_file');
-            $table->float('size');
+            $table->double('size');
             $table->text('nfo')->nullable();
             $table->integer('leechers')->default(0);
             $table->integer('seeders')->default(0);

--- a/database/migrations/2017_12_10_020753_create_users_table.php
+++ b/database/migrations/2017_12_10_020753_create_users_table.php
@@ -38,7 +38,7 @@ return new class () extends Migration {
             $table->string('about', 500)->nullable();
             $table->text('signature')->nullable();
             $table->integer('fl_tokens')->unsigned()->default(0);
-            $table->float('seedbonus', 12)->unsigned()->default(0.00);
+            $table->double('seedbonus')->unsigned()->default(0.00);
             $table->integer('invites')->unsigned()->default(0);
             $table->integer('hitandruns')->unsigned()->default(0);
             $table->string('rsskey');

--- a/database/migrations/2017_12_10_020755_add_two_factor_columns_to_users_table.php
+++ b/database/migrations/2017_12_10_020755_add_two_factor_columns_to_users_table.php
@@ -25,17 +25,23 @@ return new class () extends Migration {
     public function up(): void
     {
         Schema::table('users', function (Blueprint $table): void {
-            $table->text('two_factor_secret')
-                ->after('password')
-                ->nullable();
+            if (!Schema::hasColumn('users', 'two_factor_secret')) {
+                $table->text('two_factor_secret')
+                    ->after('password')
+                    ->nullable();
+            }
 
-            $table->text('two_factor_recovery_codes')
-                ->after('two_factor_secret')
-                ->nullable();
+            if (!Schema::hasColumn('users', 'two_factor_recovery_codes')) {
+                $table->text('two_factor_recovery_codes')
+                    ->after('two_factor_secret')
+                    ->nullable();
+            }
 
-            $table->timestamp('two_factor_confirmed_at')
-                ->after('two_factor_recovery_codes')
-                ->nullable();
+            if (!Schema::hasColumn('users', 'two_factor_confirmed_at')) {
+                $table->timestamp('two_factor_confirmed_at')
+                    ->after('two_factor_recovery_codes')
+                    ->nullable();
+            }
         });
     }
 };

--- a/database/migrations/2019_02_05_220444_create_bots_table.php
+++ b/database/migrations/2019_02_05_220444_create_bots_table.php
@@ -46,7 +46,7 @@ return new class () extends Migration {
             $table->bigInteger('uploaded')->unsigned()->default(0);
             $table->bigInteger('downloaded')->unsigned()->default(0);
             $table->integer('fl_tokens')->unsigned()->default(0);
-            $table->float('seedbonus', 12)->unsigned()->default(0.00);
+            $table->double('seedbonus')->unsigned()->default(0.00);
             $table->integer('invites')->unsigned()->default(0);
             $table->timestamps();
         });

--- a/database/migrations/2019_02_06_075938_create_bot_transactions_table.php
+++ b/database/migrations/2019_02_06_075938_create_bot_transactions_table.php
@@ -27,7 +27,7 @@ return new class () extends Migration {
         Schema::create('bot_transactions', function (Blueprint $table): void {
             $table->integer('id', true);
             $table->string('type')->default('')->nullable()->index();
-            $table->float('cost', 22)->default(0.00);
+            $table->double('cost')->default(0.00);
             $table->integer('user_id')->default(0)->index();
             $table->integer('bot_id')->default(0)->index();
             $table->boolean('to_user')->default(0)->index();

--- a/database/migrations/2019_02_10_010213_fix_chat_related_tables.php
+++ b/database/migrations/2019_02_10_010213_fix_chat_related_tables.php
@@ -25,14 +25,14 @@ return new class () extends Migration {
     public function up(): void
     {
         Schema::table('user_echoes', function (Blueprint $table): void {
-            $table->integer('room_id')->change();
-            $table->integer('bot_id')->change();
-            $table->integer('target_id')->change();
+            $table->integer('room_id')->nullable()->change();
+            $table->integer('bot_id')->nullable()->change();
+            $table->integer('target_id')->nullable()->change();
         });
         Schema::table('user_audibles', function (Blueprint $table): void {
-            $table->integer('room_id')->change();
-            $table->integer('bot_id')->change();
-            $table->integer('target_id')->change();
+            $table->integer('room_id')->nullable()->change();
+            $table->integer('bot_id')->nullable()->change();
+            $table->integer('target_id')->nullable()->change();
         });
     }
 };

--- a/database/migrations/2021_01_06_360572_update_nfo_column_on_torrents_table.php
+++ b/database/migrations/2021_01_06_360572_update_nfo_column_on_torrents_table.php
@@ -25,7 +25,7 @@ return new class () extends Migration {
     public function up(): void
     {
         Schema::table('torrents', function (Blueprint $table): void {
-            $table->binary('nfo')->change();
+            $table->binary('nfo')->nullable()->change();
         });
     }
 };

--- a/database/migrations/2022_11_24_032502_update_torrents_table.php
+++ b/database/migrations/2022_11_24_032502_update_torrents_table.php
@@ -54,10 +54,10 @@ return new class () extends Migration {
             ->update(['mal' => '0']);
 
         Schema::table('torrents', function (Blueprint $table): void {
-            $table->integer('imdb')->unsigned()->change();
-            $table->integer('tvdb')->unsigned()->change();
-            $table->integer('tmdb')->unsigned()->change();
-            $table->integer('mal')->unsigned()->change();
+            $table->integer('imdb')->unsigned()->default(0)->change();
+            $table->integer('tvdb')->unsigned()->default(0)->change();
+            $table->integer('tmdb')->unsigned()->default(0)->change();
+            $table->integer('mal')->unsigned()->default(0)->change();
         });
     }
 };

--- a/database/migrations/2022_11_24_032521_update_requests_table.php
+++ b/database/migrations/2022_11_24_032521_update_requests_table.php
@@ -54,10 +54,10 @@ return new class () extends Migration {
             ->update(['mal' => '0']);
 
         Schema::table('requests', function (Blueprint $table): void {
-            $table->integer('imdb')->unsigned()->change();
-            $table->integer('tvdb')->unsigned()->change();
-            $table->integer('tmdb')->unsigned()->change();
-            $table->integer('mal')->unsigned()->change();
+            $table->integer('imdb')->unsigned()->nullable()->change();
+            $table->integer('tvdb')->unsigned()->nullable()->change();
+            $table->integer('tmdb')->unsigned()->nullable()->change();
+            $table->integer('mal')->unsigned()->nullable()->change();
         });
     }
 };

--- a/database/migrations/2022_11_29_030020_alter_user_id.php
+++ b/database/migrations/2022_11_29_030020_alter_user_id.php
@@ -515,7 +515,7 @@ return new class () extends Migration {
         });
 
         Schema::table('peers', function (Blueprint $table): void {
-            $table->unsignedInteger('user_id')->change();
+            $table->unsignedInteger('user_id')->nullable()->change();
             $table->dropIndex('fk_peers_users1_idx');
             $table->foreign('user_id')->references('id')->on('users')->cascadeOnUpdate();
         });
@@ -574,11 +574,11 @@ return new class () extends Migration {
             $table->dropIndex('requests_user_id_foreign');
             $table->foreign('user_id')->references('id')->on('users')->cascadeOnUpdate();
 
-            $table->unsignedInteger('filled_by')->change();
+            $table->unsignedInteger('filled_by')->nullable()->change();
             $table->dropIndex('filled_by');
             $table->foreign('filled_by')->references('id')->on('users')->cascadeOnUpdate();
 
-            $table->unsignedInteger('approved_by')->change();
+            $table->unsignedInteger('approved_by')->nullable()->change();
             $table->dropIndex('approved_by');
             $table->foreign('approved_by')->references('id')->on('users')->cascadeOnUpdate();
         });

--- a/database/migrations/2022_12_22_004317_update_peers_table.php
+++ b/database/migrations/2022_12_22_004317_update_peers_table.php
@@ -39,11 +39,10 @@ return new class () extends Migration {
             $table->boolean('seeder')->nullable(false)->change();
             $table->unsignedInteger('torrent_id')->nullable(false)->change();
             $table->unsignedInteger('user_id')->nullable(false)->change();
+            $table->binary('peer_id', length: 20, fixed: true)->change();
+            $table->binary('ip', length: 16, fixed: true)->change();
         });
 
         Schema::enableForeignKeyConstraints();
-
-        DB::statement('ALTER TABLE `peers` MODIFY `peer_id` BINARY(20) NOT NULL');
-        DB::statement('ALTER TABLE `peers` MODIFY `ip` VARBINARY(16) NOT NULL');
     }
 };

--- a/database/migrations/2023_04_08_053641_alter_torrents_table.php
+++ b/database/migrations/2023_04_08_053641_alter_torrents_table.php
@@ -25,7 +25,10 @@ return new class () extends Migration {
      */
     public function up(): void
     {
-        DB::statement("ALTER TABLE torrents ADD COLUMN info_hash2 BINARY(20) NOT NULL");
+        Schema::table('torrents', function (Blueprint $table): void {
+            $table->binary('info_hash2', length: 20, fixed: true);
+        });
+
         DB::table('torrents')->update([
             'info_hash2' => DB::raw('UNHEX(info_hash)'),
             'updated_at' => DB::raw('updated_at'),

--- a/database/migrations/2023_07_22_023920_alter_movie_and_tv_ids.php
+++ b/database/migrations/2023_07_22_023920_alter_movie_and_tv_ids.php
@@ -61,16 +61,16 @@ return new class () extends Migration {
         });
 
         Schema::table('recommendations', function (Blueprint $table): void {
-            $table->unsignedInteger('movie_id')->change();
+            $table->unsignedInteger('movie_id')->nullable()->change();
             $table->foreign('movie_id')->references('id')->on('movie')->cascadeOnUpdate()->cascadeOnDelete();
 
-            $table->unsignedInteger('recommendation_movie_id')->change();
+            $table->unsignedInteger('recommendation_movie_id')->nullable()->change();
             $table->foreign('recommendation_movie_id')->references('id')->on('movie')->cascadeOnUpdate()->cascadeOnDelete();
 
-            $table->unsignedInteger('tv_id')->change();
+            $table->unsignedInteger('tv_id')->nullable()->change();
             $table->foreign('tv_id')->references('id')->on('tv')->cascadeOnUpdate()->cascadeOnDelete();
 
-            $table->unsignedInteger('recommendation_tv_id')->change();
+            $table->unsignedInteger('recommendation_tv_id')->nullable()->change();
             $table->foreign('recommendation_tv_id')->references('id')->on('tv')->cascadeOnUpdate()->cascadeOnDelete();
         });
 

--- a/database/migrations/2023_08_13_234828_add_forum_foreign_key_constraints.php
+++ b/database/migrations/2023_08_13_234828_add_forum_foreign_key_constraints.php
@@ -35,7 +35,7 @@ return new class () extends Migration {
             ->delete();
 
         Schema::table('subscriptions', function (Blueprint $table): void {
-            $table->unsignedInteger('topic_id')->change();
+            $table->unsignedInteger('topic_id')->nullable()->change();
             $table->foreign('topic_id')->references('id')->on('topics')->cascadeOnUpdate()->cascadeOnDelete();
         });
 
@@ -61,7 +61,7 @@ return new class () extends Migration {
             ]);
 
         Schema::table('forums', function (Blueprint $table): void {
-            $table->unsignedInteger('last_topic_id')->change();
+            $table->unsignedInteger('last_topic_id')->nullable()->change();
             $table->foreign('last_topic_id')->references('id')->on('topics')->cascadeOnUpdate()->nullOnDelete();
         });
 
@@ -79,7 +79,7 @@ return new class () extends Migration {
             ->delete();
 
         Schema::table('subscriptions', function (Blueprint $table): void {
-            $table->unsignedSmallInteger('forum_id')->change();
+            $table->unsignedSmallInteger('forum_id')->nullable()->change();
             $table->foreign('forum_id')->references('id')->on('forums')->cascadeOnUpdate()->cascadeOnDelete();
         });
 
@@ -116,7 +116,7 @@ return new class () extends Migration {
             ]);
 
         Schema::table('forums', function (Blueprint $table): void {
-            $table->unsignedSmallInteger('parent_id')->change();
+            $table->unsignedSmallInteger('parent_id')->nullable()->change();
             $table->foreign('parent_id')->references('id')->on('forums')->cascadeOnUpdate()->nullOnDelete();
         });
     }

--- a/database/migrations/2023_11_16_122533_create_announces.php
+++ b/database/migrations/2023_11_16_122533_create_announces.php
@@ -29,6 +29,7 @@ return new class () extends Migration {
             $table->unsignedBigInteger('downloaded');
             $table->unsignedBigInteger('left');
             $table->unsignedBigInteger('corrupt');
+            $table->binary('peer_id', length: 20, fixed: true);
             $table->unsignedSmallInteger('port');
             $table->unsignedSmallInteger('numwant');
             $table->timestamp('created_at')->useCurrent();
@@ -37,7 +38,5 @@ return new class () extends Migration {
 
             $table->index(['user_id', 'torrent_id']);
         });
-
-        DB::statement("ALTER TABLE announces ADD COLUMN peer_id BINARY(20) NOT NULL AFTER corrupt");
     }
 };


### PR DESCRIPTION
In laravel 11, they changed the syntax for changing columns so that all constraints are removed and reapplied, compared to only adding constraints that weren't added before. I generated the sql code of each migration on laravel 10, and the same on laravel 11, and compared the sql code between the two versions and changed the migrations so that the sql matched between the two versions.

Should hopefully fix #3829

Thank you Laravel for another sleepless night.