### PR TITLE
(Fix) Time elapsed calculation type warning

### DIFF
--- a/app/Helpers/StringHelper.php
+++ b/app/Helpers/StringHelper.php
@@ -52,8 +52,10 @@ class StringHelper
         return $result."\u{a0}".self::units[$i];
     }
 
-    public static function timeElapsed(int $seconds): string
+    public static function timeElapsed(int|float $seconds): string
     {
+        $seconds = \intval($seconds);
+
         if ($seconds == 0) {
             return 'N/A';
         }


### PR DESCRIPTION
Sometimes an average seedtime is passed into here which isn't an int. This function currently only supports units above one second, so cast to int first.