### PR TITLE
(Update) Don't shorten date format in torrent downloads search

### DIFF
--- a/resources/views/livewire/torrent-download-search.blade.php
+++ b/resources/views/livewire/torrent-download-search.blade.php
@@ -178,7 +178,7 @@
                                             datetime="{{ $torrentDownload->created_at_min }}"
                                             title="{{ $torrentDownload->created_at_min }}"
                                         >
-                                            {{ $torrentDownload->created_at_min->format('Y-m-d') }}
+                                            {{ $torrentDownload->created_at_min }}
                                         </time>
                                     </td>
                                     <td>
@@ -186,7 +186,7 @@
                                             datetime="{{ $torrentDownload->created_at_max }}"
                                             title="{{ $torrentDownload->created_at_max }}"
                                         >
-                                            {{ $torrentDownload->created_at_max->format('Y-m-d') }}
+                                            {{ $torrentDownload->created_at_max }}
                                         </time>
                                     </td>
                                 </tr>
@@ -253,7 +253,7 @@
                                             datetime="{{ $torrentDownload->created_at }}"
                                             title="{{ $torrentDownload->created_at }}"
                                         >
-                                            {{ $torrentDownload->created_at->format('Y-m-d') }}
+                                            {{ $torrentDownload->created_at }}
                                         </time>
                                     </td>
                                 </tr>


### PR DESCRIPTION
It's more convenient to scan timestamps to find a pattern between subsequent downloads from the same user.