### PR TITLE
(Fix) `bounty->request` relationship

### DIFF
--- a/app/Models/TorrentRequestBounty.php
+++ b/app/Models/TorrentRequestBounty.php
@@ -82,6 +82,6 @@ class TorrentRequestBounty extends Model
      */
     public function request(): \Illuminate\Database\Eloquent\Relations\BelongsTo
     {
-        return $this->belongsTo(TorrentRequest::class);
+        return $this->belongsTo(TorrentRequest::class, 'requests_id');
     }
 }


### PR DESCRIPTION
The foreign key isn't the standard name, so we have to customize it, otherwise our relations return `null`.