### PR TITLE
(Fix) Use `bool` for bot `active` instead of `int`

### DIFF
--- a/app/Http/Controllers/Staff/ChatBotController.php
+++ b/app/Http/Controllers/Staff/ChatBotController.php
@@ -80,7 +80,7 @@ class ChatBotController extends Controller
     public function disable(Bot $bot): \Illuminate\Http\RedirectResponse
     {
         $bot->update([
-            'active' => 0,
+            'active' => false,
         ]);
 
         return to_route('staff.bots.index')
@@ -93,7 +93,7 @@ class ChatBotController extends Controller
     public function enable(Bot $bot): \Illuminate\Http\RedirectResponse
     {
         $bot->update([
-            'active' => 1,
+            'active' => true,
         ]);
 
         return to_route('staff.bots.index')

--- a/app/Models/Bot.php
+++ b/app/Models/Bot.php
@@ -31,10 +31,10 @@ use Illuminate\Database\Eloquent\Model;
  * @property string|null                     $icon
  * @property string|null                     $emoji
  * @property string|null                     $help
- * @property int                             $active
- * @property int                             $is_protected
- * @property int                             $is_nerdbot
- * @property int                             $is_systembot
+ * @property bool                            $active
+ * @property bool                            $is_protected
+ * @property bool                            $is_nerdbot
+ * @property bool                            $is_systembot
  * @property \Illuminate\Support\Carbon|null $created_at
  * @property \Illuminate\Support\Carbon|null $updated_at
  */
@@ -51,6 +51,7 @@ class Bot extends Model
      * @return array{
      *     name: 'string',
      *     cost: 'decimal:2',
+     *     active: 'bool',
      *     is_protected: 'bool',
      *     is_nerdbot: 'bool',
      *     is_systembot: 'bool',
@@ -61,6 +62,7 @@ class Bot extends Model
         return [
             'name'         => 'string',
             'cost'         => 'decimal:2',
+            'active'       => 'bool',
             'is_protected' => 'bool',
             'is_nerdbot'   => 'bool',
             'is_systembot' => 'bool',

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -326,11 +326,6 @@ parameters:
 			path: app/Http/Controllers/SimilarTorrentController.php
 
 		-
-			message: "#^Parameter \\#1 \\$boolean of function abort_if expects bool, int given\\.$#"
-			count: 1
-			path: app/Http/Controllers/Staff/ChatBotController.php
-
-		-
 			message: "#^Call to function is_int\\(\\) with string\\|null will always evaluate to false\\.$#"
 			count: 1
 			path: app/Http/Controllers/Staff/ChatRoomController.php


### PR DESCRIPTION
Also update docblocks. Related: #4085.