### PR TITLE
(Fix) Don't compress webp losslessly through image proxy

### DIFF
--- a/app/Helpers/Bbcode.php
+++ b/app/Helpers/Bbcode.php
@@ -511,7 +511,7 @@ class Bbcode
             });
 
             if (!$isWhitelisted) {
-                $url = 'https://wsrv.nl/?n=-1&url='.urlencode($url);
+                $url = 'https://wsrv.nl/?n=-1&ll&url='.urlencode($url);
             }
         }
 


### PR DESCRIPTION
The `&ll` query parameter prevents webp from being compressed: https://wsrv.nl/docs/format.html#lossless-compression. Adding `&ll` to non-webp images still seems to work fine from testing.