### PR TITLE
(Fix) System users not included in conversation

### DIFF
--- a/app/Jobs/ProcessMassPM.php
+++ b/app/Jobs/ProcessMassPM.php
@@ -18,7 +18,6 @@ namespace App\Jobs;
 
 use App\Models\Conversation;
 use App\Models\PrivateMessage;
-use App\Models\User;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
@@ -46,13 +45,7 @@ class ProcessMassPM implements ShouldQueue
     {
         $conversation = Conversation::create(['subject' => $this->subject]);
 
-        if ($this->senderId !== User::SYSTEM_USER_ID) {
-            $conversation->users()->sync([$this->senderId => ['read' => true]]);
-        }
-
-        if ($this->receiverId !== User::SYSTEM_USER_ID) {
-            $conversation->users()->sync([$this->receiverId]);
-        }
+        $conversation->users()->sync([$this->senderId => ['read' => true], $this->receiverId]);
 
         PrivateMessage::create([
             'conversation_id' => $conversation->id,

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -948,7 +948,7 @@ class User extends Authenticatable implements MustVerifyEmail
     {
         $conversation = Conversation::create(['subject' => $subject]);
 
-        $conversation->users()->sync([$this->id]);
+        $conversation->users()->sync([User::SYSTEM_USER_ID => ['read' => true], $this->id]);
 
         PrivateMessage::create([
             'conversation_id' => $conversation->id,
@@ -961,7 +961,7 @@ class User extends Authenticatable implements MustVerifyEmail
     {
         $conversation = Conversation::create(['subject' => $subject]);
 
-        $conversation->users()->sync([$userId]);
+        $conversation->users()->sync([User::SYSTEM_USER_ID => ['read' => true], $userId]);
 
         PrivateMessage::create([
             'conversation_id' => $conversation->id,


### PR DESCRIPTION
We need to include system users in the conversation, even if they are soft deleted in cron job, that way they show up in the private message list

fixes #4093 