### PR TITLE
(Update) Use universal date format for tickets

### DIFF
--- a/resources/views/ticket/show.blade.php
+++ b/resources/views/ticket/show.blade.php
@@ -135,7 +135,7 @@
                             datetime="{{ $ticket->closed_at }}"
                             title="{{ $ticket->closed_at }}"
                         >
-                            {{ $ticket->closed_at->format('m/d/Y') }}
+                            {{ $ticket->closed_at->format('Y-m-d') }}
                         </time>
                     </dd>
                 </div>


### PR DESCRIPTION
I can never remember if it's m/d/y or d/m/y and there already exists a universal standard that solves this problem. This is the only place in the codebase that doesn't use Y-m-d.