### PR TITLE
Change mediainfo to longtext

### DIFF
--- a/database/migrations/2024_10_10_140532_update_mediainfo_from_text_to_longtext.php
+++ b/database/migrations/2024_10_10_140532_update_mediainfo_from_text_to_longtext.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * NOTICE OF LICENSE.
+ *
+ * UNIT3D Community Edition is open-sourced software licensed under the GNU Affero General Public License v3.0
+ * The details is bundled with this project in the file LICENSE.txt.
+ *
+ * @project    UNIT3D Community Edition
+ *
+ * @author     HDVinnie <hdinnovations@protonmail.com>
+ * @license    https://www.gnu.org/licenses/agpl-3.0.en.html/ GNU Affero General Public License v3.0
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('torrents', function (Blueprint $table): void {
+            $table->longText('mediainfo')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down(): void
+    {
+        Schema::table('torrents', function (Blueprint $table): void {
+            $table->text('mediainfo')->nullable()->change();
+        });
+    }
+};


### PR DESCRIPTION
Some special cases (e.g., many subtitles) cause the mediainfo to become larger than `text` can store. The next bigger type should fix this.