### PR TITLE
(Fix) Groupings dropdown and odd/even row colors

### DIFF
--- a/resources/sass/pages/_torrents.scss
+++ b/resources/sass/pages/_torrents.scss
@@ -531,6 +531,8 @@
 .torrent-search--grouped__dropdown {
     display: block;
     font-size: 13px;
+    background-color: var(--torrent-group-bg);
+    color: var(--torrent-group-text);
 
     > summary {
         padding: 6px;
@@ -601,7 +603,11 @@
 }
 
 .torrent-search--grouped__torrents tbody:nth-child(odd) {
-    background-color: var(--torrent-group-table-stripe);
+    background-color: var(--torrent-group-table-stripe-odd);
+}
+
+.torrent-search--grouped__torrents tbody:nth-child(even) {
+    background-color: var(--torrent-group-table-stripe-even);
 }
 
 .torrent-search--grouped__torrents > tbody > tr {
@@ -954,7 +960,11 @@ td.torrent-search--grouped__age time {
 }
 
 .similar-torrents__torrents tbody:nth-child(odd) {
-    background-color: var(--torrent-group-table-stripe);
+    background-color: var(--torrent-group-table-stripe-odd);
+}
+
+.similar-torrents__torrents tbody:nth-child(even) {
+    background-color: var(--torrent-group-table-stripe-even);
 }
 
 .similar-torrents__torrents > tbody > tr {

--- a/resources/sass/themes/_cosmic-void.scss
+++ b/resources/sass/themes/_cosmic-void.scss
@@ -309,7 +309,8 @@
     --torrent-group-header-bg: #303030;
     --torrent-group-text: white;
     --torrent-group-text-muted: #878787;
-    --torrent-group-table-stripe: rgba(255, 255, 255, 0.05);
+    --torrent-group-table-stripe-even: rgba(255, 255, 255, 0.02);
+    --torrent-group-table-stripe-odd: rgba(255, 255, 255, 0.05);
     --torrent-group-hover-brightness-emphasis: 1.2;
     --torrent-group-chip-border: rgba(255, 255, 255, 0.05);
 

--- a/resources/sass/themes/_galactic.scss
+++ b/resources/sass/themes/_galactic.scss
@@ -337,7 +337,8 @@
     --torrent-group-header-bg: #303030;
     --torrent-group-text: white;
     --torrent-group-text-muted: #878787;
-    --torrent-group-table-stripe: rgba(255, 255, 255, 0.05);
+    --torrent-group-table-stripe-even: rgba(255, 255, 255, 0.02);
+    --torrent-group-table-stripe-odd: rgba(255, 255, 255, 0.05);
     --torrent-group-hover-brightness-emphasis: 1.2;
     --torrent-group-chip-border: rgba(255, 255, 255, 0.05);
 

--- a/resources/sass/themes/_light.scss
+++ b/resources/sass/themes/_light.scss
@@ -315,7 +315,8 @@
     --torrent-group-header-bg: #d3d3d3;
     --torrent-group-text: #555;
     --torrent-group-text-muted: #555;
-    --torrent-group-table-stripe: rgba(0, 0, 0, 0.05);
+    --torrent-group-table-stripe-even: rgba(0, 0, 0, 0.015);
+    --torrent-group-table-stripe-odd: rgba(0, 0, 0, 0.07);
     --torrent-group-hover-brightness-emphasis: 1.13;
     --torrent-group-chip-border: #eee;
 

--- a/resources/sass/themes/_material-design-v3-amoled.scss
+++ b/resources/sass/themes/_material-design-v3-amoled.scss
@@ -314,7 +314,8 @@
     --torrent-group-header-bg: #000;
     --torrent-group-text: #aaa;
     --torrent-group-text-muted: #888;
-    --torrent-group-table-stripe: rgba(255, 255, 255, 0.06);
+    --torrent-group-table-stripe-even: rgba(255, 255, 255, 0.02);
+    --torrent-group-table-stripe-odd: rgba(255, 255, 255, 0.05);
     --torrent-group-hover-brightness-emphasis: 1.13;
     --torrent-group-chip-border: #222;
 

--- a/resources/sass/themes/_material-design-v3-dark.scss
+++ b/resources/sass/themes/_material-design-v3-dark.scss
@@ -315,7 +315,8 @@
     --torrent-group-header-bg: #343338;
     --torrent-group-text: #aaa;
     --torrent-group-text-muted: #888;
-    --torrent-group-table-stripe: rgba(0, 0, 0, 0.08);
+    --torrent-group-table-stripe-even: rgba(0, 0, 0, 0.18);
+    --torrent-group-table-stripe-odd: rgba(0, 0, 0, 0.1);
     --torrent-group-hover-brightness-emphasis: 1.13;
     --torrent-group-chip-border: #444;
 

--- a/resources/sass/themes/_material-design-v3-light.scss
+++ b/resources/sass/themes/_material-design-v3-light.scss
@@ -314,7 +314,8 @@
     --torrent-group-header-bg: #fff;
     --torrent-group-text: #333;
     --torrent-group-text-muted: #555;
-    --torrent-group-table-stripe: rgba(0, 0, 0, 0.05);
+    --torrent-group-table-stripe-odd: rgba(0, 0, 0, 0.02);
+    --torrent-group-table-stripe-even: rgba(0, 0, 0, 0.05);
     --torrent-group-hover-brightness-emphasis: 1.13;
     --torrent-group-chip-border: #eee;
 

--- a/resources/sass/themes/_nord.scss
+++ b/resources/sass/themes/_nord.scss
@@ -330,7 +330,8 @@
     --torrent-group-header-bg: #434c5e;
     --torrent-group-text: inherit;
     --torrent-group-text-muted: #d8dee9;
-    --torrent-group-table-stripe: rgba(0, 0, 0, 0.04);
+    --torrent-group-table-stripe-even: rgba(0, 0, 0, 0.03);
+    --torrent-group-table-stripe-odd: rgba(0, 0, 0, 0.1);
     --torrent-group-hover-brightness-emphasis: 1.05;
     --torrent-group-chip-border: #4c566a;
 

--- a/resources/sass/themes/_revel.scss
+++ b/resources/sass/themes/_revel.scss
@@ -335,7 +335,8 @@
     --torrent-group-header-bg: #3a3a3a;
     --torrent-group-text: white;
     --torrent-group-text-muted: #aaa;
-    --torrent-group-table-stripe: rgba(255, 255, 255, 0.05);
+    --torrent-group-table-stripe-odd: rgba(255, 255, 255, 0.03);
+    --torrent-group-table-stripe-even: rgba(255, 255, 255, 0.06);
     --torrent-group-hover-brightness-emphasis: 1.2;
     --torrent-group-chip-border: rgba(255, 255, 255, 0.05);
 


### PR DESCRIPTION
Increase the contrast of odd/even row and make sure that both odd/even are different than dropdown color. Add intended background color and foreground color to dropdowns which were missing on similar page previously.