### PR TITLE
(Update) Migration

### DIFF
--- a/database/migrations/2024_07_28_231553_update_cat_type_res_table.php
+++ b/database/migrations/2024_07_28_231553_update_cat_type_res_table.php
@@ -30,8 +30,8 @@ return new class () extends Migration {
 
         // Change the related torrent table columns to unsigned smallint
         Schema::table('torrents', function (Blueprint $table): void {
-            $table->unsignedSmallInteger('category_id')->change();
-            $table->unsignedSmallInteger('type_id')->change();
+            $table->unsignedSmallInteger('category_id')->nullable()->change();
+            $table->unsignedSmallInteger('type_id')->nullable()->change();
             $table->unsignedSmallInteger('resolution_id')->nullable()->change();
         });
 


### PR DESCRIPTION
- These need to be nullable for external tracker atm. It’s still covered at an application level to not be null but just need it for announce temp.