### PR TITLE
(Update) Use composite primary key for peers

### DIFF
--- a/app/Http/Controllers/AnnounceController.php
+++ b/app/Http/Controllers/AnnounceController.php
@@ -420,7 +420,7 @@ final class AnnounceController extends Controller
         // If we use eager loading, then laravel will use `where torrent_id in (123)` instead of `where torrent_id = ?`
         $torrent->setRelation(
             'peers',
-            Peer::select(['id', 'torrent_id', 'peer_id', 'user_id', 'downloaded', 'uploaded', 'left', 'seeder', 'active', 'visible', 'ip', 'port', 'updated_at'])
+            Peer::select(['torrent_id', 'peer_id', 'user_id', 'downloaded', 'uploaded', 'left', 'seeder', 'active', 'visible', 'ip', 'port', 'updated_at'])
                 ->where('torrent_id', '=', $torrent->id)
                 ->get()
         );

--- a/app/Http/Controllers/Staff/FlushController.php
+++ b/app/Http/Controllers/Staff/FlushController.php
@@ -45,7 +45,7 @@ class FlushController extends Controller
     public function peers(): \Illuminate\Http\RedirectResponse
     {
         $carbon = new Carbon();
-        $peers = Peer::select(['id', 'torrent_id', 'user_id', 'updated_at'])->where('updated_at', '<', $carbon->copy()->subHours(2)->toDateTimeString())->get();
+        $peers = Peer::select(['torrent_id', 'user_id', 'peer_id', 'updated_at'])->where('updated_at', '<', $carbon->copy()->subHours(2)->toDateTimeString())->get();
 
         foreach ($peers as $peer) {
             $history = History::where('torrent_id', '=', $peer->torrent_id)->where('user_id', '=', $peer->user_id)->first();
@@ -56,7 +56,11 @@ class FlushController extends Controller
                 $history->save();
             }
 
-            $peer->delete();
+            Peer::query()
+                ->where('torrent_id', '=', $peer->torrent_id)
+                ->where('user_id', '=', $peer->user_id)
+                ->where('peer_id', '=', $peer->peer_id)
+                ->delete();
         }
 
         return to_route('staff.dashboard.index')

--- a/app/Http/Livewire/PeerSearch.php
+++ b/app/Http/Livewire/PeerSearch.php
@@ -132,7 +132,7 @@ class PeerSearch extends Component
                     ->selectRaw('SUM(peers.`left`) as `left`')
                     ->selectRaw('MIN(peers.created_at) as created_at')
                     ->selectRaw('MAX(peers.updated_at) as updated_at')
-                    ->selectRaw('COUNT(DISTINCT(peers.id)) as peer_count')
+                    ->selectRaw('COUNT(DISTINCT(peers.torrent_id, peers.user_id, peers.peer_id)) as peer_count')
                     ->selectRaw('SUM(peers.connectable = 1) as connectable_count')
                     ->selectRaw('SUM(peers.connectable = 0) as unconnectable_count')
                     ->selectRaw('SUM(peers.active = 1) as active_count')

--- a/app/Http/Livewire/UserActive.php
+++ b/app/Http/Livewire/UserActive.php
@@ -88,7 +88,6 @@ class UserActive extends Component
         return Peer::query()
             ->join('torrents', 'peers.torrent_id', '=', 'torrents.id')
             ->select(
-                'peers.id',
                 'peers.port',
                 'peers.agent',
                 'peers.uploaded',

--- a/database/migrations/2024_07_16_083832_add_composite_primary_key_to_peers.php
+++ b/database/migrations/2024_07_16_083832_add_composite_primary_key_to_peers.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * NOTICE OF LICENSE.
+ *
+ * UNIT3D Community Edition is open-sourced software licensed under the GNU Affero General Public License v3.0
+ * The details is bundled with this project in the file LICENSE.txt.
+ *
+ * @project    UNIT3D Community Edition
+ *
+ * @author     Roardom <roardom@protonmail.com>
+ * @license    https://www.gnu.org/licenses/agpl-3.0.en.html/ GNU Affero General Public License v3.0
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('peers', function (Blueprint $table): void {
+            $table->dropColumn('id');
+            $table->primary(['user_id', 'torrent_id', 'peer_id']);
+            $table->dropUnique('peers_user_id_torrent_id_peer_id_unique');
+        });
+    }
+};


### PR DESCRIPTION
The same as was done in #2446 and reverted in ace8dcb but this time using workarounds for Eloquent when it tries to use the non-existing `id` column.