### PR TITLE
(Fix) Sorting on unregistered infohash page take 2

### DIFF
--- a/app/Http/Livewire/UnregisteredInfoHashSearch.php
+++ b/app/Http/Livewire/UnregisteredInfoHashSearch.php
@@ -80,7 +80,7 @@ class UnregisteredInfoHashSearch extends Component
                 $this->excludeSoftDeletedTorrents,
                 fn ($query) => $query->whereDoesntHave('torrent', fn ($query) => $query->onlyTrashed()->withoutGlobalScope(ApprovedScope::class))
             )
-            ->latest()
+            ->orderBy($this->sortField, $this->sortDirection)
             ->paginate($this->perPage);
     }
 


### PR DESCRIPTION
We need to order by the livewire variable, not by the created_at constant.