### PR TITLE
(Fix) Playlist sort should be alphabetical

### DIFF
--- a/app/Http/Livewire/PlaylistSearch.php
+++ b/app/Http/Livewire/PlaylistSearch.php
@@ -43,7 +43,7 @@ class PlaylistSearch extends Component
     public string $username = '';
 
     #[Url(history: true)]
-    public string $sortDirection = 'desc';
+    public string $sortDirection = 'asc';
 
     final public function updatingName(): void
     {


### PR DESCRIPTION
Currently it's z-a. It used to be a-z. Regression from #3844.