### PR TITLE
(Update) Show pruned users by default in user search

### DIFF
--- a/app/Http/Livewire/UserSearch.php
+++ b/app/Http/Livewire/UserSearch.php
@@ -34,7 +34,7 @@ class UserSearch extends Component
     #TODO: Update URL attributes once Livewire 3 fixes upstream bug. See: https://github.com/livewire/livewire/discussions/7746
 
     #[Url(history: true)]
-    public bool $show = false;
+    public bool $show = true;
 
     #[Url(history: true)]
     public int $perPage = 25;


### PR DESCRIPTION
More often than not, when users are searched, it is wanted to search pruned users as well.