### PR TITLE
(Fix) Top10 non-weekly styles

### DIFF
--- a/resources/sass/pages/_top10.scss
+++ b/resources/sass/pages/_top10.scss
@@ -1,4 +1,4 @@
-.top10 {
+.top10--weekly {
     margin: 0 calc(-1 * max(0px, 10vw - 60px)); /* Inverses the magic numbers used in the main layout styles */
     width: max-content;
     max-width: 100vw;
@@ -6,13 +6,13 @@
 }
 
 @media only screen and (min-width: 1600px) {
-    .top10 {
+    .top10--weekly {
         margin: 0 calc(-1 * max(0px, 25vw - 300px)); /* Inverses the magic numbers used in the main layout styles */
     }
 }
 
 @media only screen and (min-width: 2500px) {
-    .top10 {
+    .top10--weekly {
         margin: 0 calc(-1 * max(0px, 45vw - 800px)); /* Inverses the magic numbers used in the main layout styles */
     }
 }

--- a/resources/views/livewire/top10.blade.php
+++ b/resources/views/livewire/top10.blade.php
@@ -1,4 +1,10 @@
-<section class="panelV2 top10">
+<section
+    @class([
+        'panelV2',
+        'top10',
+        'top10--weekly' => $this->interval === 'weekly',
+    ])
+>
     <header class="panel__header">
         <h2 class="panel__heading">Top Titles</h2>
         <div class="panel__actions">


### PR DESCRIPTION
Only weekly top 10 styles should remove the default margins.

Regression from #4295 