### PR TITLE
(Update) Add indexes to audits to speed up staff activity counts

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -948,6 +948,16 @@ class User extends Authenticatable implements MustVerifyEmail
     }
 
     /**
+     * Has Many Audits.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany<Audit, $this>
+     */
+    public function audits(): \Illuminate\Database\Eloquent\Relations\HasMany
+    {
+        return $this->hasMany(Audit::class);
+    }
+
+    /**
      * Has many donations.
      *
      * @return \Illuminate\Database\Eloquent\Relations\HasMany<Donation, $this>

--- a/resources/views/Staff/audit/index.blade.php
+++ b/resources/views/Staff/audit/index.blade.php
@@ -35,14 +35,14 @@
                     </tr>
                 </thead>
                 <tbody>
-                    @foreach ($staffActivities as $activity)
+                    @foreach ($staffUsers as $staffUser)
                         <tr>
                             <td>
-                                <x-user_tag :anon="false" :user="$activity->user" />
+                                <x-user_tag :anon="false" :user="$staffUser" />
                             </td>
-                            <td>{{ $activity->last_30_days }}</td>
-                            <td>{{ $activity->last_60_days }}</td>
-                            <td>{{ $activity->total_actions }}</td>
+                            <td>{{ $staffUser->last_30_days }}</td>
+                            <td>{{ $staffUser->last_60_days }}</td>
+                            <td>{{ $staffUser->total_actions }}</td>
                         </tr>
                     @endforeach
                 </tbody>


### PR DESCRIPTION
Speeds up the queries from 1.1 s to 75 ms.