### PR TITLE
(Fix) Process mass pm not sending pms

### DIFF
--- a/app/Jobs/ProcessMassPM.php
+++ b/app/Jobs/ProcessMassPM.php
@@ -56,7 +56,7 @@ class ProcessMassPM implements ShouldQueue
 
         PrivateMessage::create([
             'conversation_id' => $conversation->id,
-            'user_id'         => $this->senderId,
+            'sender_id'       => $this->senderId,
             'message'         => $this->message
         ]);
     }


### PR DESCRIPTION
I did a ctrl+f for `PrivateMessage::create` and so no other occurrences of this typo. Probably should add the rule in larastan to detect these.