### PR TITLE
(Fix) Migration to change peers ip to varbinary

### DIFF
--- a/database/migrations/2022_12_22_004317_update_peers_table.php
+++ b/database/migrations/2022_12_22_004317_update_peers_table.php
@@ -40,7 +40,7 @@ return new class () extends Migration {
             $table->unsignedInteger('torrent_id')->nullable(false)->change();
             $table->unsignedInteger('user_id')->nullable(false)->change();
             $table->binary('peer_id', length: 20, fixed: true)->change();
-            $table->binary('ip', length: 16, fixed: true)->change();
+            $table->binary('ip', length: 16)->change();
         });
 
         Schema::enableForeignKeyConstraints();


### PR DESCRIPTION
fixup of 8c11521. It was unintentionally changed from varbinary to binary. The ip column must not be fixed length, since mysql will right pad the other 12 bytes of 4-byte ipv4 addresses with NUL (`\0`) bytes, which breaks `INET6_NTOA()`. The full 16 bytes are needed for ipv6 addresses however. Note that the commit this fixes isn't yet in stable, so anyone running the development branch in prod will have to update their schema manually.