### PR TITLE
(Update) Reset bumped torrent status after 1 week

### DIFF
--- a/app/Console/Commands/AutoRemoveTimedTorrentBuffs.php
+++ b/app/Console/Commands/AutoRemoveTimedTorrentBuffs.php
@@ -70,6 +70,10 @@ class AutoRemoveTimedTorrentBuffs extends Command
             Unit3dAnnounce::addTorrent($torrent);
         }
 
+        Torrent::query()->whereNotNull('bumped_at')->where('bumped_at', '<', now()->subWeek())->update([
+            'bumped_at' => null,
+        ]);
+
         $this->comment('Automated Removal Of Expired Torrent Buffs Command Complete');
     }
 }


### PR DESCRIPTION
There are way too many bumped torrents and overuse of the feature is desensitizing its functionality.