### PR TITLE
(Update) Don't run redundant commands when external tracker is used

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -26,12 +26,17 @@ class Kernel extends ConsoleKernel
      */
     protected function schedule(Schedule $schedule): void
     {
-        $schedule->command('auto:upsert_peers')->everyFiveSeconds();
-        $schedule->command('auto:upsert_histories')->everyFiveSeconds();
-        $schedule->command('auto:upsert_announces')->everyFiveSeconds();
+        if (! config('announce.external_tracker.is_enabled')) {
+            $schedule->command('auto:upsert_peers')->everyFiveSeconds();
+            $schedule->command('auto:upsert_histories')->everyFiveSeconds();
+            $schedule->command('auto:upsert_announces')->everyFiveSeconds();
+            $schedule->command('auto:cache_user_leech_counts')->everyThirtyMinutes();
+            $schedule->command('auto:sync_peers')->everyFiveMinutes();
+            $schedule->command('auto:torrent_balance')->hourly();
+        }
+
         $schedule->command('auto:update_user_last_actions')->everyFiveSeconds();
         $schedule->command('auto:delete_stopped_peers')->everyTwoMinutes();
-        $schedule->command('auto:cache_user_leech_counts')->everyThirtyMinutes();
         $schedule->command('auto:group ')->daily();
         $schedule->command('auto:nerdstat ')->hourly();
         $schedule->command('auto:cache_random_media')->hourly();
@@ -52,13 +57,11 @@ class Kernel extends ConsoleKernel
         $schedule->command('auto:recycle_claimed_torrent_requests')->daily();
         $schedule->command('auto:delete_unparticipated_conversations')->daily();
         $schedule->command('auto:correct_history')->daily();
-        $schedule->command('auto:sync_peers')->everyFiveMinutes();
         $schedule->command('auto:email-blacklist-update')->weekends();
         $schedule->command('auto:reset_user_flushes')->daily();
         $schedule->command('auto:stats_clients')->daily();
         $schedule->command('auto:remove_torrent_buffs')->hourly();
         $schedule->command('auto:refund_download')->daily();
-        $schedule->command('auto:torrent_balance')->hourly();
         $schedule->command('auth:clear-resets')->daily();
         $schedule->command('fetch:release_years')->everyTenMinutes();
         //$schedule->command('auto:ban_disposable_users')->weekends();


### PR DESCRIPTION
The external tracker handles the upserts (`auto:upsert_peers`, `auto:upsert_histories`, and `auto:upsert_announces`), handles incrementing/decrementing the seeders/leeches/times_completed (`auto:sync_peers`), and handles incrementing/decrementing the balance (`auto:torrent_balance`).

The external tracker keeps track of leech slots internally, so the leech slot caching isn't needed and as a result, shouldn't be touched inside the `auto:flush_peers` command either.

There's no inaccurate stats issues that could happen if these commands are run, but a normal 200 ms 3000-record upsert from the external tracker takes 2-3 seconds if they happen at the same time as the `auto:sync_peers` or `auto:torrent_balance` commands are being run.