### PR TITLE
(Fix) Autofill certain fields in similar 'add request' button

### DIFF
--- a/resources/views/livewire/similar-torrent.blade.php
+++ b/resources/views/livewire/similar-torrent.blade.php
@@ -979,11 +979,15 @@
                         <a
                             href="{{
                                 route('requests.create', [
-                                    'category_id' => $torrents->first()?->category_id ?? '',
-                                    'title' => rawurlencode(($work?->title ?? '') . ' ' . substr($work->release_date ?? '', 0, 4) ?? ''),
-                                    'imdb' => $work?->tmdb ?? '',
+                                    'category_id' => $category->id,
+                                    'title' => rawurlencode(
+                                        $category->movie_meta
+                                            ? ($work?->title ?? '') . ' ' . substr($work->release_date ?? '', 0, 4)
+                                            : ($work?->name ?? '') . ' ' . substr($work->first_air_date ?? '', 0, 4)
+                                    ),
+                                    'imdb' => $work?->imdb_id ?? '',
                                     'tmdb' => $tmdbId ?? '',
-                                    'tvdb' => $work->tvdb ?? '',
+                                    'tvdb' => $work->tvdb_id ?? '',
                                     'igdb' => $igdb ?? '',
                                 ])
                             }}"


### PR DESCRIPTION
- fixes from PR #4253
- fix pulling right columns from work for imdb and tvdb
- support tv and movie
- use $category thats already passed
- fixes undefined variable $torrents at /var/www/html/resources/views/livewire/similar-torrent.blade.php:980