### PR TITLE
(Add) Weekly top 10 charts

### DIFF
--- a/resources/sass/pages/_top10.scss
+++ b/resources/sass/pages/_top10.scss
@@ -1,3 +1,22 @@
+.top10 {
+    margin: 0 calc(-1 * max(0px, 10vw - 60px)); /* Inverses the magic numbers used in the main layout styles */
+    width: max-content;
+    max-width: 100vw;
+    align-self: center;
+}
+
+@media only screen and (min-width: 1600px) {
+    .top10 {
+        margin: 0 calc(-1 * max(0px, 25vw - 300px)); /* Inverses the magic numbers used in the main layout styles */
+    }
+}
+
+@media only screen and (min-width: 2500px) {
+    .top10 {
+        margin: 0 calc(-1 * max(0px, 45vw - 800px)); /* Inverses the magic numbers used in the main layout styles */
+    }
+}
+
 .top10-poster {
     display: grid;
     grid-template-rows: auto 1fr;
@@ -23,4 +42,22 @@
         0 5px 5px -3px rgba(0, 0, 0, 0.2);
     font-size: 11px;
     text-align: center;
+}
+
+.top10-weekly__row {
+    display: grid;
+    grid-template-columns: repeat(10, minmax(120px, 1fr));
+    gap: 0.75rem;
+
+    .torrent-search--poster__caption {
+        margin: 2px;
+    }
+
+    .torrent-search--poster__title {
+        font-size: 12px;
+    }
+
+    .torrent-search--poster__release-date {
+        font-size: 12px;
+    }
 }

--- a/resources/views/livewire/top10.blade.php
+++ b/resources/views/livewire/top10.blade.php
@@ -1,4 +1,4 @@
-<section class="panelV2">
+<section class="panelV2 top10">
     <header class="panel__header">
         <h2 class="panel__heading">Top Titles</h2>
         <div class="panel__actions">
@@ -16,6 +16,7 @@
                         <option value="month">Past Month</option>
                         <option value="year">Past Year</option>
                         <option value="all">All-time</option>
+                        <option value="weekly">Weekly</option>
                         <option value="custom">Custom</option>
                     </select>
                     <label class="form__label form__label--floating" for="interval">Interval</label>
@@ -65,46 +66,100 @@
             </div>
         </div>
     </header>
-    <div class="panel__body torrent-search--poster__results">
-        <div wire:loading.delay>Computing...</div>
+    @if ($this->interval === 'weekly')
+        <div class="data-table-wrapper">
+            <div wire:loading.delay class="panel__body">Computing...</div>
 
-        @switch($this->metaType)
-            @case('movie_meta')
-                @foreach ($works as $work)
-                    <figure class="top10-poster">
-                        <x-movie.poster
-                            :movie="$work->movie"
-                            :categoryId="$work->category_id"
-                            :tmdb="$work->tmdb"
-                        />
-                        <figcaption
-                            class="top10-poster__download-count"
-                            title="{{ __('torrent.completed-times') }}"
-                        >
-                            {{ $work->download_count }}
-                        </figcaption>
-                    </figure>
-                @endforeach
+            <table class="data-table">
+                <thead>
+                    <tr>
+                        <th>Week</th>
+                        <th>Rankings</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach ($works as $weeklyRankings)
+                        <tr>
+                            <th>
+                                {{ $weeklyRankings->first()?->week_start?->format('Y-m-d') }}
+                            </th>
+                            <td class="panel__body top10-weekly__row">
+                                @foreach ($weeklyRankings as $ranking)
+                                    <figure class="top10-poster">
+                                        @switch($this->metaType)
+                                            @case('movie_meta')
+                                                <x-movie.poster
+                                                    :movie="$ranking->movie"
+                                                    :categoryId="$ranking->category_id"
+                                                    :tmdb="$ranking->tmdb"
+                                                />
 
-                @break
-            @case('tv_meta')
-                @foreach ($works as $work)
-                    <figure class="top10-poster">
-                        <x-tv.poster
-                            :tv="$work->tv"
-                            :categoryId="$work->category_id"
-                            :tmdb="$work->tmdb"
-                        />
-                        <figcaption
-                            class="top10-poster__download-count"
-                            title="{{ __('torrent.completed-times') }}"
-                        >
-                            {{ $work->download_count }}
-                        </figcaption>
-                    </figure>
-                @endforeach
+                                                @break
+                                            @case('tv_meta')
+                                                <x-tv.poster
+                                                    :tv="$ranking->tv"
+                                                    :categoryId="$ranking->category_id"
+                                                    :tmdb="$ranking->tmdb"
+                                                />
 
-                @break
-        @endswitch
-    </div>
+                                                @break
+                                        @endswitch
+                                        <figcaption
+                                            class="top10-poster__download-count"
+                                            title="{{ __('torrent.completed-times') }}"
+                                        >
+                                            {{ $ranking->download_count }}
+                                        </figcaption>
+                                    </figure>
+                                @endforeach
+                            </td>
+                        </tr>
+                    @endforeach
+                </tbody>
+            </table>
+        </div>
+    @else
+        <div class="panel__body torrent-search--poster__results">
+            <div wire:loading.delay>Computing...</div>
+
+            @switch($this->metaType)
+                @case('movie_meta')
+                    @foreach ($works as $work)
+                        <figure class="top10-poster">
+                            <x-movie.poster
+                                :movie="$work->movie"
+                                :categoryId="$work->category_id"
+                                :tmdb="$work->tmdb"
+                            />
+                            <figcaption
+                                class="top10-poster__download-count"
+                                title="{{ __('torrent.completed-times') }}"
+                            >
+                                {{ $work->download_count }}
+                            </figcaption>
+                        </figure>
+                    @endforeach
+
+                    @break
+                @case('tv_meta')
+                    @foreach ($works as $work)
+                        <figure class="top10-poster">
+                            <x-tv.poster
+                                :tv="$work->tv"
+                                :categoryId="$work->category_id"
+                                :tmdb="$work->tmdb"
+                            />
+                            <figcaption
+                                class="top10-poster__download-count"
+                                title="{{ __('torrent.completed-times') }}"
+                            >
+                                {{ $work->download_count }}
+                            </figcaption>
+                        </figure>
+                    @endforeach
+
+                    @break
+            @endswitch
+        </div>
+    @endif
 </section>


### PR DESCRIPTION
The query is pretty gnarly but I couldn't figure out any other way to make it faster when sorting millions of history records. Currently takes about 12 seconds for a few million records.

There was also one type I spent an hour or two trying to figure out what it would be, but I gave up in the end, it might be a laravel/larastan bug.