### PR TITLE
(Fix) Only show forum/topic/post count visible to user

### DIFF
--- a/app/Http/Controllers/ForumController.php
+++ b/app/Http/Controllers/ForumController.php
@@ -42,9 +42,21 @@ class ForumController extends Controller
                 ->orderBy('position')
                 ->get()
                 ->filter(fn ($category) => $category->forums->isNotEmpty()),
-            'num_posts'  => Post::count(),
-            'num_forums' => Forum::count(),
-            'num_topics' => Topic::count(),
+            'num_posts' => cache()->remember(
+                'post-count:by-group-id:'.$request->user()->group_id,
+                3600,
+                fn () => Post::query()->authorized(canReadTopic: true)->count()
+            ),
+            'num_forums' => cache()->remember(
+                'forum-count:by-group-id:'.$request->user()->group_id,
+                3600,
+                fn () => Forum::query()->authorized(canReadTopic: true)->count()
+            ),
+            'num_topics' => cache()->remember(
+                'topic-count:by-group-id:'.$request->user()->group_id,
+                3600,
+                fn () => Topic::query()->authorized(canReadTopic: true)->count()
+            ),
         ]);
     }
 


### PR DESCRIPTION
Some forums are only visible to certain user groups so we should exclude the stats from users unable to access them.