### PR TITLE
(Fix) Top 100 stats wrong order

### DIFF
--- a/resources/views/stats/users/leechers.blade.php
+++ b/resources/views/stats/users/leechers.blade.php
@@ -43,7 +43,7 @@
                                     :anon="$user->user->privacy?->private_profile"
                                 />
                             </td>
-                            <td>{{ $user->user->leechingTorrents()->count() }}</td>
+                            <td>{{ $user->value }}</td>
                         </tr>
                     @endforeach
                 </tbody>

--- a/resources/views/stats/users/uploaders.blade.php
+++ b/resources/views/stats/users/uploaders.blade.php
@@ -43,7 +43,9 @@
                                     :anon="$user->user->privacy?->private_profile"
                                 />
                             </td>
-                            <td>{{ $user->user->torrents()->count() }}</td>
+                            <td>
+                                {{ $user->value }}
+                            </td>
                         </tr>
                     @endforeach
                 </tbody>


### PR DESCRIPTION
We're calculating a different value instead of using the existing calculated value.