### PR TITLE
(Update) Save prewarned timestamp

### DIFF
--- a/app/Console/Commands/AutoPreWarning.php
+++ b/app/Console/Commands/AutoPreWarning.php
@@ -50,7 +50,7 @@ class AutoPreWarning extends Command
         if (config('hitrun.enabled') === true) {
             $carbon = new Carbon();
             $prewarn = History::with(['user', 'torrent'])
-                ->where('prewarn', '=', 0)
+                ->whereNull('prewarned_at')
                 ->where('hitrun', '=', 0)
                 ->where('immune', '=', 0)
                 ->where('actual_downloaded', '>', 0)
@@ -73,7 +73,7 @@ class AutoPreWarning extends Command
                         ->first();
 
                     if ($exsist === null) {
-                        $pre->prewarn = true;
+                        $pre->prewarned_at = now();
                         $pre->timestamps = false;
                         $pre->save();
 

--- a/app/Console/Commands/AutoWarning.php
+++ b/app/Console/Commands/AutoWarning.php
@@ -54,7 +54,7 @@ class AutoWarning extends Command
             $carbon = new Carbon();
             $hitrun = History::with(['user', 'torrent'])
                 ->where('actual_downloaded', '>', 0)
-                ->where('prewarn', '=', 1)
+                ->where('prewarned_at', '<=', now()->subDays(config('hitrun.prewarn')))
                 ->where('hitrun', '=', 0)
                 ->where('immune', '=', 0)
                 ->where('active', '=', 0)

--- a/app/Http/Livewire/HistorySearch.php
+++ b/app/Http/Livewire/HistorySearch.php
@@ -117,7 +117,7 @@ class HistorySearch extends Component
                         DB::raw('MAX(updated_at) AS updated_at_max'),
                         DB::raw('SUM(active AND seeder) AS seeding_count'),
                         DB::raw('SUM(active AND NOT seeder) AS leeching_count'),
-                        DB::raw('SUM(prewarn = 1) AS prewarn_count'),
+                        DB::raw('SUM(prewarned_at IS NOT NULL) AS prewarn_count'),
                         DB::raw('SUM(hitrun = 1) AS hitrun_count'),
                         DB::raw('SUM(immune = 1) AS immune_count'),
                     ])
@@ -142,7 +142,7 @@ class HistorySearch extends Component
                         'completed_at',
                         DB::raw('active AND seeder AS seeding'),
                         DB::raw('active AND NOT seeder AS leeching '),
-                        'prewarn',
+                        'prewarned_at',
                         'hitrun',
                         'immune',
                     ])

--- a/app/Http/Livewire/UserTorrents.php
+++ b/app/Http/Livewire/UserTorrents.php
@@ -115,7 +115,7 @@ class UserTorrents extends Component
                 'history.completed_at',
                 'history.immune',
                 'history.hitrun',
-                'history.prewarn',
+                'history.prewarned_at',
                 'torrents.name',
                 'torrents.seeders',
                 'torrents.leechers',
@@ -156,8 +156,8 @@ class UserTorrents extends Component
             ->when($this->active === 'exclude', fn ($query) => $query->where(fn ($query) => $query->where('active', '=', 0)->orWhereNull('active')))
             ->when($this->completed === 'include', fn ($query) => $query->where('seeder', '=', 1))
             ->when($this->completed === 'exclude', fn ($query) => $query->where(fn ($query) => $query->where('seeder', '=', 0)->orWhereNull('seeder')))
-            ->when($this->prewarn === 'include', fn ($query) => $query->where('prewarn', '=', 1))
-            ->when($this->prewarn === 'exclude', fn ($query) => $query->where(fn ($query) => $query->where('prewarn', '=', 0)->orWhereNull('prewarn')))
+            ->when($this->prewarn === 'include', fn ($query) => $query->whereNotNull('prewarned_at'))
+            ->when($this->prewarn === 'exclude', fn ($query) => $query->whereNull('prewarned_at'))
             ->when($this->hitrun === 'include', fn ($query) => $query->where('hitrun', '=', 1))
             ->when($this->hitrun === 'exclude', fn ($query) => $query->where(fn ($query) => $query->where('hitrun', '=', 0)->orWhereNull('hitrun')))
             ->when($this->immune === 'include', fn ($query) => $query->where('immune', '=', 1))

--- a/app/Models/History.php
+++ b/app/Models/History.php
@@ -23,23 +23,23 @@ use DateTimeInterface;
 /**
  * App\Models\History.
  *
- * @property int    $id
- * @property int    $user_id
- * @property int    $torrent_id
- * @property string $agent
- * @property int    $uploaded
- * @property int    $actual_uploaded
- * @property int    $client_uploaded
- * @property int    $downloaded
- * @property int    $refunded_download
- * @property int    $actual_downloaded
- * @property int    $client_downloaded
- * @property int    $seeder
- * @property int    $active
- * @property int    $seedtime
- * @property int    $immune
- * @property bool   $hitrun
- * @property bool   $prewarn
+ * @property int                             $id
+ * @property int                             $user_id
+ * @property int                             $torrent_id
+ * @property string                          $agent
+ * @property int                             $uploaded
+ * @property int                             $actual_uploaded
+ * @property int                             $client_uploaded
+ * @property int                             $downloaded
+ * @property int                             $refunded_download
+ * @property int                             $actual_downloaded
+ * @property int                             $client_downloaded
+ * @property int                             $seeder
+ * @property int                             $active
+ * @property int                             $seedtime
+ * @property int                             $immune
+ * @property bool                            $hitrun
+ * @property \Illuminate\Support\Carbon|null $prewarned_at
  */
 class History extends Model
 {
@@ -62,14 +62,14 @@ class History extends Model
     /**
      * Get the attributes that should be cast.
      *
-     * @return array{completed_at: 'datetime', hitrun: 'bool', prewarn: 'bool'}
+     * @return array{completed_at: 'datetime', hitrun: 'bool', prewarned_at: 'datetime'}
      */
     protected function casts(): array
     {
         return [
             'completed_at' => 'datetime',
             'hitrun'       => 'bool',
-            'prewarn'      => 'bool',
+            'prewarned_at' => 'datetime',
         ];
     }
 

--- a/database/factories/HistoryFactory.php
+++ b/database/factories/HistoryFactory.php
@@ -50,7 +50,7 @@ class HistoryFactory extends Factory
             'seedtime'          => $this->faker->randomNumber(),
             'immune'            => $this->faker->boolean(),
             'hitrun'            => $this->faker->boolean(),
-            'prewarn'           => $this->faker->boolean(),
+            'prewarned_at'      => $this->faker->dateTime(),
             'completed_at'      => $this->faker->dateTime(),
         ];
     }

--- a/database/migrations/2024_06_23_202341_add_prewarned_at_to_history.php
+++ b/database/migrations/2024_06_23_202341_add_prewarned_at_to_history.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * NOTICE OF LICENSE.
+ *
+ * UNIT3D Community Edition is open-sourced software licensed under the GNU Affero General Public License v3.0
+ * The details is bundled with this project in the file LICENSE.txt.
+ *
+ * @project    UNIT3D Community Edition
+ *
+ * @author     HDVinnie <hdinnovations@protonmail.com>
+ * @license    https://www.gnu.org/licenses/agpl-3.0.en.html/ GNU Affero General Public License v3.0
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('history', function (Blueprint $table): void {
+            $table->timestamp('prewarned_at')->nullable()->after('hitrun');
+            $table->dropIndex('history_idx_prewa_hitru_immun_activ_actua');
+            $table->dropColumn('prewarn');
+            $table->index(['prewarned_at', 'hitrun', 'immune', 'active', 'actual_downloaded'], 'history_idx_prewa_hitru_immun_activ_actua');
+        });
+    }
+};

--- a/resources/sass/components/_user-torrents.scss
+++ b/resources/sass/components/_user-torrents.scss
@@ -41,9 +41,9 @@
 .user-torrents__created-at-header,
 .user-torrents__updated-at-header,
 .user-torrents__completed-at-header,
+.user-torrents__prewarned-header,
 .user-torrents__seeding-header,
 .user-torrents__leeching-header,
-.user-torrents__prewarned-header,
 .user-torrents__warned-header,
 .user-torrents__immune-header,
 .user-torrents__uploader-header,
@@ -66,13 +66,13 @@
 .user-torrents__seedtime,
 .user-torrents__created-at,
 .user-torrents__updated-at,
-.user-torrents__completed-at {
+.user-torrents__completed-at,
+.user-torrents__prewarned {
     font-size: 14px;
 }
 
 .user-torrents__seeding,
 .user-torrents__leeching,
-.user-torrents__prewarned,
 .user-torrents__warned,
 .user-torrents__immune,
 .user-torrents__uploader,
@@ -103,14 +103,12 @@
 
 .user-torrents__seeding-header,
 .user-torrents__leeching-header,
-.user-torrents__prewarned-header,
 .user-torrents__warned-header,
 .user-torrents__immune-header,
 .user-torrents__uploader-header,
 .user-torrents__status-header,
 .user-torrents__seeding,
 .user-torrents__leeching,
-.user-torrents__prewarned,
 .user-torrents__warned,
 .user-torrents__immune,
 .user-torrents__uploader,

--- a/resources/views/livewire/history-search.blade.php
+++ b/resources/views/livewire/history-search.blade.php
@@ -376,6 +376,13 @@
                                     @include('livewire.includes._sort-icon', ['field' => 'history.completed_at'])
                                 </th>
                                 <th
+                                    wire:click="sortBy('history.prewarned_at')"
+                                    role="columnheader button"
+                                >
+                                    {{ __('torrent.prewarn') }}
+                                    @include('livewire.includes._sort-icon', ['field' => 'history.prewarned_at'])
+                                </th>
+                                <th
                                     wire:click="sortBy('history.seedtime')"
                                     role="columnheader button"
                                 >
@@ -389,13 +396,6 @@
                                 <th wire:click="sortBy('leeching')" role="columnheader button">
                                     {{ __('torrent.leeching') }}
                                     @include('livewire.includes._sort-icon', ['field' => 'leeching'])
-                                </th>
-                                <th
-                                    wire:click="sortBy('prewarn')"
-                                    role="columnheader button"
-                                    title="{{ __('torrent.prewarn') }}"
-                                >
-                                    <i class="fas fa-exclamation"></i>
                                 </th>
                                 <th
                                     wire:click="sortBy('hitrun')"
@@ -472,6 +472,14 @@
                                             {{ $history->completed_at ? $history->completed_at->diffForHumans() : 'N/A' }}
                                         </time>
                                     </td>
+                                    <td>
+                                        <time
+                                            datetime="{{ $history->prewarned_at }}"
+                                            title="{{ $history->prewarned_at }}"
+                                        >
+                                            {{ $history->prewarned_at ? $history->prewarned_at->diffForHumans() : 'N/A' }}
+                                        </time>
+                                    </td>
 
                                     @if ($history->seedtime < config('hitrun.seedtime'))
                                         <td
@@ -539,19 +547,6 @@
                                             <i
                                                 class="{{ config('other.font-awesome') }} text-red fa-times"
                                                 title="Not warned"
-                                            ></i>
-                                        @endif
-                                    </td>
-                                    <td>
-                                        @if ($history->prewarn)
-                                            <i
-                                                class="{{ config('other.font-awesome') }} text-green fa-check"
-                                                title="Prewarned"
-                                            ></i>
-                                        @else
-                                            <i
-                                                class="{{ config('other.font-awesome') }} text-red fa-times"
-                                                title="Not Prewarned"
                                             ></i>
                                         @endif
                                     </td>

--- a/resources/views/livewire/user-torrents.blade.php
+++ b/resources/views/livewire/user-torrents.blade.php
@@ -368,6 +368,14 @@
                         @include('livewire.includes._sort-icon', ['field' => 'completed_at'])
                     </th>
                     <th
+                        class="user-torrents__prewarned-header"
+                        wire:click="sortBy('prewarn')"
+                        role="columnheader button"
+                    >
+                        {{ __('torrent.prewarn') }}
+                        @include('livewire.includes._sort-icon', ['field' => 'prewarned_at'])
+                    </th>
+                    <th
                         class="user-torrents__seeding-header"
                         wire:click="sortBy('seeding')"
                         role="columnheader button"
@@ -382,14 +390,6 @@
                         title="{{ __('torrent.leeching') }}"
                     >
                         <i class="fas fa-arrow-down"></i>
-                    </th>
-                    <th
-                        class="user-torrents__prewarned-header"
-                        wire:click="sortBy('prewarn')"
-                        role="columnheader button"
-                        title="{{ __('torrent.prewarn') }}"
-                    >
-                        <i class="fas fa-exclamation"></i>
                     </th>
                     <th
                         class="user-torrents__warned-header"
@@ -563,6 +563,14 @@
                                         {{ $history->completed_at ?? 'N/A' }}
                                     </time>
                                 </td>
+                                <td class="user-torrents__prewarned-at">
+                                    <time
+                                        datetime="{{ $history->prewarned_at }}"
+                                        title="{{ $history->prewarned_at }}"
+                                    >
+                                        {{ $history->prewarned_at ?? 'N/A' }}
+                                    </time>
+                                </td>
                             @else
                                 <td class="user-torrents__leechtime">
                                     @if ($history->leechtime === null)
@@ -606,6 +614,15 @@
                                         {{ $history->completed_at === null ? 'N/A' : \explode(' ', $history->completed_at)[0] }}
                                     </time>
                                 </td>
+
+                                <td class="user-torrents__prewarned-at">
+                                    <time
+                                        datetime="{{ $history->prewarned_at }}"
+                                        title="{{ $history->prewarned_at }}"
+                                    >
+                                        {{ $history->prewarned_at === null ? 'N/A' : \explode(' ', $history->prewarned_at)[0] }}
+                                    </time>
+                                </td>
                             @endif
                             <td class="user-torrents__seeding">
                                 @if ($history->seeding == 1)
@@ -630,19 +647,6 @@
                                     <i
                                         class="{{ config('other.font-awesome') }} text-red fa-times"
                                         title="Not {{ __('torrent.leeching') }}"
-                                    ></i>
-                                @endif
-                            </td>
-                            <td class="user-torrents__prewarned">
-                                @if ($history->prewarn == 1)
-                                    <i
-                                        class="{{ config('other.font-awesome') }} fa-check text-green"
-                                        title="Prewarned"
-                                    ></i>
-                                @else
-                                    <i
-                                        class="{{ config('other.font-awesome') }} fa-times text-red"
-                                        title="Not prewarned"
                                     ></i>
                                 @endif
                             </td>


### PR DESCRIPTION
Allows users to more easily see when they were prewarned in case they no longer have their notification.

It was decided to discard previous prewarn values and have the system prewarn users again if applicable.

It was decided that keeping the history of prewarn values wasn't valuable for this migration.