### PR TITLE
(Update) Keep image when updating playlist

### DIFF
--- a/app/Http/Controllers/PlaylistController.php
+++ b/app/Http/Controllers/PlaylistController.php
@@ -154,9 +154,11 @@ class PlaylistController extends Controller
             $filename = 'playlist-cover_'.uniqid('', true).'.'.$image->getClientOriginalExtension();
             $path = public_path('/files/img/'.$filename);
             Image::make($image->getRealPath())->fit(400, 225)->encode('png', 100)->save($path);
-        }
 
-        $playlist->update(['cover_image' => $filename ?? null] + $request->validated());
+            $playlist->update(['cover_image' => $filename] + $request->validated());
+        } else {
+            $playlist->update($request->validated());
+        }
 
         return to_route('playlists.show', ['playlist' => $playlist])
             ->withSuccess(trans('playlist.update-success'));


### PR DESCRIPTION
When updating a playlist, if no image is specified, it removes the image from the playlist. Instead, keep the latest image provided. This is mostly for convenience from user reports which strongly request this feature.