### PR TITLE
(Fix) Invalid value type for page in Torrent search

### DIFF
--- a/app/Http/Livewire/TorrentSearch.php
+++ b/app/Http/Livewire/TorrentSearch.php
@@ -496,7 +496,7 @@ class TorrentSearch extends Component
                 ],
                 'filter'               => $this->filters()->toMeilisearchFilter(),
                 'matchingStrategy'     => 'all',
-                'page'                 => $this->getPage(),
+                'page'                 => (int) $this->getPage(),
                 'hitsPerPage'          => min($this->perPage, 100),
                 'attributesToRetrieve' => ['id'],
             ]);


### PR DESCRIPTION
- This ensures that the page parameter is correctly cast to an integer before being passed to the Meilisearch API.