### PR TITLE
(Fix) Torrents sorted incorrectly when using meilisearch

### DIFF
--- a/app/Http/Livewire/TorrentSearch.php
+++ b/app/Http/Livewire/TorrentSearch.php
@@ -505,7 +505,7 @@ class TorrentSearch extends Component
 
             $eagerLoads($torrents);
 
-            $torrents = $torrents->get();
+            $torrents = $torrents->get()->sortBy(fn ($torrent) => array_search($torrent->id, $ids));
 
             $torrents = new LengthAwarePaginator($torrents, $results->getTotalHits(), $this->perPage, $this->getPage());
         }


### PR DESCRIPTION
We need to sort the torrents after they've been fetched from the database to match the same order that meilisearch returned.

Fixes regression from https://github.com/HDInnovations/UNIT3D-Community-Edition/pull/4236.