### PR TITLE
(Update) Disable events upon initial creation

### DIFF
--- a/app/Http/Requests/Staff/StoreEventRequest.php
+++ b/app/Http/Requests/Staff/StoreEventRequest.php
@@ -51,10 +51,6 @@ class StoreEventRequest extends FormRequest
                 'required',
                 'date',
             ],
-            'active' => [
-                'required',
-                'boolean',
-            ],
         ];
     }
 }

--- a/resources/views/Staff/event/create.blade.php
+++ b/resources/views/Staff/event/create.blade.php
@@ -75,18 +75,6 @@
                 </p>
             </div>
             <p class="form__group">
-                <input type="hidden" name="active" value="0" />
-                <input
-                    type="checkbox"
-                    class="form__checkbox"
-                    id="active"
-                    name="active"
-                    value="1"
-                    @checked(old('active'))
-                />
-                <label class="form__label" for="active">{{ __('common.active') }}?</label>
-            </p>
-            <p class="form__group">
                 <button class="form__button form__button--filled" wire:click="store">
                     {{ __('common.save') }}
                 </button>


### PR DESCRIPTION
Sometimes, a staff member might accidentally enable an event on creation before adding prizes. If the event has already started, users might try and claim prizes before prizes have been added, which makes them win nothing. Only allow enabling an event after it's been created on the edit screen to make it harder to mess up.