### PR TITLE
(Fix) Lag in Chrome when meta has lots of credits

### DIFF
--- a/resources/sass/components/_meta.scss
+++ b/resources/sass/components/_meta.scss
@@ -263,13 +263,14 @@
     overflow-x: auto;
     grid-area: chips;
     gap: 24px;
+    will-change: transform;
 }
 
 .meta__chip-container {
     position: relative;
     padding-top: 16px;
     height: calc(100%);
-    overflow-y: auto;
+    overflow-y: scroll;
     flex: 1 0 200px;
 }
 
@@ -314,6 +315,7 @@
     gap: 3px 20px;
     border-radius: 26px;
     padding: 6px 26px 6px 6px;
+    will-change: backdrop-filter, background;
 }
 
 .meta-chip:hover {

--- a/resources/views/torrent/partials/movie_meta.blade.php
+++ b/resources/views/torrent/partials/movie_meta.blade.php
@@ -201,6 +201,7 @@
                                 class="meta-chip__image"
                                 src="{{ tmdb_image('cast_face', $credit->person->still) }}"
                                 alt=""
+                                loading="lazy"
                             />
                         @else
                             <i
@@ -226,6 +227,7 @@
                                 class="meta-chip__image"
                                 src="{{ tmdb_image('cast_face', $credit->person->still) }}"
                                 alt=""
+                                loading="lazy"
                             />
                         @else
                             <i

--- a/resources/views/torrent/partials/tv_meta.blade.php
+++ b/resources/views/torrent/partials/tv_meta.blade.php
@@ -200,6 +200,7 @@
                                 class="meta-chip__image"
                                 src="{{ tmdb_image('cast_face', $credit->person->still) }}"
                                 alt=""
+                                loading="lazy"
                             />
                         @else
                             <i
@@ -225,6 +226,7 @@
                                 class="meta-chip__image"
                                 src="{{ tmdb_image('cast_face', $credit->person->still) }}"
                                 alt=""
+                                loading="lazy"
                             />
                         @else
                             <i


### PR DESCRIPTION
On pages with lots of credits, like /similar/2.1431, Chrome will crash (on modern hardware). `loading="lazy"` fixes the crash. The other changes make the actor list not lag immensely when scrolling. Each change makes it slightly faster.

Fixes #4104 