### PR TITLE
(Update) Remove bbcode tags if selection already contains tags

### DIFF
--- a/resources/views/livewire/bbcode-input.blade.php
+++ b/resources/views/livewire/bbcode-input.blade.php
@@ -345,12 +345,22 @@
                     input = this.$refs.bbcode;
                     start = input.selectionStart;
                     end = input.selectionEnd;
-                    input.value =
-                        input.value.substring(0, start) +
-                        openTag +
-                        input.value.substring(start, end) +
-                        closeTag +
-                        input.value.substring(end);
+                    alreadyNested =
+                        input.value.substring(start, start + openTag.length) === openTag &&
+                        input.value.substring(end - closeTag.length, end) === closeTag;
+                    if (alreadyNested) {
+                        input.value =
+                            input.value.substring(0, start) +
+                            input.value.substring(start + openTag.length, end - closeTag.length) +
+                            input.value.substring(end);
+                    } else {
+                        input.value =
+                            input.value.substring(0, start) +
+                            openTag +
+                            input.value.substring(start, end) +
+                            closeTag +
+                            input.value.substring(end);
+                    }
                     input.dispatchEvent(new Event('input'));
                     input.focus();
                     if (openTag.charAt(openTag.length - 2) === '=') {
@@ -361,7 +371,11 @@
                     } else if (start == end) {
                         input.setSelectionRange(start + openTag.length, end + openTag.length);
                     } else {
-                        input.setSelectionRange(start, end + openTag.length + closeTag.length);
+                        if (alreadyNested) {
+                            input.setSelectionRange(start, end - openTag.length - closeTag.length);
+                        } else {
+                            input.setSelectionRange(start, end + openTag.length + closeTag.length);
+                        }
                     }
                 },
             }));


### PR DESCRIPTION
This way, pushing bold twice first removes the bold tags, then removes the tags on the second button push. For convenience. Hopefully I'm not missing any edge cases where this isn't intended behavior.