### PR TITLE
(Fix) Conversation and ticket search tabs flashing

### DIFF
--- a/resources/views/livewire/conversation-search.blade.php
+++ b/resources/views/livewire/conversation-search.blade.php
@@ -55,7 +55,6 @@
             class="panel__tab panel__tab--full-width"
             role="tab"
             x-bind:class="tab === 'all' && 'panel__tab--active'"
-            x-cloak
             x-on:click="tab = 'all'"
         >
             {{ __('stat.all') }}
@@ -64,7 +63,6 @@
             class="panel__tab panel__tab--full-width"
             role="tab"
             x-bind:class="tab === 'unread' && 'panel__tab--active'"
-            x-cloak
             x-on:click="tab = 'unread'"
         >
             {{ __('pm.unread') }}
@@ -73,7 +71,6 @@
             class="panel__tab panel__tab--full-width"
             role="tab"
             x-bind:class="tab === 'inbox' && 'panel__tab--active'"
-            x-cloak
             x-on:click="tab = 'inbox'"
         >
             {{ __('pm.inbox') }}
@@ -82,7 +79,6 @@
             class="panel__tab panel__tab--full-width"
             role="tab"
             x-bind:class="tab === 'outbox' && 'panel__tab--active'"
-            x-cloak
             x-on:click="tab = 'outbox'"
         >
             {{ __('pm.outbox') }}

--- a/resources/views/livewire/ticket-search.blade.php
+++ b/resources/views/livewire/ticket-search.blade.php
@@ -55,7 +55,6 @@
             class="panel__tab panel__tab--full-width"
             role="tab"
             x-bind:class="tab === 'open' && 'panel__tab--active'"
-            x-cloak
             x-on:click="tab = 'open'"
         >
             Open
@@ -64,7 +63,6 @@
             class="panel__tab panel__tab--full-width"
             role="tab"
             x-bind:class="tab === 'closed' && 'panel__tab--active'"
-            x-cloak
             x-on:click="tab = 'closed'"
         >
             Closed


### PR DESCRIPTION
It was likely this was a bad copy-paste error from the person-credit tabs which are by default hidden and are unhidden for tabs with greater than 0 items. This is not needed for ticket search and conversation search and adds an unneeded flash of unstyled content. Remove `x-cloak` removes the flash.