### PR TITLE
(Fix) Bookmarks deleting themselves after navigating to next page

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -158,7 +158,7 @@ Alpine.data("bookmark", (torrentId, bookmarked) => ({
     bookmarked: bookmarked,
     button: {
         ["x-on:click"]() {
-            this.bookmarked ? this.destroy() : this.store();
+            this.bookmarked ? this.deleteBookmark() : this.createBookmark();
         },
         ["x-bind:title"]() {
             return this.bookmarked ? "Unbookmark" : "Bookmark";
@@ -169,13 +169,13 @@ Alpine.data("bookmark", (torrentId, bookmarked) => ({
             return this.bookmarked ? "fa-bookmark-slash" : "fa-bookmark";
         },
     },
-    store() {
+    createBookmark() {
         axios.post(`/api/bookmarks/${this.torrentId}`).then((response) => {
             this.bookmarked = Boolean(response.data);
             this.dispatchEvent();
         });
     },
-    destroy() {
+    deleteBookmark() {
         axios.delete(`/api/bookmarks/${this.torrentId}`).then((response) => {
             this.bookmarked = Boolean(response.data);
             this.dispatchEvent();


### PR DESCRIPTION
Apparently `destroy()` is a special function in alpinejs and runs whenever a component is cleaned up.

Resolves the issue described in #4001