### PR TITLE
(Fix) Comparison image size override

### DIFF
--- a/resources/sass/components/_comparison.scss
+++ b/resources/sass/components/_comparison.scss
@@ -52,6 +52,7 @@
 .comparison__image {
     image-rendering: crisp-edges;
     max-width: max-content !important;
+    max-height: max-content !important;
 }
 
 .comparison__figcaption {


### PR DESCRIPTION
Torrent comments prevent huge image sizes, but comparison images shouldn't be restricted to this. All that's needed is to define an original image height so that it's not overrided by the max image size css in the comment styles.