### PR TITLE
(Fix) Torrent/request showing two imdb links when leading zeroes

### DIFF
--- a/resources/views/torrent/partials/movie_meta.blade.php
+++ b/resources/views/torrent/partials/movie_meta.blade.php
@@ -113,7 +113,7 @@
             </li>
         @endforeach
 
-        @foreach (array_unique(array_filter([$meta->imdb_id ?? 0, $torrent->imdb ?? 0])) as $imdbId)
+        @foreach (array_unique(array_filter([(int) $meta->imdb_id ?? 0, $torrent->imdb ?? 0])) as $imdbId)
             <li class="meta__imdb">
                 <a
                     class="meta-id-tag"

--- a/resources/views/torrent/partials/tv_meta.blade.php
+++ b/resources/views/torrent/partials/tv_meta.blade.php
@@ -112,7 +112,7 @@
             </li>
         @endforeach
 
-        @foreach (array_unique(array_filter([$meta->imdb_id ?? 0, $torrent->imdb ?? 0])) as $imdbId)
+        @foreach (array_unique(array_filter([(int) $meta->imdb_id ?? 0, $torrent->imdb ?? 0])) as $imdbId)
             <li class="meta__imdb">
                 <a
                     class="meta-id-tag"


### PR DESCRIPTION
Leading zeroes would cause the comparing to see different ids, and then end up generating the same ids twice, causing two identical links to appear.