### PR TITLE
(Fix) Bug #3815

### DIFF
--- a/app/Http/Livewire/TopTorrents.php
+++ b/app/Http/Livewire/TopTorrents.php
@@ -42,22 +42,6 @@ class TopTorrents extends Component
     final public function torrents(): \Illuminate\Support\Collection
     {
         $torrents = Torrent::query()
-            ->select([
-                'id',
-                'name',
-                'user_id',
-                'category_id',
-                'type_id',
-                'resolution_id',
-                'tmdb',
-                'igdb',
-                'size',
-                'anon',
-                'seeders',
-                'leechers',
-                'times_completed',
-                'created_at'
-            ])
             ->with(['user.group', 'category', 'type', 'resolution'])
             ->withExists([
                 'bookmarks'          => fn ($query) => $query->where('user_id', '=', $this->user->id),


### PR DESCRIPTION
- As seen in #3815 there are many selects missing for resources/views/components/partials/_torrent-icons.blade.php. It is pointless to add them all just to omit a few. There was no performance loss locally.
- closes #3815