### PR TITLE
(Add) Allow the use of channel_key to join the announce channel

### DIFF
--- a/app/Bots/IRCAnnounceBot.php
+++ b/app/Bots/IRCAnnounceBot.php
@@ -117,10 +117,11 @@ class IRCAnnounceBot
     public function to(string $recipient): self
     {
         $this->recipient = $recipient;
+        $channelKey = config('irc-bot.channel_key', '');
 
         if (config('irc-bot.joinchannel')) {
             if ($this->isValidChannelName($recipient)) {
-                $this->join($recipient);
+                $this->join($recipient, $channelKey);
                 $this->isInChannel = true;
             } else {
                 Log::error('Tried to channel with invalid name.', [
@@ -192,7 +193,7 @@ class IRCAnnounceBot
     /**
      * @see https://www.rfc-editor.org/rfc/rfc1459#section-4.2.1
      */
-    private function join(string $channel, string $key = ''): void
+    private function join(string $channel, string $channelKey = ''): void
     {
         if (!$this->isValidChannelName($channel)) {
             Log::error('Tried to join a channel with invalid name.', ['name' => $channel]);
@@ -200,7 +201,7 @@ class IRCAnnounceBot
             return;
         }
 
-        $this->send("JOIN {$channel} {$key}");
+        $this->send("JOIN {$channel} {$channelKey}");
     }
 
     /**

--- a/app/Http/Controllers/AnnounceController.php
+++ b/app/Http/Controllers/AnnounceController.php
@@ -153,7 +153,7 @@ final class AnnounceController extends Controller
         }
 
         // Block Other Browser, Crawler (May Cheater or Faker Client) by check Requests headers
-        if(
+        if (
             $request->header('accept-language')
             || $request->header('referer')
             || $request->header('accept-charset')
@@ -207,7 +207,7 @@ final class AnnounceController extends Controller
         }
 
         // If Passkey Length Is Wrong
-        if(\strlen($passkey) !== 32) {
+        if (\strlen($passkey) !== 32) {
             throw new TrackerException(132, [':attribute' => 'passkey', ':rule' => 32]);
         }
 

--- a/app/Http/Controllers/TicketAttachmentController.php
+++ b/app/Http/Controllers/TicketAttachmentController.php
@@ -38,7 +38,7 @@ class TicketAttachmentController extends Controller
      */
     public static function storeTicketAttachments(Request $request, Ticket $ticket, User $user): void
     {
-        foreach($request->attachments as $file) {
+        foreach ($request->attachments as $file) {
             if ($file->getSize() > 1000000) {
                 continue;
             }

--- a/app/Http/Controllers/TicketController.php
+++ b/app/Http/Controllers/TicketController.php
@@ -50,7 +50,7 @@ class TicketController extends Controller
     {
         $ticket = Ticket::create(['user_id' => $request->user()->id] + $request->validated());
 
-        if($request->hasFile('attachments')) {
+        if ($request->hasFile('attachments')) {
             TicketAttachmentController::storeTicketAttachments($request, $ticket, $request->user());
         }
 

--- a/app/Http/Controllers/TorrentController.php
+++ b/app/Http/Controllers/TorrentController.php
@@ -423,7 +423,7 @@ class TorrentController extends Controller
         // Backup the files contained in the torrent
         $files = TorrentTools::getTorrentFiles($decodedTorrent);
 
-        foreach($files as &$file) {
+        foreach ($files as &$file) {
             $file['torrent_id'] = $torrent->id;
         }
 

--- a/config/irc-bot.php
+++ b/config/irc-bot.php
@@ -30,6 +30,7 @@ return [
     'username'     => 'UNIT3D',
     'password'     => 'UNIT3D',
     'channel'      => '#announce',
+    'channel_key'  => 'UNIT3D',
     'nickservpass' => false,
     'joinchannel'  => false,
 ];


### PR DESCRIPTION
I added the option `channel_key` to irc-bot and renamed `$key` to `$channel_key` to make reading easier.

Many trackers use a shared key to join their #announce channel, and these changes will enable UNIT3D to send messages to those channels. 