### PR TITLE
(Refactor) Move welcome message to listener and add tests

### DIFF
--- a/app/Actions/Fortify/CreateNewUser.php
+++ b/app/Actions/Fortify/CreateNewUser.php
@@ -19,7 +19,6 @@ namespace App\Actions\Fortify;
 use App\Models\Group;
 use App\Models\Invite;
 use App\Models\User;
-use App\Repositories\ChatRepository;
 use App\Rules\EmailBlacklist;
 use Exception;
 use Illuminate\Http\RedirectResponse;
@@ -32,10 +31,6 @@ use Laravel\Fortify\Contracts\CreatesNewUsers;
 class CreateNewUser implements CreatesNewUsers
 {
     use PasswordValidationRules;
-
-    public function __construct(private readonly ChatRepository $chatRepository)
-    {
-    }
 
     /**
      * Validate and create a newly registered user.
@@ -106,29 +101,6 @@ class CreateNewUser implements CreatesNewUsers
                 ]);
             }
         }
-
-        // Select A Random Welcome Message
-        $profileUrl = href_profile($user);
-
-        $welcomeArray = [
-            \sprintf('[url=%s]%s[/url], Welcome to ', $profileUrl, $user->username).config('other.title').'! Hope you enjoy the community.',
-            \sprintf("[url=%s]%s[/url], We've been expecting you.", $profileUrl, $user->username),
-            \sprintf("[url=%s]%s[/url] has arrived. Party's over.", $profileUrl, $user->username),
-            \sprintf("It's a bird! It's a plane! Nevermind, it's just [url=%s]%s[/url].", $profileUrl, $user->username),
-            \sprintf('Ready player [url=%s]%s[/url].', $profileUrl, $user->username),
-            \sprintf('A wild [url=%s]%s[/url] appeared.', $profileUrl, $user->username),
-            'Welcome to '.config('other.title').\sprintf(' [url=%s]%s[/url]. We were expecting you.', $profileUrl, $user->username),
-        ];
-
-        $this->chatRepository->systemMessage(
-            $welcomeArray[array_rand($welcomeArray)]
-        );
-
-        // Send Welcome PM
-        $user->sendSystemNotification(
-            subject: config('welcomepm.subject'),
-            message: config('welcomepm.message'),
-        );
 
         return $user;
     }

--- a/app/Listeners/RegisteredListener.php
+++ b/app/Listeners/RegisteredListener.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Listeners;
+
+use App\Models\User;
+use App\Repositories\ChatRepository;
+use Illuminate\Auth\Events\Registered;
+use Illuminate\Support\Arr;
+
+readonly class RegisteredListener
+{
+    public function __construct(private ChatRepository $chatRepository)
+    {
+    }
+
+    public function __invoke(Registered $event): void
+    {
+        /** @var User $user */
+        $user = $event->user;
+
+        $this->chatRepository->systemMessage($this->getWelcomeMessage($user));
+
+        // Send Welcome PM
+        $user->sendSystemNotification(
+            subject: config('welcomepm.subject'),
+            message: config('welcomepm.message'),
+        );
+    }
+
+    private function getWelcomeMessage(User $user): string
+    {
+        // Select A Random Welcome Message
+        $profileUrl = href_profile($user);
+
+        return Arr::random([
+            \sprintf('[url=%s]%s[/url], Welcome to ', $profileUrl, $user->username).config('other.title').'! Hope you enjoy the community.',
+            \sprintf("[url=%s]%s[/url], We've been expecting you.", $profileUrl, $user->username),
+            \sprintf("[url=%s]%s[/url] has arrived. Party's over.", $profileUrl, $user->username),
+            \sprintf("It's a bird! It's a plane! Nevermind, it's just [url=%s]%s[/url].", $profileUrl, $user->username),
+            \sprintf('Ready player [url=%s]%s[/url].', $profileUrl, $user->username),
+            \sprintf('A wild [url=%s]%s[/url] appeared.', $profileUrl, $user->username),
+            'Welcome to '.config('other.title').\sprintf(' [url=%s]%s[/url]. We were expecting you.', $profileUrl, $user->username),
+        ]);
+    }
+}

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -33,8 +33,10 @@ use App\Listeners\NotifyUserTicketWasAssigned;
 use App\Listeners\NotifyUserTicketWasClosed;
 use App\Listeners\NotifyUserTicketWasCreated;
 use App\Listeners\PasswordProtectBackup;
+use App\Listeners\RegisteredListener;
 use Assada\Achievements\Event\Unlocked;
 use Illuminate\Auth\Events\Login;
+use Illuminate\Auth\Events\Registered;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
 use Spatie\Backup\Events\BackupZipWasCreated;
 
@@ -49,6 +51,10 @@ class EventServiceProvider extends ServiceProvider
         // Login Timestamp
         Login::class => [
             LoginListener::class,
+        ],
+
+        Registered::class => [
+            RegisteredListener::class,
         ],
 
         // Achievements System

--- a/tests/Unit/Listeners/RegisteredListenerTest.php
+++ b/tests/Unit/Listeners/RegisteredListenerTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * NOTICE OF LICENSE.
+ *
+ * UNIT3D Community Edition is open-sourced software licensed under the GNU Affero General Public License v3.0
+ * The details is bundled with this project in the file LICENSE.txt.
+ *
+ * @project    UNIT3D Community Edition
+ *
+ * @author     HDVinnie <hdinnovations@protonmail.com>
+ * @license    https://www.gnu.org/licenses/agpl-3.0.en.html/ GNU Affero General Public License v3.0
+ */
+
+use App\Models\Bot;
+use App\Models\Chatroom;
+use App\Models\User;
+use Illuminate\Auth\Events\Registered;
+use Illuminate\Support\Facades\Event;
+
+use function Pest\Laravel\assertDatabaseHas;
+
+test('newly registered user is greeted in chat room', function (): void {
+    User::factory()->system()->create();
+    $bot = Bot::factory()->create([
+        'command' => 'Systembot',
+    ]);
+    $chatroom = Chatroom::factory()->create([
+        'name' => config('chat.system_chatroom'),
+    ]);
+
+    $user = User::factory()->create();
+
+    Event::dispatch(new Registered($user));
+
+    assertDatabaseHas('messages', [
+        'user_id'     => User::SYSTEM_USER_ID,
+        'chatroom_id' => $chatroom->id,
+        'bot_id'      => $bot->id,
+        'receiver_id' => null,
+    ]);
+
+    $conversation = $user->conversations->first();
+
+    expect($conversation)->not->toBeNull()
+        ->and($conversation->subject)->toBe(config('welcomepm.subject'));
+
+    $systemMessage = $conversation->messages->first();
+
+    expect($systemMessage)->not->toBeNull()
+        ->and($systemMessage->message)->toBe(config('welcomepm.message'))
+        ->and($systemMessage->sender_id)->toBe(User::SYSTEM_USER_ID);
+});


### PR DESCRIPTION
This PR moves the logic responsible for sending welcome message to newly registered user into a listener. This makes it much easier to test the registration flow as it no longer depends on `Bot` and `Chatroom` classes and allows to test that particular logic separately instead.

Using event listeners instead of controllers/actions makes it easier to decouple the logic and allows to conditionally run it in the future if needed. It is also easy to mock it using `Event::fake()` in tests.