### PR TITLE
(Fix) Stats show total seedtime, not avg

### DIFF
--- a/resources/views/livewire/top-users.blade.php
+++ b/resources/views/livewire/top-users.blade.php
@@ -271,7 +271,7 @@
                             </h3>
                             <h4 class="user-stat-card__stat">
                                 {{ App\Helpers\StringHelper::timeElapsed($seedtime->seedtime ?? 0) }}
-                                Seedtime Average
+                                {{ __('user.total-seedtime') }}
                             </h4>
 
                             @if ($seedtime->privacy?->private_profile)


### PR DESCRIPTION
The stats calculate the total seed time, not the average. Therefor, naming should be for total time.