### PR TITLE
(Refactor) Don't call `->toDateTimeString()` on carbon instances

### DIFF
--- a/app/Console/Commands/AutoCorrectHistory.php
+++ b/app/Console/Commands/AutoCorrectHistory.php
@@ -48,7 +48,7 @@ class AutoCorrectHistory extends Command
     {
         History::query()
             ->where('active', '=', 1)
-            ->where('updated_at', '<', Carbon::now()->subHours(2)->toDateTimeString())
+            ->where('updated_at', '<', Carbon::now()->subHours(2))
             ->update([
                 'active'     => 0,
                 'updated_at' => DB::raw('updated_at'),

--- a/app/Console/Commands/AutoDisableInactiveUsers.php
+++ b/app/Console/Commands/AutoDisableInactiveUsers.php
@@ -55,8 +55,8 @@ class AutoDisableInactiveUsers extends Command
 
             $matches = User::whereIntegerInRaw('group_id', config('pruning.group_ids'))->get();
 
-            $users = $matches->where('created_at', '<', $current->copy()->subDays(config('pruning.account_age'))->toDateTimeString())
-                ->where('last_login', '<', $current->copy()->subDays(config('pruning.last_login'))->toDateTimeString())
+            $users = $matches->where('created_at', '<', $current->copy()->subDays(config('pruning.account_age')))
+                ->where('last_login', '<', $current->copy()->subDays(config('pruning.last_login')))
                 ->all();
 
             foreach ($users as $user) {

--- a/app/Console/Commands/AutoFlushPeers.php
+++ b/app/Console/Commands/AutoFlushPeers.php
@@ -49,7 +49,7 @@ class AutoFlushPeers extends Command
     {
         $carbon = new Carbon();
         $peers = Peer::select(['torrent_id', 'user_id', 'peer_id', 'seeder', 'updated_at'])
-            ->where('updated_at', '<', $carbon->copy()->subHours(2)->toDateTimeString())
+            ->where('updated_at', '<', $carbon->copy()->subHours(2))
             ->where('active', '=', 1)
             ->get();
 

--- a/app/Console/Commands/AutoPreWarning.php
+++ b/app/Console/Commands/AutoPreWarning.php
@@ -57,7 +57,7 @@ class AutoPreWarning extends Command
                 ->where('actual_downloaded', '>', 0)
                 ->where('active', '=', 0)
                 ->where('seedtime', '<=', config('hitrun.seedtime'))
-                ->where('updated_at', '<', $carbon->copy()->subDays(config('hitrun.prewarn'))->toDateTimeString())
+                ->where('updated_at', '<', $carbon->copy()->subDays(config('hitrun.prewarn')))
                 ->get();
 
             $usersWithPreWarnings = [];

--- a/app/Console/Commands/AutoRecycleAudits.php
+++ b/app/Console/Commands/AutoRecycleAudits.php
@@ -46,7 +46,7 @@ class AutoRecycleAudits extends Command
     final public function handle(): void
     {
         $current = Carbon::now();
-        $audits = Audit::where('created_at', '<', $current->copy()->subDays(config('audit.recycle'))->toDateTimeString())->get();
+        $audits = Audit::where('created_at', '<', $current->copy()->subDays(config('audit.recycle')))->get();
 
         foreach ($audits as $audit) {
             $audit->delete();

--- a/app/Console/Commands/AutoRecycleClaimedTorrentRequests.php
+++ b/app/Console/Commands/AutoRecycleClaimedTorrentRequests.php
@@ -64,7 +64,7 @@ class AutoRecycleClaimedTorrentRequests extends Command
 
         foreach ($torrentRequests as $torrentRequest) {
             $requestClaim = TorrentRequestClaim::where('request_id', '=', $torrentRequest->id)
-                ->where('created_at', '<', $current->copy()->subDays(7)->toDateTimeString())
+                ->where('created_at', '<', $current->copy()->subDays(7))
                 ->first();
 
             if ($requestClaim) {

--- a/app/Console/Commands/AutoRecycleFailedLogins.php
+++ b/app/Console/Commands/AutoRecycleFailedLogins.php
@@ -46,7 +46,7 @@ class AutoRecycleFailedLogins extends Command
     final public function handle(): void
     {
         $current = Carbon::now();
-        $failedLogins = FailedLoginAttempt::where('created_at', '<', $current->copy()->subDays(30)->toDateTimeString())->get();
+        $failedLogins = FailedLoginAttempt::where('created_at', '<', $current->copy()->subDays(30))->get();
 
         foreach ($failedLogins as $failedLogin) {
             $failedLogin->delete();

--- a/app/Console/Commands/AutoRemoveFeaturedTorrent.php
+++ b/app/Console/Commands/AutoRemoveFeaturedTorrent.php
@@ -57,7 +57,7 @@ class AutoRemoveFeaturedTorrent extends Command
     final public function handle(): void
     {
         $current = Carbon::now();
-        $featuredTorrents = FeaturedTorrent::where('created_at', '<', $current->copy()->subDays(7)->toDateTimeString())->get();
+        $featuredTorrents = FeaturedTorrent::where('created_at', '<', $current->copy()->subDays(7))->get();
 
         foreach ($featuredTorrents as $featuredTorrent) {
             // Find The Torrent

--- a/app/Console/Commands/AutoRemovePersonalFreeleech.php
+++ b/app/Console/Commands/AutoRemovePersonalFreeleech.php
@@ -48,7 +48,7 @@ class AutoRemovePersonalFreeleech extends Command
     final public function handle(): void
     {
         $current = Carbon::now();
-        $personalFreeleech = PersonalFreeleech::where('created_at', '<', $current->copy()->subDays(1)->toDateTimeString())->get();
+        $personalFreeleech = PersonalFreeleech::where('created_at', '<', $current->copy()->subDays(1))->get();
 
         foreach ($personalFreeleech as $pfl) {
             // Send Private Message

--- a/app/Console/Commands/AutoRemoveTimedTorrentBuffs.php
+++ b/app/Console/Commands/AutoRemoveTimedTorrentBuffs.php
@@ -46,7 +46,7 @@ class AutoRemoveTimedTorrentBuffs extends Command
      */
     final public function handle(): void
     {
-        $flTorrents = Torrent::whereNotNull('fl_until')->where('fl_until', '<', Carbon::now()->toDateTimeString())->get();
+        $flTorrents = Torrent::whereNotNull('fl_until')->where('fl_until', '<', Carbon::now())->get();
 
         foreach ($flTorrents as $torrent) {
             $torrent->free = 0;
@@ -57,7 +57,7 @@ class AutoRemoveTimedTorrentBuffs extends Command
             Unit3dAnnounce::addTorrent($torrent);
         }
 
-        $duTorrents = Torrent::whereNotNull('du_until')->where('du_until', '<', Carbon::now()->toDateTimeString())->get();
+        $duTorrents = Torrent::whereNotNull('du_until')->where('du_until', '<', Carbon::now())->get();
 
         foreach ($duTorrents as $torrent) {
             $torrent->doubleup = false;

--- a/app/Console/Commands/AutoSoftDeleteDisabledUsers.php
+++ b/app/Console/Commands/AutoSoftDeleteDisabledUsers.php
@@ -66,7 +66,7 @@ class AutoSoftDeleteDisabledUsers extends Command
             $disabledGroup = cache()->rememberForever('disabled_group', fn () => Group::where('slug', '=', 'disabled')->pluck('id'));
 
             $users = User::where('group_id', '=', $disabledGroup[0])
-                ->where('disabled_at', '<', now()->copy()->subDays(config('pruning.soft_delete'))->toDateTimeString())
+                ->where('disabled_at', '<', now()->copy()->subDays(config('pruning.soft_delete')))
                 ->get();
 
             foreach ($users as $user) {

--- a/app/Console/Commands/AutoWarning.php
+++ b/app/Console/Commands/AutoWarning.php
@@ -59,7 +59,7 @@ class AutoWarning extends Command
                 ->where('immune', '=', 0)
                 ->where('active', '=', 0)
                 ->where('seedtime', '<', config('hitrun.seedtime'))
-                ->where('updated_at', '<', $carbon->copy()->subDays(config('hitrun.grace'))->toDateTimeString())
+                ->where('updated_at', '<', $carbon->copy()->subDays(config('hitrun.grace')))
                 ->get();
 
             $usersWithWarnings = [];

--- a/app/Http/Controllers/Staff/FlushController.php
+++ b/app/Http/Controllers/Staff/FlushController.php
@@ -46,7 +46,7 @@ class FlushController extends Controller
     public function peers(): \Illuminate\Http\RedirectResponse
     {
         $carbon = new Carbon();
-        $peers = Peer::select(['torrent_id', 'user_id', 'peer_id', 'updated_at'])->where('updated_at', '<', $carbon->copy()->subHours(2)->toDateTimeString())->get();
+        $peers = Peer::select(['torrent_id', 'user_id', 'peer_id', 'updated_at'])->where('updated_at', '<', $carbon->copy()->subHours(2))->get();
 
         foreach ($peers as $peer) {
             History::query()

--- a/app/Http/Controllers/User/EarningController.php
+++ b/app/Http/Controllers/User/EarningController.php
@@ -69,7 +69,7 @@ class EarningController extends Controller
 
         $legendary = $distinctSeeds
             ->clone()
-            ->whereRelation('torrent', 'created_at', '<', Carbon::now()->subYear()->toDateTimeString())
+            ->whereRelation('torrent', 'created_at', '<', Carbon::now()->subYear())
             ->count();
 
         $old = $distinctSeeds
@@ -77,8 +77,8 @@ class EarningController extends Controller
             ->whereHas(
                 'torrent',
                 fn ($query) => $query
-                    ->where('created_at', '<', Carbon::now()->subMonths(6)->toDateTimeString())
-                    ->where('created_at', '>', Carbon::now()->subYear()->toDateTimeString()),
+                    ->where('created_at', '<', Carbon::now()->subMonths(6))
+                    ->where('created_at', '>', Carbon::now()->subYear()),
             )
             ->count();
 

--- a/app/Http/Controllers/User/PeerController.php
+++ b/app/Http/Controllers/User/PeerController.php
@@ -57,7 +57,7 @@ class PeerController extends Controller
         }
 
         // Only peers older than 70 minutes are allowed to be flushed otherwise users could use this to exploit leech slots
-        $cutoff = (new Carbon())->copy()->subMinutes(70)->toDateTimeString();
+        $cutoff = (new Carbon())->copy()->subMinutes(70);
 
         $user->peers()
             ->where('updated_at', '<', $cutoff)


### PR DESCRIPTION
Eloquent already does this for us automatically by calling __toString() on Carbon instances with the default format being the same as the mysql timestamp format.