### PR TITLE
(Refactor) Use CommonMark for markdown parsing

### DIFF
--- a/app/Helpers/MarkdownExtra.php
+++ b/app/Helpers/MarkdownExtra.php
@@ -553,7 +553,7 @@ class MarkdownExtra extends Markdown
         $DOMDocument = new DOMDocument();
 
         // http://stackoverflow.com/q/11309194/200145
-        $elementMarkup = mb_convert_encoding((string) $elementMarkup, 'HTML-ENTITIES', 'UTF-8');
+        $elementMarkup = htmlentities((string) $elementMarkup, ENT_QUOTES | ENT_HTML5, 'UTF-8');
 
         // http://stackoverflow.com/q/4879946/200145
         $DOMDocument->loadHTML($elementMarkup);

--- a/app/Helpers/MarkdownExtra.php
+++ b/app/Helpers/MarkdownExtra.php
@@ -553,7 +553,7 @@ class MarkdownExtra extends Markdown
         $DOMDocument = new DOMDocument();
 
         // http://stackoverflow.com/q/11309194/200145
-        $elementMarkup = htmlentities((string) $elementMarkup, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+        $elementMarkup = mb_convert_encoding((string) $elementMarkup, 'HTML-ENTITIES', 'UTF-8');
 
         // http://stackoverflow.com/q/4879946/200145
         $DOMDocument->loadHTML($elementMarkup);

--- a/app/Helpers/MarkdownExtra.php
+++ b/app/Helpers/MarkdownExtra.php
@@ -20,6 +20,9 @@ namespace App\Helpers;
 use DOMDocument;
 use DOMElement;
 
+/**
+ * @deprecated Use \GrahamCampbell\Markdown\Facades\Markdown instead
+ */
 class MarkdownExtra extends Markdown
 {
     public function __construct()

--- a/app/Helpers/MarkdownExtra.php
+++ b/app/Helpers/MarkdownExtra.php
@@ -550,13 +550,17 @@ class MarkdownExtra extends Markdown
         // http://stackoverflow.com/q/1148928/200145
         libxml_use_internal_errors(true);
 
-        $DOMDocument = new DOMDocument();
+        $DOMDocument = new DOMDocument('1.0', 'utf-8');
+
+        $DOMDocument->loadHTML('<?xml encoding="UTF-8">'.$elementMarkup);
 
         // http://stackoverflow.com/q/11309194/200145
-        $elementMarkup = mb_convert_encoding((string) $elementMarkup, 'HTML-ENTITIES', 'UTF-8');
+        foreach ($DOMDocument->childNodes as $item) {
+            if ($item->nodeType == XML_PI_NODE) {
+                $DOMDocument->removeChild($item);
+            }
+        }
 
-        // http://stackoverflow.com/q/4879946/200145
-        $DOMDocument->loadHTML($elementMarkup);
         $DOMDocument->removeChild($DOMDocument->doctype);
         $DOMDocument->replaceChild($DOMDocument->firstChild->firstChild->firstChild, $DOMDocument->firstChild);
 

--- a/app/Models/Page.php
+++ b/app/Models/Page.php
@@ -17,8 +17,8 @@ declare(strict_types=1);
 namespace App\Models;
 
 use App\Helpers\Bbcode;
-use App\Helpers\MarkdownExtra;
 use App\Traits\Auditable;
+use GrahamCampbell\Markdown\Facades\Markdown;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
@@ -56,8 +56,8 @@ class Page extends Model
     /**
      * Parse Content And Return Valid HTML.
      */
-    public function getContentHtml(): ?string
+    public function getContentHtml(): string
     {
-        return (new MarkdownExtra())->text((new Bbcode())->parse($this->content, false));
+        return Markdown::convert((new Bbcode())->parse($this->content, false))->getContent();
     }
 }

--- a/app/Models/Wiki.php
+++ b/app/Models/Wiki.php
@@ -17,8 +17,8 @@ declare(strict_types=1);
 namespace App\Models;
 
 use App\Helpers\Bbcode;
-use App\Helpers\MarkdownExtra;
 use App\Traits\Auditable;
+use GrahamCampbell\Markdown\Facades\Markdown;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -52,6 +52,6 @@ class Wiki extends Model
      */
     public function getContentHtml(): string
     {
-        return (new MarkdownExtra())->text((new Bbcode())->parse($this->content, false));
+        return Markdown::convert((new Bbcode())->parse($this->content, false))->getContent();
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         "bjeavons/zxcvbn-php": "^1.3.1",
         "doctrine/dbal": "^3.9.3",
         "gabrielelana/byte-units": "^0.5.0",
+        "graham-campbell/markdown": "^15.2",
         "guzzlehttp/guzzle": "^7.9.2",
         "hdvinnie/laravel-joypixel-emojis": "^v3.0.0",
         "hdvinnie/laravel-security-headers": "^v3.0.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8968ba4e56e6b77cdb2c5fa7fb05a61a",
+    "content-hash": "2b7b1571638ee3814dcd8de9c741fd01",
     "packages": [
         {
             "name": "assada/laravel-achievements",
@@ -1198,6 +1198,86 @@
                 "source": "https://github.com/gabrielelana/byte-units/tree/master"
             },
             "time": "2018-01-11T10:40:03+00:00"
+        },
+        {
+            "name": "graham-campbell/markdown",
+            "version": "v15.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/GrahamCampbell/Laravel-Markdown.git",
+                "reference": "d594fc197b9068de5e234a890be361807a1ab34f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/GrahamCampbell/Laravel-Markdown/zipball/d594fc197b9068de5e234a890be361807a1ab34f",
+                "reference": "d594fc197b9068de5e234a890be361807a1ab34f",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/contracts": "^8.75 || ^9.0 || ^10.0 || ^11.0",
+                "illuminate/filesystem": "^8.75 || ^9.0 || ^10.0 || ^11.0",
+                "illuminate/support": "^8.75 || ^9.0 || ^10.0 || ^11.0",
+                "illuminate/view": "^8.75 || ^9.0 || ^10.0 || ^11.0",
+                "league/commonmark": "^2.4.2",
+                "php": "^7.4.15 || ^8.0.2"
+            },
+            "require-dev": {
+                "graham-campbell/analyzer": "^4.1",
+                "graham-campbell/testbench": "^6.1",
+                "mockery/mockery": "^1.6.6",
+                "phpunit/phpunit": "^9.6.17 || ^10.5.13"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "GrahamCampbell\\Markdown\\MarkdownServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GrahamCampbell\\Markdown\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                }
+            ],
+            "description": "Markdown Is A CommonMark Wrapper For Laravel",
+            "keywords": [
+                "Graham Campbell",
+                "GrahamCampbell",
+                "Laravel Markdown",
+                "Laravel-Markdown",
+                "common mark",
+                "commonmark",
+                "framework",
+                "laravel",
+                "markdown"
+            ],
+            "support": {
+                "issues": "https://github.com/GrahamCampbell/Laravel-Markdown/issues",
+                "source": "https://github.com/GrahamCampbell/Laravel-Markdown/tree/v15.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/graham-campbell/markdown",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-03-17T23:07:39+00:00"
         },
         {
             "name": "graham-campbell/result-type",

--- a/config/markdown.php
+++ b/config/markdown.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Laravel Markdown.
+ *
+ * (c) Graham Campbell <hello@gjcampbell.co.uk>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Enable View Integration
+    |--------------------------------------------------------------------------
+    |
+    | This option specifies if the view integration is enabled so you can write
+    | markdown views and have them rendered as html. The following extensions
+    | are currently supported: ".md", ".md.php", and ".md.blade.php". You may
+    | disable this integration if it is conflicting with another package.
+    |
+    | Default: true
+    |
+    */
+
+    'views' => true,
+
+    /*
+    |--------------------------------------------------------------------------
+    | CommonMark Extensions
+    |--------------------------------------------------------------------------
+    |
+    | This option specifies what extensions will be automatically enabled.
+    | Simply provide your extension class names here.
+    |
+    | Default: [
+    |              League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension::class,
+    |              League\CommonMark\Extension\Table\TableExtension::class,
+    |          ]
+    |
+    */
+
+    'extensions' => [
+        League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension::class,
+        League\CommonMark\Extension\Autolink\AutolinkExtension::class,
+        League\CommonMark\Extension\Table\TableExtension::class,
+        League\CommonMark\Extension\Strikethrough\StrikethroughExtension::class,
+        League\CommonMark\Extension\Attributes\AttributesExtension::class,
+        League\CommonMark\Extension\DescriptionList\DescriptionListExtension::class,
+        League\CommonMark\Extension\Footnote\FootnoteExtension::class,
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Renderer Configuration
+    |--------------------------------------------------------------------------
+    |
+    | This option specifies an array of options for rendering HTML.
+    |
+    | Default: [
+    |              'block_separator' => "\n",
+    |              'inner_separator' => "\n",
+    |              'soft_break'      => "\n",
+    |          ]
+    |
+    */
+
+    'renderer' => [
+        'block_separator' => "\n",
+        'inner_separator' => "\n",
+        'soft_break'      => "\n",
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Commonmark Configuration
+    |--------------------------------------------------------------------------
+    |
+    | This option specifies an array of options for commonmark.
+    |
+    | Default: [
+    |              'enable_em' => true,
+    |              'enable_strong' => true,
+    |              'use_asterisk' => true,
+    |              'use_underscore' => true,
+    |              'unordered_list_markers' => ['-', '+', '*'],
+    |          ]
+    |
+    */
+
+    'commonmark' => [
+        'enable_em'              => true,
+        'enable_strong'          => true,
+        'use_asterisk'           => true,
+        'use_underscore'         => true,
+        'unordered_list_markers' => ['-', '+', '*'],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | HTML Input
+    |--------------------------------------------------------------------------
+    |
+    | This option specifies how to handle untrusted HTML input.
+    |
+    | Default: 'strip'
+    |
+    */
+
+    'html_input' => 'allow',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Allow Unsafe Links
+    |--------------------------------------------------------------------------
+    |
+    | This option specifies whether to allow risky image URLs and links.
+    |
+    | Default: true
+    |
+    */
+
+    'allow_unsafe_links' => true,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Maximum Nesting Level
+    |--------------------------------------------------------------------------
+    |
+    | This option specifies the maximum permitted block nesting level.
+    |
+    | Default: PHP_INT_MAX
+    |
+    */
+
+    'max_nesting_level' => PHP_INT_MAX,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Slug Normalizer
+    |--------------------------------------------------------------------------
+    |
+    | This option specifies an array of options for slug normalization.
+    |
+    | Default: [
+    |              'max_length' => 255,
+    |              'unique' => 'document',
+    |          ]
+    |
+    */
+
+    'slug_normalizer' => [
+        'max_length' => 255,
+        'unique'     => 'document',
+    ],
+];

--- a/tests/Unit/Helpers/MarkdownExtraTest.php
+++ b/tests/Unit/Helpers/MarkdownExtraTest.php
@@ -299,7 +299,7 @@ MD,
     yield 'html elements' => [
         <<<'HTML'
 <img src="https://example.com/image.jpg" alt="Image" />
-<p>&lt;div&gt;&amp;star;â¨©™ï¸ð&lt;&amp;sol;div&gt;</p>
+<div>☆✨©™️😎</div>
 <p><strong>Strong ☆ ✨</strong></p>
 HTML,
         <<<'MD'

--- a/tests/Unit/Helpers/MarkdownExtraTest.php
+++ b/tests/Unit/Helpers/MarkdownExtraTest.php
@@ -1,0 +1,332 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * NOTICE OF LICENSE.
+ *
+ * UNIT3D Community Edition is open-sourced software licensed under the GNU Affero General Public License v3.0
+ * The details is bundled with this project in the file LICENSE.txt.
+ *
+ * @project    UNIT3D Community Edition
+ *
+ * @author     HDVinnie <hdinnovations@protonmail.com>
+ * @license    https://www.gnu.org/licenses/agpl-3.0.en.html/ GNU Affero General Public License v3.0
+ */
+
+use App\Helpers\MarkdownExtra;
+
+describe('markdown support', tests: function (): void {
+    it(
+        'Generates HTML from Markdown',
+        function (
+            string $result,
+            string $markdown,
+            bool $minify = true,
+            bool $strict = false,
+            bool $safeMode = false
+        ): void {
+            $service = (new MarkdownExtra())
+                ->setSafeMode($safeMode)
+                ->setStrictMode($strict);
+
+            $html = $service->parse($markdown);
+            $html = $minify ? str_replace(["\r\n", "\r", "\n"], '', $html) : $html;
+
+            $this->assertEquals($result, $html);
+        }
+    )->with(function (): iterable {
+        yield from basicMarkdown();
+
+        yield from codeBlocks();
+
+        yield from blockQuote();
+
+        yield from extendedSyntax();
+    });
+
+    it('Handles auto linking', function (string $result, string $markdown, bool $autoLink = true): void {
+        $service = (new MarkdownExtra())->setUrlsLinked($autoLink);
+        $this->assertEquals($result, $service->parse($markdown));
+    })->with(function (): iterable {
+        yield 'auto link' => ['<p><a href="https://example.com">https://example.com</a></p>', 'https://example.com'];
+
+        yield 'auto link disabled' => ['<p>https://example.com</p>', 'https://example.com', false];
+    });
+});
+
+function basicMarkdown(): iterable
+{
+    yield 'heading' => ['<h1>Heading</h1>', '# Heading'];
+
+    yield 'paragraph' => ['<p>Paragraph</p>', 'Paragraph'];
+
+    yield 'table' => ['<table><thead><tr><th>Header</th></tr></thead><tbody><tr><td>Cell</td></tr></tbody></table>', "| Header |\n|--------|\n| Cell   |"];
+
+    yield 'list' => ['<ul><li>Item 1</li><li>Item 2</li></ul>', "- Item 1\n- Item 2"];
+
+    yield 'image' => ['<p><img src="https://example.com/image.jpg" alt="Image" /></p>', '![Image](https://example.com/image.jpg)'];
+
+    yield 'link' => ['<p><a href="https://example.com">Link</a></p>', '[Link](https://example.com)'];
+
+    yield 'inline link' => ['<p><a href="https://example.com">https://example.com</a></p>', '<https://example.com>'];
+
+    yield 'inline URL' => ['<p><a href="https://example.com">https://example.com</a></p>', 'https://example.com'];
+
+    yield 'inline email' => ['<p><a href="mailto:test@example.com">test@example.com</a></p>', '<test@example.com>'];
+
+    yield 'bold' => ['<p><strong>This is bold</strong></p>', '**This is bold**'];
+
+    yield 'italic' => ['<p><em>This is italic</em></p>', '*This is italic*'];
+
+    yield 'escaped italic' => ['<p>I do not want _italic text_ here</p>', 'I do not want \_italic text\_ here'];
+
+    yield 'copy' => ['<p>&copy;</p>', '&copy;'];
+
+    yield 'strikethrough' => ['<p><del>This is strikethrough</del></p>', '~~This is strikethrough~~'];
+
+    yield 'bold italic' => ['<p><strong><em>This is bold italic</em></strong></p>', '***This is bold italic***'];
+
+    yield 'bold italic strikethrough' => ['<p><strong><em><del>This is bold italic strikethrough</del></em></strong></p>', '***~~This is bold italic strikethrough~~***'];
+
+    yield 'code' => ['<p>Do not use <code>dump()</code> in your code please.</p>', 'Do not use `dump()` in your code please.'];
+
+    yield 'heading level 1' => ['<h1>Header 1</h1><h2>Header 2</h2><h3>Header 3</h3><h4>Header 4</h4><h5>Header 5</h5><h6>Header 6</h6>', "# Header 1\n\n## Header 2\n\n### Header 3\n\n#### Header 4\n\n##### Header 5\n\n###### Header 6"];
+
+    yield 'heading with custom id' => ['<h3 id="custom-id">My Great Heading</h3>', '### My Great Heading {#custom-id}'];
+
+    yield 'heading level 1 and 2' => ['<h1>Heading level 1</h1><h2>Heading level 2</h2>', "Heading level 1\n===============\nHeading level 2\n---------------"];
+
+    yield 'horizontal rule' => ['<hr />', '____'];
+
+    yield 'escaped html' => ['<p>&lt;test</p>', '<test'];
+
+    yield 'escaped backslash' => ['<p>\test</p>', '\\test'];
+
+    yield 'comment' => ['', '[comment]: <> (This is a comment, it will not be included)'];
+
+    yield 'comment' => ['', '[//]: <> (This is a comment, it will not be included)'];
+
+    yield 'list with nested list' => [
+        <<<'HTML'
+<ul>
+<li>Item 1<ul>
+<li>Item 1.1
+Test</li>
+<li>Item 1.2<ul>
+<li>Item 1.2.1</li>
+</ul>
+</li>
+</ul>
+</li>
+<li>Item 2</li>
+<li>Item 3</li>
+</ul>
+<p>Test</p>
+HTML,
+        <<<MD
+- Item 1\n  - Item 1.1\n  Test\n  - Item 1.2\n    - Item 1.2.1\n- Item 2\n- Item 3\n\nTest
+MD,
+        false,
+    ];
+
+    yield 'ordered list' => ['<ol><li>Item 1</li><li>Item 2</li></ol>', "1. Item 1\n2. Item 2"];
+
+    yield 'html elements with safe mode' => ['<p>&lt;strong&gt;Strong&lt;/strong&gt;</p>', '<strong>Strong</strong>', false, false, true];
+}
+
+function codeBlocks(): iterable
+{
+    yield 'code block' => [
+        '<pre><code>echo "Hello, World!";</code></pre>',
+        "```\necho \"Hello, World!\";\n```",
+    ];
+
+    yield 'code block with language' => [
+        '<pre><code class="language-php">echo "Hello, World!";</code></pre>',
+        "```php\necho \"Hello, World!\";\n```",
+    ];
+
+    yield 'code block with language json' => [
+        <<<'HTML'
+<pre><code class="language-json">
+{
+    "firstName": "John",
+    "lastName": "Smith",
+    "age": 25
+}</code></pre>
+HTML,
+        <<<'MD'
+```json
+{
+    "firstName": "John",
+    "lastName": "Smith",
+    "age": 25
+}
+MD,
+        false,
+    ];
+
+    yield 'code block with language text' => [
+        <<<'HTML'
+<pre><code class="language-text">code();
+address@domain.example</code></pre>
+HTML,
+        <<<'MD'
+~~~text
+code();
+address@domain.example
+~~~
+MD,
+        false,
+    ];
+
+    yield 'code block using 4 spaces' => [
+        <<<'HTML'
+<pre><code>{
+  "firstName": "John",
+  "lastName": "Smith",
+  "age": 25
+}</code></pre>
+HTML,
+        <<<'MD'
+    {
+      "firstName": "John",
+      "lastName": "Smith",
+      "age": 25
+    }
+MD,
+        false,
+    ];
+}
+
+function blockQuote(): iterable
+{
+    yield 'blockquote' => [
+        <<<'HTML'
+<blockquote>
+<p>This is a quote
+And here is the second line
+One more line</p>
+</blockquote>
+<p>And this is not a quote</p>
+HTML,
+        <<<'MD'
+> This is a quote
+> And here is the second line
+One more line
+
+And this is not a quote
+MD,
+        false,
+    ];
+}
+
+function extendedSyntax(): iterable
+{
+    yield 'footnotes' => [
+        <<<'HTML'
+<p>Here is a simple footnote<sup id="fnref1:1"><a href="#fn:1" class="footnote-ref">1</a></sup>. With some additional<sup id="fnref1:2"><a href="#fn:2" class="footnote-ref">2</a></sup> text after it.</p>
+<div class="footnotes">
+<hr />
+<ol>
+<li id="fn:1">
+<p>Another footnote.&#160;<a href="#fnref1:1" rev="footnote" class="footnote-backref">&#8617;</a></p>
+</li>
+<li id="fn:2">
+<p>My reference.
+Some more text here.</p>
+<p>Continuing here.&#160;<a href="#fnref1:2" rev="footnote" class="footnote-backref">&#8617;</a></p>
+</li>
+</ol>
+</div>
+HTML,
+        <<<'MD'
+Here is a simple footnote[^1]. With some additional[^2] text after it.
+
+[^2]: My reference.
+Some more text here.
+
+    Continuing here.
+[^1]: Another footnote.
+MD,
+        false,
+    ];
+
+    yield 'definition lists' => [
+        <<<'HTML'
+<dl>
+<dt>First Term</dt>
+<dd>This is the definition of the first term.</dd>
+<dt>Second Term</dt>
+<dd>This is one definition of the second term.</dd>
+<dd>
+<p>This is another definition of the second term.
+Continuing here</p>
+<p>One more line</p>
+</dd>
+</dl>
+HTML,
+        <<<'MD'
+First Term
+: This is the definition of the first term.
+
+Second Term
+: This is one definition of the second term.
+: This is another definition of the second term.
+Continuing here
+
+    One more line
+MD,
+        false,
+    ];
+
+    yield 'abbreviations' => [
+        <<<'HTML'
+<p>The <abbr title="Hyper Text Markup Language">HTML</abbr> specification
+is maintained by the <abbr title="World Wide Web Consortium">W3C</abbr>.</p>
+HTML,
+        <<<'MD'
+The HTML specification
+is maintained by the W3C.
+
+*[HTML]: Hyper Text Markup Language
+*[W3C]:  World Wide Web Consortium
+MD,
+        false,
+    ];
+
+    yield 'html elements' => [
+        <<<'HTML'
+<img src="https://example.com/image.jpg" alt="Image" />
+<p>&lt;div&gt;&amp;star;â¨©™ï¸ð&lt;&amp;sol;div&gt;</p>
+<p><strong>Strong ☆ ✨</strong></p>
+HTML,
+        <<<'MD'
+<img src="https://example.com/image.jpg" alt="Image" />
+<div>☆✨©™️😎</div>
+<strong>Strong ☆ ✨</strong>
+MD,
+        false,
+    ];
+
+    yield 'HTML comments' => [
+        <<<'HTML'
+<!-- This is a comment -->
+<!--
+This
+is a comment
+too
+-->
+HTML,
+        <<<'MD'
+<!-- This is a comment -->
+<!--
+This
+is a comment
+too
+-->
+MD,
+        false,
+    ];
+}

--- a/tests/Unit/Models/PageTest.php
+++ b/tests/Unit/Models/PageTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * NOTICE OF LICENSE.
+ *
+ * UNIT3D Community Edition is open-sourced software licensed under the GNU Affero General Public License v3.0
+ * The details is bundled with this project in the file LICENSE.txt.
+ *
+ * @project    UNIT3D Community Edition
+ *
+ * @author     HDVinnie <hdinnovations@protonmail.com>
+ * @license    https://www.gnu.org/licenses/agpl-3.0.en.html/ GNU Affero General Public License v3.0
+ */
+
+use App\Models\Page;
+
+describe('page model', function (): void {
+    it('parses BBCode and Markdown', function (): void {
+        $page = Page::factory()->make([
+            'content' => '# Hello [b]world[/b]',
+        ]);
+
+        expect(trim($page->getContentHtml()))->toBe('<h1>Hello <b>world</b></h1>');
+    });
+});


### PR DESCRIPTION
Adds some tests to cover most of `Markdown` and `MarkdownExtra` services. This should be helpful when migrating to another engine in the future.

Fixes #4283 I'm not sure if using `htmlentities()` is correct here though - I think it should only be used when safe mode is on (see tests).

`Helpers` coverage looks as follows now:
<img width="899" alt="image" src="https://github.com/user-attachments/assets/d68464ba-39a7-44d5-9334-892e9a9172a4">
