### PR TITLE
(Fix) Mediainfo and description search

### DIFF
--- a/app/Http/Livewire/TorrentSearch.php
+++ b/app/Http/Livewire/TorrentSearch.php
@@ -434,7 +434,7 @@ class TorrentSearch extends Component
             $this->reset('sortField');
         }
 
-        $isSqlAllowed = ($user->group->is_modo || $user->group->is_editor) && $this->driver === 'sql';
+        $isSqlAllowed = (($user->group->is_modo || $user->group->is_editor) && $this->driver === 'sql') || $this->description || $this->mediainfo;
 
         $eagerLoads = fn (Builder $query) => $query
             ->with(['user:id,username,group_id', 'user.group', 'category', 'type', 'resolution'])


### PR DESCRIPTION
There's no easy way of adding these to meilisearch right now. Indexing them is inefficient and causes multi-second queries. It would be useful to use the `CONTAINS` operator to search these, but that meilisearch feature is still experimental and we should wait until it's stable before using it.