### PR TITLE
(Fix) Comments disappear after replying

### DIFF
--- a/app/Http/Livewire/Comments.php
+++ b/app/Http/Livewire/Comments.php
@@ -212,7 +212,6 @@ class Comments extends Component
         return $this->model
             ->comments()
             ->with(['user:id,username,group_id,image,title', 'user.group', 'children.user:id,username,group_id,image,title', 'children.user.group'])
-            ->withExists('children')
             ->parent()
             ->latest()
             ->paginate($this->perPage);

--- a/resources/views/livewire/comment.blade.php
+++ b/resources/views/livewire/comment.blade.php
@@ -9,7 +9,7 @@
                 {{ $comment->created_at?->diffForHumans() }}
             </time>
             <menu class="comment__toolbar">
-                @if ($comment->isParent() && ! $comment->children_exists)
+                @if ($comment->isParent() && $comment->children()->doesntExist())
                     <li class="comment__toolbar-item">
                         <button wire:click="$toggle('isReplying')" class="comment__reply">
                             <abbr class="comment__reply-abbr" title="Reply to this comment">
@@ -123,7 +123,7 @@
     @if ($comment->isParent())
         <section class="comment__replies">
             <h5 class="sr-only">Replies</h5>
-            @if (! $comment->children_exists)
+            @if ($comment->children()->exists())
                 <ul class="comment__reply-list">
                     @foreach ($comment->children as $child)
                         <livewire:comment :comment="$child" :key="$child->id" />
@@ -131,7 +131,7 @@
                 </ul>
             @endif
 
-            @if ($isReplying || ! $comment->children_exists)
+            @if ($isReplying || $comment->children()->exists())
                 <form wire:submit="postReply" class="form reply-comment" x-data="toggle">
                     <p class="form__group">
                         <textarea

--- a/resources/views/livewire/comment.blade.php
+++ b/resources/views/livewire/comment.blade.php
@@ -123,7 +123,7 @@
     @if ($comment->isParent())
         <section class="comment__replies">
             <h5 class="sr-only">Replies</h5>
-            @if ($comment->children_exists)
+            @if (! $comment->children_exists)
                 <ul class="comment__reply-list">
                     @foreach ($comment->children as $child)
                         <livewire:comment :comment="$child" :key="$child->id" />
@@ -131,7 +131,7 @@
                 </ul>
             @endif
 
-            @if ($isReplying || $comment->children_exists)
+            @if ($isReplying || ! $comment->children_exists)
                 <form wire:submit="postReply" class="form reply-comment" x-data="toggle">
                     <p class="form__group">
                         <textarea


### PR DESCRIPTION
Using eager loading prevents nested livewire components to refresh individually after a reply is made.

Not entirely sure why this doesn't work... but I've lost too much sleep trying to make it work so I give up for now.