### PR TITLE
(Update) Show torrent upload/download count in navbar

### DIFF
--- a/resources/views/partials/top_nav.blade.php
+++ b/resources/views/partials/top_nav.blade.php
@@ -473,7 +473,22 @@
                     <li>
                         <a href="{{ route('users.torrents.index', ['user' => auth()->user()]) }}">
                             <i class="{{ config('other.font-awesome') }} fa-upload"></i>
+                            @php
+                                $uploadCount = Cache::remember(
+                                    'users:' . auth()->id() . ':upload_count',
+                                    60,
+                                    fn () => auth()
+                                        ->user()
+                                        ->torrents()
+                                        ->count() ?? 0
+                                );
+                            @endphp
+
                             {{ __('user.my-uploads') }}
+
+                            @if ($uploadCount > 0)
+                                ({{ $uploadCount }})
+                            @endif
                         </a>
                     </li>
                     <li>
@@ -481,7 +496,23 @@
                             href="{{ route('users.history.index', ['user' => auth()->user(), 'downloaded' => 'include']) }}"
                         >
                             <i class="{{ config('other.font-awesome') }} fa-download"></i>
+                            @php
+                                $downloadCount = Cache::remember(
+                                    'users:' . auth()->id() . ':download_count',
+                                    60,
+                                    fn () => auth()
+                                        ->user()
+                                        ->history()
+                                        ->where('actual_downloaded', '>', 0)
+                                        ->count() ?? 0
+                                );
+                            @endphp
+
                             {{ __('user.my-downloads') }}
+
+                            @if ($downloadCount > 0)
+                                ({{ $downloadCount }})
+                            @endif
                         </a>
                     </li>
                     <li>


### PR DESCRIPTION
I tried adding counts to requests and bookmarks as well but it looks way too busy. Database query times for each query are less than 1 ms.