### PR TITLE
(Update) Improve db performance when calculating top movie/tv statistics

### DIFF
--- a/database/migrations/2024_09_29_041904_add_indexes_for_top10_performance.php
+++ b/database/migrations/2024_09_29_041904_add_indexes_for_top10_performance.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * NOTICE OF LICENSE.
+ *
+ * UNIT3D Community Edition is open-sourced software licensed under the GNU Affero General Public License v3.0
+ * The details is bundled with this project in the file LICENSE.txt.
+ *
+ * @project    UNIT3D Community Edition
+ *
+ * @author     Roardom <roardom@protonmail.com>
+ * @license    https://www.gnu.org/licenses/agpl-3.0.en.html/ GNU Affero General Public License v3.0
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('torrents', function (Blueprint $table): void {
+            $table->index(['category_id', 'status', 'deleted_at', 'tmdb', 'size']);
+        });
+
+        Schema::table('history', function (Blueprint $table): void {
+            $table->index(['torrent_id', 'completed_at', 'created_at']);
+        });
+    }
+};


### PR DESCRIPTION
Improves the query time from 23 s to 1.5 s on my untuned dev instance for top10 queries and yearly overview queries. We have a little bit of wiggle room in history table upserts that we can afford the extra index update on history creation/completion to compensate from these otherwise very slow queries.