### PR TITLE
(Fix) Only delete audit log entries newer than unix epoch

### DIFF
--- a/app/Console/Commands/AutoRecycleAudits.php
+++ b/app/Console/Commands/AutoRecycleAudits.php
@@ -19,6 +19,7 @@ namespace App\Console\Commands;
 use App\Models\Audit;
 use Exception;
 use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
 use Throwable;
 
 class AutoRecycleAudits extends Command
@@ -45,7 +46,7 @@ class AutoRecycleAudits extends Command
     final public function handle(): void
     {
         Audit::query()
-            ->where('created_at', '<', now()->subDays(config('audit.recycle')))
+            ->where('created_at', '<', now()->subDays(config('audit.recycle'))->max(Carbon::createFromTimestamp(0)))
             ->delete();
 
         $this->comment('Automated Audit Recycle Command Complete');


### PR DESCRIPTION
It's easy for the config entry to recycle audits after a huge number of days. For example, a number of days less than the unix epoch once subtracted from the current time. Such a number will generate errors in the cron job audit recycling query. So, limit queries to use a datetime newer than the unix epoch to compensate.