### PR TITLE
(Fix) Torrent search playlist filter

### DIFF
--- a/app/Traits/TorrentFilter.php
+++ b/app/Traits/TorrentFilter.php
@@ -240,10 +240,12 @@ trait TorrentFilter
                 ->where('playlist_id', '=', $playlistId)
                 ->when(
                     $authenticatedUser === null,
-                    fn ($query) => $query->where('is_private', '=', false),
+                    fn ($query) => $query->whereRelation('playlist', 'is_private', '=', false),
                     fn ($query) => $query->when(
                         ! $authenticatedUser->group->is_modo,
-                        fn ($query) => $query->where(fn ($query) => $query->where('is_private', '=', false)->orWhere('user_id', '=', $authenticatedUser->id))
+                        fn ($query) => $query->where(fn ($query) => $query
+                            ->whereRelation('playlist', 'is_private', '=', false)
+                            ->orWhereRelation('playlist', 'user_id', '=', $authenticatedUser->id))
                     )
                 )
         );


### PR DESCRIPTION
We need to filter the given columns on the `playlists` table, not the `playlist_torrent` table.