### PR TITLE
(Fix) Double url encoding in bbcode comparison

### DIFF
--- a/resources/views/partials/comparison.blade.php
+++ b/resources/views/partials/comparison.blade.php
@@ -58,7 +58,7 @@
 
                                 <img
                                     class="comparison__image"
-                                    src="{{ $url }}"
+                                    src="{!! $url !!}"
                                     loading="lazy"
                                     x-bind:class="screen != {{ $loop->iteration }} && 'comparison__image--hidden'"
                                 />


### PR DESCRIPTION
The url is already sanitized and ran through `htmlspecialchars` at the end of the `sanitizeUrl` function. When using `{{ }}`, laravel runs the url through `htmlspecialchars` a second time, which breaks the url. Since the url is already properly sanitized, we can safely display the data without escaping in blade a second time.