### PR TITLE
(Fix) Torrent name overflowing panel on low resolutions

### DIFF
--- a/resources/sass/pages/_torrents.scss
+++ b/resources/sass/pages/_torrents.scss
@@ -961,7 +961,6 @@ td.torrent-search--grouped__age time {
     border-bottom: 0;
 }
 
-.similar-torrents__torrents tr:last-child,
 th.similar-torrents__type {
     background-color: initial;
     font-size: 13px;


### PR DESCRIPTION
Applying nowrap to the last table row doesn't make any sense and all descendant elements inherit the style.