### PR TITLE
(FIX) Appending missing colon to the function privmsg 

### DIFF
--- a/app/Bots/IRCAnnounceBot.php
+++ b/app/Bots/IRCAnnounceBot.php
@@ -219,7 +219,7 @@ class IRCAnnounceBot
      */
     private function privmsg(string $receiver, string $textToBeSent): void
     {
-        $this->send("PRIVMSG {$receiver} {$textToBeSent}");
+        $this->send("PRIVMSG {$receiver} :{$textToBeSent}");
     }
 
     /**

--- a/app/Helpers/TorrentHelper.php
+++ b/app/Helpers/TorrentHelper.php
@@ -133,15 +133,15 @@ class TorrentHelper
 
             (new IRCAnnounceBot())
                 ->to(config('irc-bot.channel'))
-                ->say(':['.config('app.name').'] '.($anon ? 'An anonymous user' : $username).' has uploaded '.$torrent->name.' grab it now!')
+                ->say('['.config('app.name').'] '.($anon ? 'An anonymous user' : $username).' has uploaded '.$torrent->name.' grab it now!')
                 ->say(
-                    ':[Category: '.$category->name.'] '
+                    '[Category: '.$category->name.'] '
                     .'[Type: '.$torrent->type->name.'] '
                     .'[Size: '.$torrent->getSize().'] '
                     .'[TMDB vote average: '.($meta->vote_average ?? 0).'] '
                     .'[TMDB vote count: '.($meta->vote_count ?? 0).']'
                 )
-                ->say(sprintf(':[Link: %s/torrents/', $appurl).$id.']');
+                ->say(sprintf('[Link: %s/torrents/', $appurl).$id.']');
         }
 
         cache()->forget('announce-torrents:by-infohash:'.$torrent->info_hash);


### PR DESCRIPTION
Appending the parameter delimiter straight to the function `privmsg` instead of doing it for each message.

Reference: https://github.com/HDInnovations/UNIT3D-Community-Edition/pull/3950#issuecomment-2193108026