### PR TITLE
(Fix) Remove version from `docker-compose.yml`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
     nginx:
         image: 'nginx:latest'


### PR DESCRIPTION
This key is deprecated and no longer means anything. Fixes the following deprecation warning when running sail commands:

```
WARN[0000] /[...]/UNIT3D-Community-Edition/docker-compose.yml: `version` is obsolete
```