### PR TITLE
(Fix) Only search via year if year is 4 digits long

### DIFF
--- a/resources/views/livewire/torrent-search.blade.php
+++ b/resources/views/livewire/torrent-search.blade.php
@@ -84,26 +84,38 @@
                 </div>
                 <div class="form__group--short-horizontal">
                     <div class="form__group--short-horizontal">
-                        <p class="form__group">
+                        <p class="form__group" x-data="{ startYear: @entangle('startYear') }">
                             <input
                                 id="startYear"
-                                wire:model.live="startYear"
+                                x-on:input.debounce.150ms="
+                                    if ($el.checkValidity()) {
+                                        $wire.set('startYear', $event.target.value);
+                                    }
+                                "
+                                x-model.live="startYear"
                                 class="form__text"
                                 inputmode="numeric"
-                                pattern="[0-9]*"
+                                minlength="4"
+                                pattern="[0-9]{4}"
                                 placeholder=" "
                             />
                             <label class="form__label form__label--floating" for="startYear">
                                 {{ __('torrent.start-year') }}
                             </label>
                         </p>
-                        <p class="form__group">
+                        <p class="form__group" x-data="{ endYear: @entangle('endYear') }">
                             <input
                                 id="endYear"
-                                wire:model.live="endYear"
+                                x-on:input.debounce.150ms="
+                                    if ($el.checkValidity()) {
+                                        $wire.set('endYear', $event.target.value);
+                                    }
+                                "
+                                x-model.live="endYear"
                                 class="form__text"
                                 inputmode="numeric"
-                                pattern="[0-9]*"
+                                minlength="4"
+                                pattern="[0-9]{4}"
                                 placeholder=" "
                             />
                             <label class="form__label form__label--floating" for="endYear">


### PR DESCRIPTION
Hacky workaround to prevent slow searches from overwriting your search input as you type in digit by digit slower than the debounce but faster than it takes for the results to return (which replaces the entire html form state with what it was when it was sent).