### PR TITLE
(Refactor) Use early returns in console commands

### DIFF
--- a/app/Console/Commands/AutoBanDisposableUsers.php
+++ b/app/Console/Commands/AutoBanDisposableUsers.php
@@ -50,51 +50,53 @@ class AutoBanDisposableUsers extends Command
      */
     final public function handle(): void
     {
+        if (!cache()->has(config('email-blacklist.cache-key'))) {
+            $this->comment('Email Blacklist Cache Key Not Found. Skipping!');
+
+            return;
+        }
+
         $bannedGroup = cache()->rememberForever('banned_group', fn () => Group::where('slug', '=', 'banned')->pluck('id'));
 
-        if (cache()->has(config('email-blacklist.cache-key'))) {
-            User::where('group_id', '!=', $bannedGroup[0])->chunkById(100, function ($users) use ($bannedGroup): void {
-                foreach ($users as $user) {
-                    $v = validator([
-                        'email' => $user->email,
-                    ], [
-                        'email' => [
-                            'required',
-                            'string',
-                            'email',
-                            'max:70',
-                            new EmailBlacklist(),
-                        ],
-                    ]);
+        User::where('group_id', '!=', $bannedGroup[0])->chunkById(100, function ($users) use ($bannedGroup): void {
+            foreach ($users as $user) {
+                $v = validator([
+                    'email' => $user->email,
+                ], [
+                    'email' => [
+                        'required',
+                        'string',
+                        'email',
+                        'max:70',
+                        new EmailBlacklist(),
+                    ],
+                ]);
 
-                    if ($v->fails()) {
-                        // If User Is Using A Disposable Email Set The Users Group To Banned
-                        $user->group_id = $bannedGroup[0];
-                        $user->can_download = 0;
-                        $user->save();
+                if ($v->fails()) {
+                    // If User Is Using A Disposable Email Set The Users Group To Banned
+                    $user->group_id = $bannedGroup[0];
+                    $user->can_download = 0;
+                    $user->save();
 
-                        // Log The Ban To Ban Log
-                        $domain = substr((string) strrchr((string) $user->email, '@'), 1);
-                        $logban = new Ban();
-                        $logban->owned_by = $user->id;
-                        $logban->created_by = User::SYSTEM_USER_ID;
-                        $logban->ban_reason = 'Detected disposable email, '.$domain.' not allowed.';
-                        $logban->unban_reason = '';
-                        $logban->save();
+                    // Log The Ban To Ban Log
+                    $domain = substr((string) strrchr((string) $user->email, '@'), 1);
+                    $logban = new Ban();
+                    $logban->owned_by = $user->id;
+                    $logban->created_by = User::SYSTEM_USER_ID;
+                    $logban->ban_reason = 'Detected disposable email, '.$domain.' not allowed.';
+                    $logban->unban_reason = '';
+                    $logban->save();
 
-                        // Send Email
-                        $user->notify(new UserBan($logban));
-                    }
-
-                    cache()->forget('user:'.$user->passkey);
-
-                    Unit3dAnnounce::addUser($user);
+                    // Send Email
+                    $user->notify(new UserBan($logban));
                 }
-            });
 
-            $this->comment('Automated User Banning Command Complete');
-        } else {
-            $this->comment('Email Blacklist Cache Key Not Found. Skipping!');
-        }
+                cache()->forget('user:'.$user->passkey);
+
+                Unit3dAnnounce::addUser($user);
+            }
+        });
+
+        $this->comment('Automated User Banning Command Complete');
     }
 }

--- a/app/Console/Commands/AutoNerdStat.php
+++ b/app/Console/Commands/AutoNerdStat.php
@@ -54,45 +54,47 @@ class AutoNerdStat extends Command
     final public function handle(): void
     {
         // Check if the nerd bot is enabled in the configuration.
-        if (config('chat.nerd_bot')) {
-            // Define the possible stats.
-            $stats = collect([
-                'birthday',
-                'logins',
-                'uploads',
-                'users',
-                'fl25',
-                'fl50',
-                'fl75',
-                'fl100',
-                'du',
-                'peers',
-                'bans',
-                'warnings',
-                'king',
-            ])->random();
-
-            // Generate the message based on the selected stat.
-            $message = match ($stats) {
-                'birthday' => config('other.title').' Birthday Is [b]'.config('other.birthdate').'[/b]!',
-                'logins'   => 'In The Last 24 Hours [color=#93c47d][b]'.DB::table('users')->whereNotNull('last_login')->where('last_login', '>', now()->subDay())->count().'[/b][/color] Unique Users Have Logged Into '.config('other.title').'!',
-                'uploads'  => 'In The Last 24 Hours [color=#93c47d][b]'.DB::table('torrents')->where('created_at', '>', now()->subDay())->count().'[/b][/color] Torrents Have Been Uploaded To '.config('other.title').'!',
-                'users'    => 'In The Last 24 Hours [color=#93c47d][b]'.DB::table('users')->where('created_at', '>', now()->subDay())->count().'[/b][/color] Users Have Registered To '.config('other.title').'!',
-                'fl25'     => 'There Are Currently [color=#93c47d][b]'.DB::table('torrents')->where('free', '=', 25)->count().'[/b][/color] 25% Freeleech Torrents On '.config('other.title').'!',
-                'fl50'     => 'There Are Currently [color=#93c47d][b]'.DB::table('torrents')->where('free', '=', 50)->count().'[/b][/color] 50% Freeleech Torrents On '.config('other.title').'!',
-                'fl75'     => 'There Are Currently [color=#93c47d][b]'.DB::table('torrents')->where('free', '=', 75)->count().'[/b][/color] 75% Freeleech Torrents On '.config('other.title').'!',
-                'fl100'    => 'There Are Currently [color=#93c47d][b]'.DB::table('torrents')->where('free', '=', 100)->count().'[/b][/color] 100% Freeleech Torrents On '.config('other.title').'!',
-                'du'       => 'There Are Currently [color=#93c47d][b]'.DB::table('torrents')->where('doubleup', '=', 1)->count().'[/b][/color] Double Upload Torrents On '.config('other.title').'!',
-                'peers'    => 'Currently There Are [color=#93c47d][b]'.DB::table('peers')->where('active', '=', 1)->count().'[/b][/color] Peers On '.config('other.title').'!',
-                'bans'     => 'In The Last 24 Hours [color=#dd7e6b][b]'.DB::table('bans')->whereNull('unban_reason')->whereNull('removed_at')->where('created_at', '>', now()->subDay())->count().'[/b][/color] Users Have Been Banned From '.config('other.title').'!',
-                'warnings' => 'In The Last 24 Hours [color=#dd7e6b][b]'.DB::table('warnings')->where('created_at', '>', now()->subDay())->count().'[/b][/color] Hit and Run Warnings Have Been Issued On '.config('other.title').'!',
-                'king'     => config('other.title').' Is King!',
-                default    => 'Nerd Stat Error!',
-            };
-
-            // Post the message to the chatbox.
-            $this->chatRepository->systemMessage($message);
+        if (!config('chat.nerd_bot')) {
+            return;
         }
+
+        // Define the possible stats.
+        $stats = collect([
+            'birthday',
+            'logins',
+            'uploads',
+            'users',
+            'fl25',
+            'fl50',
+            'fl75',
+            'fl100',
+            'du',
+            'peers',
+            'bans',
+            'warnings',
+            'king',
+        ])->random();
+
+        // Generate the message based on the selected stat.
+        $message = match ($stats) {
+            'birthday' => config('other.title').' Birthday Is [b]'.config('other.birthdate').'[/b]!',
+            'logins'   => 'In The Last 24 Hours [color=#93c47d][b]'.DB::table('users')->whereNotNull('last_login')->where('last_login', '>', now()->subDay())->count().'[/b][/color] Unique Users Have Logged Into '.config('other.title').'!',
+            'uploads'  => 'In The Last 24 Hours [color=#93c47d][b]'.DB::table('torrents')->where('created_at', '>', now()->subDay())->count().'[/b][/color] Torrents Have Been Uploaded To '.config('other.title').'!',
+            'users'    => 'In The Last 24 Hours [color=#93c47d][b]'.DB::table('users')->where('created_at', '>', now()->subDay())->count().'[/b][/color] Users Have Registered To '.config('other.title').'!',
+            'fl25'     => 'There Are Currently [color=#93c47d][b]'.DB::table('torrents')->where('free', '=', 25)->count().'[/b][/color] 25% Freeleech Torrents On '.config('other.title').'!',
+            'fl50'     => 'There Are Currently [color=#93c47d][b]'.DB::table('torrents')->where('free', '=', 50)->count().'[/b][/color] 50% Freeleech Torrents On '.config('other.title').'!',
+            'fl75'     => 'There Are Currently [color=#93c47d][b]'.DB::table('torrents')->where('free', '=', 75)->count().'[/b][/color] 75% Freeleech Torrents On '.config('other.title').'!',
+            'fl100'    => 'There Are Currently [color=#93c47d][b]'.DB::table('torrents')->where('free', '=', 100)->count().'[/b][/color] 100% Freeleech Torrents On '.config('other.title').'!',
+            'du'       => 'There Are Currently [color=#93c47d][b]'.DB::table('torrents')->where('doubleup', '=', 1)->count().'[/b][/color] Double Upload Torrents On '.config('other.title').'!',
+            'peers'    => 'Currently There Are [color=#93c47d][b]'.DB::table('peers')->where('active', '=', 1)->count().'[/b][/color] Peers On '.config('other.title').'!',
+            'bans'     => 'In The Last 24 Hours [color=#dd7e6b][b]'.DB::table('bans')->whereNull('unban_reason')->whereNull('removed_at')->where('created_at', '>', now()->subDay())->count().'[/b][/color] Users Have Been Banned From '.config('other.title').'!',
+            'warnings' => 'In The Last 24 Hours [color=#dd7e6b][b]'.DB::table('warnings')->where('created_at', '>', now()->subDay())->count().'[/b][/color] Hit and Run Warnings Have Been Issued On '.config('other.title').'!',
+            'king'     => config('other.title').' Is King!',
+            default    => 'Nerd Stat Error!',
+        };
+
+        // Post the message to the chatbox.
+        $this->chatRepository->systemMessage($message);
 
         // Output a success message to the console.
         $this->comment('Automated Nerd Stat Command Complete');

--- a/app/Console/Commands/AutoPreWarning.php
+++ b/app/Console/Commands/AutoPreWarning.php
@@ -48,50 +48,52 @@ class AutoPreWarning extends Command
      */
     final public function handle(): void
     {
-        if (config('hitrun.enabled') === true) {
-            $carbon = new Carbon();
-            $prewarn = History::with(['user', 'torrent'])
-                ->whereNull('prewarned_at')
-                ->where('hitrun', '=', 0)
-                ->where('immune', '=', 0)
-                ->where('actual_downloaded', '>', 0)
-                ->where('active', '=', 0)
-                ->where('seedtime', '<=', config('hitrun.seedtime'))
-                ->where('updated_at', '<', $carbon->copy()->subDays(config('hitrun.prewarn')))
-                ->get();
+        if (config('hitrun.enabled') !== true) {
+            return;
+        }
 
-            $usersWithPreWarnings = [];
+        $carbon = new Carbon();
+        $prewarn = History::with(['user', 'torrent'])
+            ->whereNull('prewarned_at')
+            ->where('hitrun', '=', 0)
+            ->where('immune', '=', 0)
+            ->where('actual_downloaded', '>', 0)
+            ->where('active', '=', 0)
+            ->where('seedtime', '<=', config('hitrun.seedtime'))
+            ->where('updated_at', '<', $carbon->copy()->subDays(config('hitrun.prewarn')))
+            ->get();
 
-            foreach ($prewarn as $pre) {
-                if (null === $pre->torrent) {
-                    continue;
-                }
+        $usersWithPreWarnings = [];
 
-                if (!$pre->user->group->is_immune && $pre->actual_downloaded > ($pre->torrent->size * (config('hitrun.buffer') / 100))) {
-                    $exsist = Warning::withTrashed()
-                        ->where('torrent', '=', $pre->torrent->id)
-                        ->where('user_id', '=', $pre->user->id)
-                        ->first();
-
-                    if ($exsist === null) {
-                        History::query()
-                            ->where('torrent_id', '=', $pre->torrent_id)
-                            ->where('user_id', '=', $pre->user_id)
-                            ->update([
-                                'prewarned_at' => now(),
-                                'updated_at'   => DB::raw('updated_at'),
-                            ]);
-
-                        // Add user to usersWithWarnings array
-                        $usersWithPreWarnings[$pre->user->id] = $pre->user;
-                    }
-                }
+        foreach ($prewarn as $pre) {
+            if (null === $pre->torrent) {
+                continue;
             }
 
-            // Send a single notification for each user with warnings
-            foreach ($usersWithPreWarnings as $user) {
-                $user->notify(new UserPreWarning($user));
+            if (!$pre->user->group->is_immune && $pre->actual_downloaded > ($pre->torrent->size * (config('hitrun.buffer') / 100))) {
+                $exsist = Warning::withTrashed()
+                    ->where('torrent', '=', $pre->torrent->id)
+                    ->where('user_id', '=', $pre->user->id)
+                    ->first();
+
+                if ($exsist === null) {
+                    History::query()
+                        ->where('torrent_id', '=', $pre->torrent_id)
+                        ->where('user_id', '=', $pre->user_id)
+                        ->update([
+                            'prewarned_at' => now(),
+                            'updated_at'   => DB::raw('updated_at'),
+                        ]);
+
+                    // Add user to usersWithWarnings array
+                    $usersWithPreWarnings[$pre->user->id] = $pre->user;
+                }
             }
+        }
+
+        // Send a single notification for each user with warnings
+        foreach ($usersWithPreWarnings as $user) {
+            $user->notify(new UserPreWarning($user));
         }
 
         $this->comment('Automated User Pre-Warning Command Complete');

--- a/app/Console/Commands/AutoSoftDeleteDisabledUsers.php
+++ b/app/Console/Commands/AutoSoftDeleteDisabledUsers.php
@@ -62,70 +62,72 @@ class AutoSoftDeleteDisabledUsers extends Command
      */
     final public function handle(): void
     {
-        if (config('pruning.user_pruning')) {
-            $disabledGroup = cache()->rememberForever('disabled_group', fn () => Group::where('slug', '=', 'disabled')->pluck('id'));
+        if (!config('pruning.user_pruning')) {
+            return;
+        }
 
-            $users = User::where('group_id', '=', $disabledGroup[0])
-                ->where('disabled_at', '<', now()->copy()->subDays(config('pruning.soft_delete')))
-                ->get();
+        $disabledGroup = cache()->rememberForever('disabled_group', fn () => Group::where('slug', '=', 'disabled')->pluck('id'));
 
-            foreach ($users as $user) {
-                $user->update([
-                    'can_download' => false,
-                    'group_id'     => UserGroup::PRUNED->value,
-                    'deleted_by'   => User::SYSTEM_USER_ID,
-                ]);
+        $users = User::where('group_id', '=', $disabledGroup[0])
+            ->where('disabled_at', '<', now()->copy()->subDays(config('pruning.soft_delete')))
+            ->get();
 
-                Torrent::withoutGlobalScope(ApprovedScope::class)->where('user_id', '=', $user->id)->update([
-                    'user_id' => User::SYSTEM_USER_ID,
-                ]);
+        foreach ($users as $user) {
+            $user->update([
+                'can_download' => false,
+                'group_id'     => UserGroup::PRUNED->value,
+                'deleted_by'   => User::SYSTEM_USER_ID,
+            ]);
 
-                Comment::where('user_id', '=', $user->id)->update([
-                    'user_id' => User::SYSTEM_USER_ID,
-                ]);
+            Torrent::withoutGlobalScope(ApprovedScope::class)->where('user_id', '=', $user->id)->update([
+                'user_id' => User::SYSTEM_USER_ID,
+            ]);
 
-                Post::where('user_id', '=', $user->id)->update([
-                    'user_id' => User::SYSTEM_USER_ID,
-                ]);
+            Comment::where('user_id', '=', $user->id)->update([
+                'user_id' => User::SYSTEM_USER_ID,
+            ]);
 
-                Topic::where('first_post_user_id', '=', $user->id)->update([
-                    'first_post_user_id' => User::SYSTEM_USER_ID,
-                ]);
+            Post::where('user_id', '=', $user->id)->update([
+                'user_id' => User::SYSTEM_USER_ID,
+            ]);
 
-                Topic::where('last_post_user_id', '=', $user->id)->update([
-                    'last_post_user_id' => User::SYSTEM_USER_ID,
-                ]);
+            Topic::where('first_post_user_id', '=', $user->id)->update([
+                'first_post_user_id' => User::SYSTEM_USER_ID,
+            ]);
 
-                PrivateMessage::where('sender_id', '=', $user->id)->update([
-                    'sender_id' => User::SYSTEM_USER_ID,
-                ]);
+            Topic::where('last_post_user_id', '=', $user->id)->update([
+                'last_post_user_id' => User::SYSTEM_USER_ID,
+            ]);
 
-                Participant::where('user_id', '=', $user->id)->delete();
-                Message::where('user_id', '=', $user->id)->delete();
-                Like::where('user_id', '=', $user->id)->delete();
-                Thank::where('user_id', '=', $user->id)->delete();
-                Peer::where('user_id', '=', $user->id)->delete();
-                History::where('user_id', '=', $user->id)->delete();
-                FailedLoginAttempt::where('user_id', '=', $user->id)->delete();
+            PrivateMessage::where('sender_id', '=', $user->id)->update([
+                'sender_id' => User::SYSTEM_USER_ID,
+            ]);
 
-                // Removes all follows for user
-                $user->followers()->detach();
-                $user->following()->detach();
+            Participant::where('user_id', '=', $user->id)->delete();
+            Message::where('user_id', '=', $user->id)->delete();
+            Like::where('user_id', '=', $user->id)->delete();
+            Thank::where('user_id', '=', $user->id)->delete();
+            Peer::where('user_id', '=', $user->id)->delete();
+            History::where('user_id', '=', $user->id)->delete();
+            FailedLoginAttempt::where('user_id', '=', $user->id)->delete();
 
-                // Removes all FL Tokens for user
-                foreach (FreeleechToken::where('user_id', '=', $user->id)->get() as $token) {
-                    $token->delete();
-                    cache()->forget('freeleech_token:'.$user->id.':'.$token->torrent_id);
-                }
+            // Removes all follows for user
+            $user->followers()->detach();
+            $user->following()->detach();
 
-                cache()->forget('user:'.$user->passkey);
-
-                Unit3dAnnounce::removeUser($user);
-
-                dispatch(new SendDeleteUserMail($user));
-
-                $user->delete();
+            // Removes all FL Tokens for user
+            foreach (FreeleechToken::where('user_id', '=', $user->id)->get() as $token) {
+                $token->delete();
+                cache()->forget('freeleech_token:'.$user->id.':'.$token->torrent_id);
             }
+
+            cache()->forget('user:'.$user->passkey);
+
+            Unit3dAnnounce::removeUser($user);
+
+            dispatch(new SendDeleteUserMail($user));
+
+            $user->delete();
         }
 
         $this->comment('Automated Soft Delete Disabled Users Command Complete');

--- a/app/Console/Commands/AutoWarning.php
+++ b/app/Console/Commands/AutoWarning.php
@@ -50,72 +50,74 @@ class AutoWarning extends Command
      */
     final public function handle(): void
     {
-        if (config('hitrun.enabled') === true) {
-            $carbon = new Carbon();
-            $hitrun = History::with(['user', 'torrent'])
-                ->where('actual_downloaded', '>', 0)
-                ->where('prewarned_at', '<=', now()->subDays(config('hitrun.prewarn')))
-                ->where('hitrun', '=', 0)
-                ->where('immune', '=', 0)
-                ->where('active', '=', 0)
-                ->where('seedtime', '<', config('hitrun.seedtime'))
-                ->where('updated_at', '<', $carbon->copy()->subDays(config('hitrun.grace')))
-                ->get();
+        if (config('hitrun.enabled') !== true) {
+            return;
+        }
 
-            $usersWithWarnings = [];
+        $carbon = new Carbon();
+        $hitrun = History::with(['user', 'torrent'])
+            ->where('actual_downloaded', '>', 0)
+            ->where('prewarned_at', '<=', now()->subDays(config('hitrun.prewarn')))
+            ->where('hitrun', '=', 0)
+            ->where('immune', '=', 0)
+            ->where('active', '=', 0)
+            ->where('seedtime', '<', config('hitrun.seedtime'))
+            ->where('updated_at', '<', $carbon->copy()->subDays(config('hitrun.grace')))
+            ->get();
 
-            foreach ($hitrun as $hr) {
-                if (!$hr->user->group->is_immune && $hr->actual_downloaded > ($hr->torrent->size * (config('hitrun.buffer') / 100))) {
-                    $exsist = Warning::withTrashed()
-                        ->where('torrent', '=', $hr->torrent->id)
-                        ->where('user_id', '=', $hr->user->id)
-                        ->first();
+        $usersWithWarnings = [];
 
-                    // Insert Warning Into Warnings Table if doesnt already exsist
-                    if ($exsist === null) {
-                        $warning = new Warning();
-                        $warning->user_id = $hr->user->id;
-                        $warning->warned_by = User::SYSTEM_USER_ID;
-                        $warning->torrent = $hr->torrent->id;
-                        $warning->reason = \sprintf('Hit and Run Warning For Torrent %s', $hr->torrent->name);
-                        $warning->expires_on = $carbon->copy()->addDays(config('hitrun.expire'));
-                        $warning->active = true;
-                        $warning->save();
+        foreach ($hitrun as $hr) {
+            if (!$hr->user->group->is_immune && $hr->actual_downloaded > ($hr->torrent->size * (config('hitrun.buffer') / 100))) {
+                $exsist = Warning::withTrashed()
+                    ->where('torrent', '=', $hr->torrent->id)
+                    ->where('user_id', '=', $hr->user->id)
+                    ->first();
 
-                        History::query()
-                            ->where('torrent_id', '=', $hr->torrent_id)
-                            ->where('user_id', '=', $hr->user_id)
-                            ->update([
-                                'hitrun'     => true,
-                                'updated_at' => DB::raw('updated_at'),
-                            ]);
+                // Insert Warning Into Warnings Table if doesnt already exsist
+                if ($exsist === null) {
+                    $warning = new Warning();
+                    $warning->user_id = $hr->user->id;
+                    $warning->warned_by = User::SYSTEM_USER_ID;
+                    $warning->torrent = $hr->torrent->id;
+                    $warning->reason = \sprintf('Hit and Run Warning For Torrent %s', $hr->torrent->name);
+                    $warning->expires_on = $carbon->copy()->addDays(config('hitrun.expire'));
+                    $warning->active = true;
+                    $warning->save();
 
-                        // Add +1 To Users Warnings Count In Users Table
-                        $hr->user->hitandruns++;
-                        $hr->user->save();
+                    History::query()
+                        ->where('torrent_id', '=', $hr->torrent_id)
+                        ->where('user_id', '=', $hr->user_id)
+                        ->update([
+                            'hitrun'     => true,
+                            'updated_at' => DB::raw('updated_at'),
+                        ]);
 
-                        // Add user to usersWithWarnings array
-                        $usersWithWarnings[$hr->user->id] = $hr->user;
-                    }
+                    // Add +1 To Users Warnings Count In Users Table
+                    $hr->user->hitandruns++;
+                    $hr->user->save();
+
+                    // Add user to usersWithWarnings array
+                    $usersWithWarnings[$hr->user->id] = $hr->user;
                 }
             }
+        }
 
-            // Send a single notification for each user with warnings
-            foreach ($usersWithWarnings as $user) {
-                $user->notify(new UserWarning($user));
-            }
+        // Send a single notification for each user with warnings
+        foreach ($usersWithWarnings as $user) {
+            $user->notify(new UserWarning($user));
+        }
 
-            // Calculate User Warning Count and Disable DL Priv If Required.
-            $warnings = Warning::with('warneduser')->select(DB::raw('user_id, count(*) as value'))->where('active', '=', 1)->groupBy('user_id')->having('value', '>=', config('hitrun.max_warnings'))->get();
+        // Calculate User Warning Count and Disable DL Priv If Required.
+        $warnings = Warning::with('warneduser')->select(DB::raw('user_id, count(*) as value'))->where('active', '=', 1)->groupBy('user_id')->having('value', '>=', config('hitrun.max_warnings'))->get();
 
-            foreach ($warnings as $warning) {
-                if ($warning->warneduser->can_download) {
-                    $warning->warneduser->can_download = 0;
-                    $warning->warneduser->save();
+        foreach ($warnings as $warning) {
+            if ($warning->warneduser->can_download) {
+                $warning->warneduser->can_download = 0;
+                $warning->warneduser->save();
 
-                    cache()->forget('user:'.$warning->warneduser->passkey);
-                    Unit3dAnnounce::addUser($warning->warneduser);
-                }
+                cache()->forget('user:'.$warning->warneduser->passkey);
+                Unit3dAnnounce::addUser($warning->warneduser);
             }
         }
 


### PR DESCRIPTION
Reducing indentation results in cleaner code and prevents bugs like #3802.