### PR TITLE
(Update) Remove unncessary home page queries

### DIFF
--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -17,9 +17,7 @@ declare(strict_types=1);
 namespace App\Http\Controllers;
 
 use App\Models\Article;
-use App\Models\Bookmark;
 use App\Models\FeaturedTorrent;
-use App\Models\FreeleechToken;
 use App\Models\Group;
 use App\Models\Poll;
 use App\Models\Post;
@@ -55,9 +53,8 @@ class HomeController extends Controller
         }
 
         return view('home.index', [
-            'user'               => $user,
-            'personal_freeleech' => cache()->get('personal_freeleech:'.$user->id),
-            'users'              => cache()->remember(
+            'user'  => $user,
+            'users' => cache()->remember(
                 'online_users:by-group:'.auth()->user()->group_id,
                 $expiresAt,
                 fn () => User::with('group', 'privacy')
@@ -121,8 +118,6 @@ class HomeController extends Controller
                         ->orWhereNull('expires_at');
                 })->latest()->first();
             }),
-            'freeleech_tokens' => FreeleechToken::where('user_id', $user->id)->get(),
-            'bookmarks'        => Bookmark::where('user_id', $user->id)->get(),
         ]);
     }
 }

--- a/tests/Feature/Http/Controllers/HomeControllerTest.php
+++ b/tests/Feature/Http/Controllers/HomeControllerTest.php
@@ -23,7 +23,6 @@ test('index returns an ok response', function (): void {
     $response->assertOk();
     $response->assertViewIs('home.index');
     $response->assertViewHas('user');
-    $response->assertViewHas('personal_freeleech');
     $response->assertViewHas('users');
     $response->assertViewHas('groups');
     $response->assertViewHas('articles');
@@ -31,6 +30,4 @@ test('index returns an ok response', function (): void {
     $response->assertViewHas('posts');
     $response->assertViewHas('featured');
     $response->assertViewHas('poll');
-    $response->assertViewHas('freeleech_tokens');
-    $response->assertViewHas('bookmarks');
 });


### PR DESCRIPTION
The data from these queries were originally used directly in the views to avoid n+1, but now the TopTorrents Livewire component includes the appropriate queries.