### PR TITLE
(Fix) Request deletion permissions

### DIFF
--- a/resources/views/requests/partials/delete.blade.php
+++ b/resources/views/requests/partials/delete.blade.php
@@ -1,18 +1,20 @@
-<li class="form__group form__group--short-horizontal">
-    <form
-        action="{{ route('requests.destroy', ['torrentRequest' => $torrentRequest]) }}"
-        method="POST"
-        x-data="confirmation"
-        style="display: contents"
-    >
-        @csrf
-        @method('DELETE')
-        <button
-            x-on:click.prevent="confirmAction"
-            data-b64-deletion-message="{{ base64_encode('Are you sure you want to delete this torrent request and lose the BON?') }}"
-            class="form__button form__button--outlined form__button--centered"
+@if ($canEdit)
+    <li class="form__group form__group--short-horizontal">
+        <form
+            action="{{ route('requests.destroy', ['torrentRequest' => $torrentRequest]) }}"
+            method="POST"
+            x-data="confirmation"
+            style="display: contents"
         >
-            {{ __('common.delete') }}
-        </button>
-    </form>
-</li>
+            @csrf
+            @method('DELETE')
+            <button
+                x-on:click.prevent="confirmAction"
+                data-b64-deletion-message="{{ base64_encode('Are you sure you want to delete this torrent request and lose the BON?') }}"
+                class="form__button form__button--outlined form__button--centered"
+            >
+                {{ __('common.delete') }}
+            </button>
+        </form>
+    </li>
+@endif


### PR DESCRIPTION
If we don't allow users to edit their request if someone else has added their bon to it, surely we shouldn't allow them to delete the request either.