### PR TITLE
(Fix) Show trumping icon on similar page

### DIFF
--- a/app/Http/Livewire/SimilarTorrent.php
+++ b/app/Http/Livewire/SimilarTorrent.php
@@ -258,6 +258,7 @@ class SimilarTorrent extends Component
                             ->where('seeder', '=', 1)
                             ->orWhereNotNull('completed_at')
                     ),
+                'trump',
             ])
             ->when(
                 $this->category->movie_meta,


### PR DESCRIPTION
`trump` must be included if exists in order to show the trumping icon in the torrents.similar view.