### PR TITLE
(Update) Improve footer performance

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -19,13 +19,11 @@ namespace App\Providers;
 use App\Helpers\ByteUnits;
 use App\Helpers\HiddenCaptcha;
 use App\Interfaces\ByteUnitsInterface;
-use App\Models\Page;
 use App\Models\User;
 use App\Observers\UserObserver;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\Vite;
 use Illuminate\Support\ServiceProvider;
-use Illuminate\View\View;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -52,13 +50,6 @@ class AppServiceProvider extends ServiceProvider
     {
         // User Observer For Cache
         User::observe(UserObserver::class);
-
-        // Share $footer_pages across all views
-        view()->composer('*', function (View $view): void {
-            $footerPages = cache()->remember('cached-pages', 3_600, fn () => Page::select(['id', 'name', 'created_at'])->take(6)->get());
-
-            $view->with(['footer_pages' => $footerPages]);
-        });
 
         // Hidden Captcha
         Blade::directive('hiddencaptcha', fn ($mustBeEmptyField = '_username') => \sprintf('<?= App\Helpers\HiddenCaptcha::render(%s); ?>', $mustBeEmptyField));

--- a/resources/views/partials/footer.blade.php
+++ b/resources/views/partials/footer.blade.php
@@ -44,7 +44,7 @@
                 <li><a href="{{ route('wikis.index') }}">Wikis</a></li>
             </ul>
         </section>
-        @if ($footer_pages)
+        @if ($footer_pages = cache()->remember('cached-pages',3600,fn () => \App\Models\Page::select(['id', 'name', 'created_at'])->take(6)->get()))
             <section class="footer__section">
                 <h2 class="footer__section-title">{{ __('common.pages') }}</h2>
                 <ul class="footer__section-list">


### PR DESCRIPTION
This function was ran in every view. The problem is for every partial, it was ran again. On pages like /mediahub/persons/x, this function was called 4000+ times because of all the partials, causing redis cache hits to use up more than 75% of the processing time to return the response. Fix by only calling it in the footer explicitly.