### PR TITLE
(Update) Moderation Private Message

### DIFF
--- a/app/Http/Controllers/Staff/ModerationController.php
+++ b/app/Http/Controllers/Staff/ModerationController.php
@@ -114,14 +114,14 @@ class ModerationController extends Controller
                     'moderated_by' => $staff->id,
                 ]);
 
-                $conversation = Conversation::create(['subject' => 'Your upload, '.$torrent->name.' ,has been rejected by '.$staff->username]);
+                $conversation = Conversation::create(['subject' => 'Your upload, '.$torrent->name.', has been rejected by '.$staff->username]);
 
-                $conversation->users()->sync([$staff->id, $torrent->user_id]);
+                $conversation->users()->sync([$staff->id => ['read' => true], $torrent->user_id]);
 
                 PrivateMessage::create([
                     'conversation_id' => $conversation->id,
                     'sender_id'       => $staff->id,
-                    'message'         => "Greetings, \n\nYour upload ".$torrent->name." has been rejected. Please see below the message from the staff member.\n\n".$request->message,
+                    'message'         => "Greetings, \n\nYour upload [url=".config('app.url')."/torrents/".$id."]".$torrent->name."[/url] has been rejected. Please see below the message from the staff member.\n\n[quote=".$staff->username."]".$request->message."[/quote]",
                 ]);
 
                 cache()->forget('announce-torrents:by-infohash:'.$torrent->info_hash);
@@ -138,14 +138,14 @@ class ModerationController extends Controller
                     'moderated_by' => $staff->id,
                 ]);
 
-                $conversation = Conversation::create(['subject' => 'Your upload, '.$torrent->name.' ,has been postponed by '.$staff->username]);
+                $conversation = Conversation::create(['subject' => 'Your upload, '.$torrent->name.', has been postponed by '.$staff->username]);
 
-                $conversation->users()->sync([$staff->id, $torrent->user_id]);
+                $conversation->users()->sync([$staff->id => ['read' => true], $torrent->user_id]);
 
                 PrivateMessage::create([
                     'conversation_id' => $conversation->id,
                     'sender_id'       => $staff->id,
-                    'message'         => "Greetings, \n\nYour upload, ".$torrent->name." ,has been postponed. Please see below the message from the staff member.\n\n".$request->message,
+                    'message'         => "Greetings, \n\nYour upload [url=".config('app.url')."/torrents/".$id."]".$torrent->name."[/url] has been postponed. Please see below the message from the staff member.\n\n[quote=".$staff->username."]".$request->message."[/quote]",
                 ]);
 
                 cache()->forget('announce-torrents:by-infohash:'.$torrent->info_hash);

--- a/app/Http/Controllers/Staff/ModerationController.php
+++ b/app/Http/Controllers/Staff/ModerationController.php
@@ -121,7 +121,7 @@ class ModerationController extends Controller
                 PrivateMessage::create([
                     'conversation_id' => $conversation->id,
                     'sender_id'       => $staff->id,
-                    'message'         => "Greetings, \n\nYour upload [url=".config('app.url')."/torrents/".$id."]".$torrent->name."[/url] has been rejected. Please see below the message from the staff member.\n\n[quote=".$staff->username."]".$request->message."[/quote]",
+                    'message'         => "Greetings, \n\nYour upload, [url=/torrents/".$id.']'.$torrent->name."[/url], has been rejected. Please see below the message from the staff member.\n\n[quote=".$staff->username.']'.$request->message.'[/quote]',
                 ]);
 
                 cache()->forget('announce-torrents:by-infohash:'.$torrent->info_hash);
@@ -145,7 +145,7 @@ class ModerationController extends Controller
                 PrivateMessage::create([
                     'conversation_id' => $conversation->id,
                     'sender_id'       => $staff->id,
-                    'message'         => "Greetings, \n\nYour upload [url=".config('app.url')."/torrents/".$id."]".$torrent->name."[/url] has been postponed. Please see below the message from the staff member.\n\n[quote=".$staff->username."]".$request->message."[/quote]",
+                    'message'         => "Greetings, \n\nYour upload, [url=/torrents/".$id.']'.$torrent->name."[/url], has been postponed. Please see below the message from the staff member.\n\n[quote=".$staff->username.']'.$request->message.'[/quote]',
                 ]);
 
                 cache()->forget('announce-torrents:by-infohash:'.$torrent->info_hash);


### PR DESCRIPTION
- Fix: Spacing typo.
- Fix: Set sender as read=true.
- Update: Add the URL to the message.
- Update: Add a quote tag around the staff message.