### PR TITLE
(Fix) Validation for torrent request updates

### DIFF
--- a/app/Http/Requests/UpdateTorrentRequestRequest.php
+++ b/app/Http/Requests/UpdateTorrentRequestRequest.php
@@ -16,7 +16,10 @@ declare(strict_types=1);
 
 namespace App\Http\Requests;
 
+use App\Models\Category;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
 
 class UpdateTorrentRequestRequest extends FormRequest
 {
@@ -33,37 +36,64 @@ class UpdateTorrentRequestRequest extends FormRequest
      *
      * @return array<string, \Illuminate\Contracts\Validation\Rule|array<\Illuminate\Contracts\Validation\Rule|string>|string>
      */
-    public function rules(): array
+    public function rules(Request $request): array
     {
+        $category = Category::findOrFail($request->integer('category_id'));
+
         return [
             'name' => [
                 'required',
                 'max:180',
             ],
             'imdb' => [
-                'required',
-                'decimal:0',
-                'min:0',
+                Rule::when($category->movie_meta || $category->tv_meta, [
+                    'required',
+                    'decimal:0',
+                    'min:0',
+                ]),
+                Rule::when(!($category->movie_meta || $category->tv_meta), [
+                    Rule::in([0]),
+                ]),
             ],
             'tvdb' => [
-                'required',
-                'decimal:0',
-                'min:0',
+                Rule::when($category->tv_meta, [
+                    'required',
+                    'decimal:0',
+                    'min:0',
+                ]),
+                Rule::when(!$category->tv_meta, [
+                    Rule::in([0]),
+                ]),
             ],
             'tmdb' => [
-                'required',
-                'decimal:0',
-                'min:0',
+                Rule::when($category->movie_meta || $category->tv_meta, [
+                    'required',
+                    'decimal:0',
+                    'min:0',
+                ]),
+                Rule::when(!($category->movie_meta || $category->tv_meta), [
+                    Rule::in([0]),
+                ]),
             ],
             'mal' => [
-                'required',
-                'decimal:0',
-                'min:0',
+                Rule::when($category->movie_meta || $category->tv_meta, [
+                    'required',
+                    'decimal:0',
+                    'min:0',
+                ]),
+                Rule::when(!($category->movie_meta || $category->tv_meta), [
+                    Rule::in([0]),
+                ]),
             ],
             'igdb' => [
-                'required',
-                'decimal:0',
-                'min:0',
+                Rule::when($category->game_meta, [
+                    'required',
+                    'decimal:0',
+                    'min:0',
+                ]),
+                Rule::when(!$category->game_meta, [
+                    Rule::in([0]),
+                ]),
             ],
             'category_id' => [
                 'required',

--- a/app/Http/Requests/UpdateTorrentRequestRequest.php
+++ b/app/Http/Requests/UpdateTorrentRequestRequest.php
@@ -34,7 +34,7 @@ class UpdateTorrentRequestRequest extends FormRequest
     /**
      * Get the validation rules that apply to the request.
      *
-     * @return array<string, \Illuminate\Contracts\Validation\Rule|array<\Illuminate\Contracts\Validation\Rule|string>|string>
+     * @return array<string, array<\Illuminate\Validation\ConditionalRules|string>|string>
      */
     public function rules(Request $request): array
     {


### PR DESCRIPTION
Hi,

Updated the validation rules in UpdateTorrentRequestRequest so they match the ones in StoreTorrentRequestRequest. The change came about because updating requests with no_meta category would break on validation. Weren't sure if any test needed updating.