### PR TITLE
(Fix) Search filter width on groupings view

### DIFF
--- a/resources/sass/pages/_torrents.scss
+++ b/resources/sass/pages/_torrents.scss
@@ -24,7 +24,13 @@
 
 @supports selector(:has(.torrent-search-grouped_-results)) {
     .torrent-search__filters {
-        margin: 0 max(12px, 45vw - 600px);
+        margin: 0 max(12px, 45vw - 600px); /* Adds magic numbers to shrink the advanced search a shorter width than the results on higher resolutions. */
+    }
+
+    .torrent-search__filters:has(
+            + .torrent-search__results .torrent-search--grouped__results
+        ) {
+        margin: 0 calc(-1 * max(0px, 45vw - 800px) + max(12px, 45vw - 600px)); /* Inverses the magic numbers used in main layout styles for high resolution then adds own magic numbers */
     }
 }
 
@@ -951,6 +957,10 @@ td.torrent-search--grouped__age time {
     border-style: solid;
     border-color: var(--torrent-group-header-bg);
     border-collapse: collapse;
+}
+
+.similar-torrents__filters {
+    margin: 0 calc(-1 * max(0px, 45vw - 800px) + max(12px, 45vw - 600px)); /* Inverses the magic numbers used in main layout styles for high resolution then adds own magic numbers */
 }
 
 .similar-torrents__torrents tbody:nth-child(odd) {

--- a/resources/views/livewire/similar-torrent.blade.php
+++ b/resources/views/livewire/similar-torrent.blade.php
@@ -1,6 +1,6 @@
 <div class="similar-torrents-list">
     <div style="display: flex; flex-direction: column; gap: 16px">
-        <section class="panelV2 torrent-search__filters" x-data="toggle">
+        <section class="panelV2 similar-torrents__filters" x-data="toggle">
             <header class="panel__header">
                 <h2 class="panel__heading">{{ __('common.search') }}</h2>
                 <div class="panel__actions">


### PR DESCRIPTION
These were missed when I originally added them because my browser didn't support `:has` so I was seeing the `@supports not` styles instead. I added the proper selector this time and copied the styles from the `@supports not` styles.