### PR TITLE
(Fix) Don't remove name from torrent grouping if contains ` / `

### DIFF
--- a/resources/views/components/partials/_torrent-group-row.blade.php
+++ b/resources/views/components/partials/_torrent-group-row.blade.php
@@ -19,7 +19,7 @@
                             $releaseYear = $media->release_date instanceof \Illuminate\Support\Carbon ? $media->release_date->year : (int) $media->release_date;
                         @endphp
 
-                        {{ \preg_replace('/^.*( ' . implode(' | ', range($releaseYear - 1, $releaseYear + 1)) . ' )/i', '', $torrent->name) }}
+                        {{ str_contains($torrent->name, ' / ') ? $torrent->name : \preg_replace('/^.*( ' . implode(' | ', range($releaseYear - 1, $releaseYear + 1)) . ' )/i', '', $torrent->name) }}
 
                         @break
                     @case('tv')
@@ -34,7 +34,7 @@
                             }
                         @endphp
 
-                        {{ \preg_replace('/^.*( ' . implode(' | ', $firstAirDateRange) . ' | (?=S\d{2,4}(?:-S\d{2,4})?(?:-?E\d{2,4})*? |' . implode('-|', $fullRange) . '-))/i', '', $torrent->name) }}
+                        {{ str_contains($torrent->name, ' / ') ? $torrent->name : \preg_replace('/^.*( ' . implode(' | ', $firstAirDateRange) . ' | (?=S\d{2,4}(?:-S\d{2,4})?(?:-?E\d{2,4})*? |' . implode('-|', $fullRange) . '-))/i', '', $torrent->name) }}
 
                         @break
                 @endswitch


### PR DESCRIPTION
` / ` signifies that it's a multi-title upload and we shouldn't remove the title since the grouping only shows one of the titles. The other titles are still important.