### PR TITLE
(Fix) Warning actions on wrong warning

### DIFF
--- a/resources/views/livewire/user-warnings.blade.php
+++ b/resources/views/livewire/user-warnings.blade.php
@@ -91,7 +91,7 @@
             Soft Deleted ({{ $deletedWarningsCount ?? 0 }})
         </li>
     </menu>
-    <div class="data-table-wrapper" x-data="userWarnings">
+    <div class="data-table-wrapper">
         <table class="data-table">
             <thead>
                 <tr>
@@ -127,7 +127,7 @@
             </thead>
             <tbody>
                 @forelse ($warnings as $warning)
-                    <tr x-ref="warning" data-warning-id="{{ $warning->id }}">
+                    <tr x-data="userWarnings" data-warning-id="{{ $warning->id }}">
                         <td>
                             <x-user_tag :user="$warning->staffuser" :anon="false" />
                         </td>

--- a/resources/views/livewire/user-warnings.blade.php
+++ b/resources/views/livewire/user-warnings.blade.php
@@ -183,7 +183,6 @@
                                                 @method('PATCH')
                                                 <button
                                                     x-on:click.prevent="restoreWarning"
-                                                    data-warning-id="{{ $warning->id }}"
                                                     data-b64-deletion-message="{{ base64_encode('Are you sure you want to restore this warning: ' . $warning->reason . '?') }}"
                                                     class="form__button form__button--text"
                                                 >
@@ -199,7 +198,6 @@
                                                         @csrf
                                                         <button
                                                             x-on:click.prevent="deactivateWarning"
-                                                            data-warning-id="{{ $warning->id }}"
                                                             data-b64-deletion-message="{{ base64_encode('Are you sure you want to deactivate this warning: ' . $warning->reason . '?') }}"
                                                             class="form__button form__button--text"
                                                         >
@@ -213,7 +211,6 @@
                                                         @csrf
                                                         <button
                                                             x-on:click.prevent="reactivateWarning"
-                                                            data-warning-id="{{ $warning->id }}"
                                                             data-b64-deletion-message="{{ base64_encode('Are you sure you want to reactivate this warning: ' . $warning->reason . '?') }}"
                                                             class="form__button form__button--text"
                                                         >
@@ -229,7 +226,6 @@
                                                 @csrf
                                                 <button
                                                     x-on:click.prevent="destroyWarning"
-                                                    data-warning-id="{{ $warning->id }}"
                                                     data-b64-deletion-message="{{ base64_encode('Are you sure you want to delete this warning: ' . $warning->reason . '?') }}"
                                                     class="form__button form__button--text"
                                                 >
@@ -265,16 +261,16 @@
                     this.confirmAction(() => this.$wire.massDeactivate());
                 },
                 destroyWarning() {
-                    this.confirmAction(() => this.$wire.destroy(this.$el.dataset.warningId));
+                    this.confirmAction(() => this.$wire.destroy(this.$root.dataset.warningId));
                 },
                 reactivateWarning() {
-                    this.confirmAction(() => this.$wire.reactivate(this.$el.dataset.warningId));
+                    this.confirmAction(() => this.$wire.reactivate(this.$root.dataset.warningId));
                 },
                 deactivateWarning() {
-                    this.confirmAction(() => this.$wire.deactivate(this.$el.dataset.warningId));
+                    this.confirmAction(() => this.$wire.deactivate(this.$root.dataset.warningId));
                 },
                 restoreWarning() {
-                    this.confirmAction(() => this.$wire.restore(this.$el.dataset.warningId));
+                    this.confirmAction(() => this.$wire.restore(this.$root.dataset.warningId));
                 },
                 confirmAction(onConfirm) {
                     Swal.fire({

--- a/resources/views/livewire/user-warnings.blade.php
+++ b/resources/views/livewire/user-warnings.blade.php
@@ -265,24 +265,16 @@
                     this.confirmAction(() => this.$wire.massDeactivate());
                 },
                 destroyWarning() {
-                    this.confirmAction(() =>
-                        this.$wire.destroy(this.$el.dataset.warningId),
-                    );
+                    this.confirmAction(() => this.$wire.destroy(this.$el.dataset.warningId));
                 },
                 reactivateWarning() {
-                    this.confirmAction(() =>
-                        this.$wire.reactivate(this.$el.dataset.warningId),
-                    );
+                    this.confirmAction(() => this.$wire.reactivate(this.$el.dataset.warningId));
                 },
                 deactivateWarning() {
-                    this.confirmAction(() =>
-                        this.$wire.deactivate(this.$el.dataset.warningId),
-                    );
+                    this.confirmAction(() => this.$wire.deactivate(this.$el.dataset.warningId));
                 },
                 restoreWarning() {
-                    this.confirmAction(() =>
-                        this.$wire.restore(this.$el.dataset.warningId),
-                    );
+                    this.confirmAction(() => this.$wire.restore(this.$el.dataset.warningId));
                 },
                 confirmAction(onConfirm) {
                     Swal.fire({

--- a/resources/views/livewire/user-warnings.blade.php
+++ b/resources/views/livewire/user-warnings.blade.php
@@ -183,6 +183,7 @@
                                                 @method('PATCH')
                                                 <button
                                                     x-on:click.prevent="restoreWarning"
+                                                    data-warning-id="{{ $warning->id }}"
                                                     data-b64-deletion-message="{{ base64_encode('Are you sure you want to restore this warning: ' . $warning->reason . '?') }}"
                                                     class="form__button form__button--text"
                                                 >
@@ -198,6 +199,7 @@
                                                         @csrf
                                                         <button
                                                             x-on:click.prevent="deactivateWarning"
+                                                            data-warning-id="{{ $warning->id }}"
                                                             data-b64-deletion-message="{{ base64_encode('Are you sure you want to deactivate this warning: ' . $warning->reason . '?') }}"
                                                             class="form__button form__button--text"
                                                         >
@@ -211,6 +213,7 @@
                                                         @csrf
                                                         <button
                                                             x-on:click.prevent="reactivateWarning"
+                                                            data-warning-id="{{ $warning->id }}"
                                                             data-b64-deletion-message="{{ base64_encode('Are you sure you want to reactivate this warning: ' . $warning->reason . '?') }}"
                                                             class="form__button form__button--text"
                                                         >
@@ -226,6 +229,7 @@
                                                 @csrf
                                                 <button
                                                     x-on:click.prevent="destroyWarning"
+                                                    data-warning-id="{{ $warning->id }}"
                                                     data-b64-deletion-message="{{ base64_encode('Are you sure you want to delete this warning: ' . $warning->reason . '?') }}"
                                                     class="form__button form__button--text"
                                                 >
@@ -262,22 +266,22 @@
                 },
                 destroyWarning() {
                     this.confirmAction(() =>
-                        this.$wire.destroy(this.$refs.warning.dataset.warningId),
+                        this.$wire.destroy(this.$el.dataset.warningId),
                     );
                 },
                 reactivateWarning() {
                     this.confirmAction(() =>
-                        this.$wire.reactivate(this.$refs.warning.dataset.warningId),
+                        this.$wire.reactivate(this.$el.dataset.warningId),
                     );
                 },
                 deactivateWarning() {
                     this.confirmAction(() =>
-                        this.$wire.deactivate(this.$refs.warning.dataset.warningId),
+                        this.$wire.deactivate(this.$el.dataset.warningId),
                     );
                 },
                 restoreWarning() {
                     this.confirmAction(() =>
-                        this.$wire.restore(this.$refs.warning.dataset.warningId),
+                        this.$wire.restore(this.$el.dataset.warningId),
                     );
                 },
                 confirmAction(onConfirm) {


### PR DESCRIPTION
Fixes the issue where deactivating/deleting/restoring/reactivating a warning performed the action on a random warning instead of the once selected.