### PR TITLE
(Add) Client torrent size sum to profile page

### DIFF
--- a/app/Http/Controllers/User/UserController.php
+++ b/app/Http/Controllers/User/UserController.php
@@ -93,8 +93,14 @@ class UserController extends Controller
             // 'boughtDownload'        => BonTransactions::where('sender_id', '=', $user->id)->where([['name', 'like', '%Download%']])->sum('cost'),
             'invitedBy' => Invite::where('accepted_by', '=', $user->id)->first(),
             'clients'   => $user->peers()
+                ->join('torrents', 'torrents.id', '=', 'peers.torrent_id')
                 ->select('agent', 'port')
-                ->selectRaw('INET6_NTOA(ip) as ip, MIN(created_at) as created_at, MAX(updated_at) as updated_at, COUNT(*) as num_peers, MAX(connectable) as connectable')
+                ->selectRaw('INET6_NTOA(peers.ip) as ip')
+                ->selectRaw('MIN(peers.created_at) as created_at')
+                ->selectRaw('MAX(peers.updated_at) as updated_at')
+                ->selectRaw('SUM(torrents.size) as size')
+                ->selectRaw('COUNT(*) as num_peers')
+                ->selectRaw('MAX(peers.connectable) as connectable')
                 ->groupBy(['ip', 'port', 'agent'])
                 ->where('active', '=', true)
                 ->get(),

--- a/resources/views/user/profile/show.blade.php
+++ b/resources/views/user/profile/show.blade.php
@@ -256,6 +256,7 @@
                                 <th>{{ __('torrent.started') }}</th>
                                 <th>{{ __('torrent.last-update') }}</th>
                                 <th>{{ __('torrent.peers') }}</th>
+                                <th>{{ __('torrent.size') }}</th>
                                 @if (\config('announce.connectable_check') === true)
                                     <th>Connectable</th>
                                 @endif
@@ -299,6 +300,9 @@
                                         >
                                             {{ $client->num_peers }}
                                         </a>
+                                    </td>
+                                    <td>
+                                        {{ App\Helpers\StringHelper::formatBytes($client->size) }}
                                     </td>
                                     @if (\config('announce.connectable_check') == true)
                                         @php


### PR DESCRIPTION
This query's execution time is increased from 10 ms to ~550 ms for power users with a few thousand torrents, or ~30 ms for average users with a few dozen torrents. Is the increased page load time worth its usefulness?