### PR TITLE
(Fix) Bug #4284

### DIFF
--- a/resources/views/components/torrent/card.blade.php
+++ b/resources/views/components/torrent/card.blade.php
@@ -100,7 +100,7 @@
             </ul>
         </div>
         <p class="torrent-card__plot">
-            {{ Str::limit(strip_tags($meta?->overview ?: $meta?->summary), 350, '...') }}
+            {{ Str::of($meta?->overview ?: $meta?->summary)->stripTags()->limit(350, '...') }}
         </p>
     </div>
     <footer class="torrent-card__footer">


### PR DESCRIPTION
- `strip_tags(): Passing null to parameter #1 ($string) of type string is deprecated in torrent card component`
- This change ensures that null values are handled properly, avoiding the deprecation warning.
- Closes #4284