### PR TITLE
(Update) Add indexes to torrents table

### DIFF
--- a/database/migrations/2024_07_02_082323_add_indexes_to_torrents_table.php
+++ b/database/migrations/2024_07_02_082323_add_indexes_to_torrents_table.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * NOTICE OF LICENSE.
+ *
+ * UNIT3D Community Edition is open-sourced software licensed under the GNU Affero General Public License v3.0
+ * The details is bundled with this project in the file LICENSE.txt.
+ *
+ * @project    UNIT3D Community Edition
+ *
+ * @author     Roardom <roardom@protonmail.com>
+ * @license    https://www.gnu.org/licenses/agpl-3.0.en.html/ GNU Affero General Public License v3.0
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('torrents', function (Blueprint $table): void {
+            $table->index(['user_id', 'status', 'anon', 'deleted_at']);
+            $table->index('name');
+        });
+    }
+};


### PR DESCRIPTION
Index on the name makes it so that the query to check if a torrent of the same name already exists upons upload is instant instead of taking 600 ms. Index on user_id, status, anon, deleted_at makes home page load instantly instead of taking 10+ seconds to calculate user stats.