### PR TITLE
(Add) Allow internal options for internals in non-internal group

### DIFF
--- a/.cspell/dependencies.txt
+++ b/.cspell/dependencies.txt
@@ -9,6 +9,7 @@ getmeili
 imagick
 imgbb
 joypixels
+larastan
 laravel
 linkify
 livewire

--- a/app/Http/Controllers/API/TorrentController.php
+++ b/app/Http/Controllers/API/TorrentController.php
@@ -169,6 +169,7 @@ class TorrentController extends BaseController
         $torrent->stream = $request->input('stream');
         $torrent->sd = $request->input('sd');
         $torrent->personal_release = $request->input('personal_release') ?? false;
+
         /** @phpstan-ignore property.notFound (Larastan doesn't yet support loadExists()) */
         $torrent->internal = $user->group->is_modo || $user->internals_exists ? ($request->input('internal') ?? 0) : 0;
 
@@ -192,6 +193,7 @@ class TorrentController extends BaseController
         if (($user->group->is_modo || $user->internals_exists) && isset($fl_until)) {
             $torrent->fl_until = Carbon::now()->addDays($request->integer('fl_until'));
         }
+
         /** @phpstan-ignore property.notFound (Larastan doesn't yet support loadExists()) */
         $torrent->sticky = $user->group->is_modo || $user->internals_exists ? ($request->input('sticky') ?? false) : false;
         $torrent->moderated_at = Carbon::now();

--- a/app/Http/Controllers/API/TorrentController.php
+++ b/app/Http/Controllers/API/TorrentController.php
@@ -171,8 +171,10 @@ class TorrentController extends BaseController
         $torrent->personal_release = $request->input('personal_release') ?? false;
         /** @phpstan-ignore property.notFound (Larastan doesn't yet support loadExists()) */
         $torrent->internal = $user->group->is_modo || $user->internals_exists ? ($request->input('internal') ?? 0) : 0;
+
         /** @phpstan-ignore property.notFound (Larastan doesn't yet support loadExists()) */
         $torrent->doubleup = $user->group->is_modo || $user->internals_exists ? ($request->input('doubleup') ?? 0) : 0;
+
         /** @phpstan-ignore property.notFound (Larastan doesn't yet support loadExists()) */
         $torrent->refundable = $user->group->is_modo || $user->internals_exists ? ($request->input('refundable') ?? false) : false;
         $du_until = $request->input('du_until');

--- a/app/Http/Controllers/API/TorrentController.php
+++ b/app/Http/Controllers/API/TorrentController.php
@@ -105,7 +105,7 @@ class TorrentController extends BaseController
      */
     public function store(Request $request): \Illuminate\Http\JsonResponse
     {
-        $user = $request->user();
+        $user = $request->user()->loadExists('internals');
         abort_unless($user->can_upload ?? $user->group->can_upload, 403, __('torrent.cant-upload').' '.__('torrent.cant-upload-desc'));
 
         $requestFile = $request->file('torrent');
@@ -169,21 +169,29 @@ class TorrentController extends BaseController
         $torrent->stream = $request->input('stream');
         $torrent->sd = $request->input('sd');
         $torrent->personal_release = $request->input('personal_release') ?? false;
-        $torrent->internal = $user->group->is_modo || $user->group->is_internal ? ($request->input('internal') ?? 0) : 0;
-        $torrent->doubleup = $user->group->is_modo || $user->group->is_internal ? ($request->input('doubleup') ?? 0) : 0;
-        $torrent->refundable = $user->group->is_modo || $user->group->is_internal ? ($request->input('refundable') ?? false) : false;
+        /** @phpstan-ignore property.notFound (Larastan doesn't yet support loadExists()) */
+        $torrent->internal = $user->group->is_modo || $user->internals_exists ? ($request->input('internal') ?? 0) : 0;
+        /** @phpstan-ignore property.notFound (Larastan doesn't yet support loadExists()) */
+        $torrent->doubleup = $user->group->is_modo || $user->internals_exists ? ($request->input('doubleup') ?? 0) : 0;
+        /** @phpstan-ignore property.notFound (Larastan doesn't yet support loadExists()) */
+        $torrent->refundable = $user->group->is_modo || $user->internals_exists ? ($request->input('refundable') ?? false) : false;
         $du_until = $request->input('du_until');
 
-        if (($user->group->is_modo || $user->group->is_internal) && isset($du_until)) {
+        /** @phpstan-ignore property.notFound (Larastan doesn't yet support loadExists()) */
+        if (($user->group->is_modo || $user->internals_exists) && isset($du_until)) {
             $torrent->du_until = Carbon::now()->addDays($request->integer('du_until'));
         }
-        $torrent->free = $user->group->is_modo || $user->group->is_internal ? ($request->input('free') ?? 0) : 0;
+
+        /** @phpstan-ignore property.notFound (Larastan doesn't yet support loadExists()) */
+        $torrent->free = $user->group->is_modo || $user->internals_exists ? ($request->input('free') ?? 0) : 0;
         $fl_until = $request->input('fl_until');
 
-        if (($user->group->is_modo || $user->group->is_internal) && isset($fl_until)) {
+        /** @phpstan-ignore property.notFound (Larastan doesn't yet support loadExists()) */
+        if (($user->group->is_modo || $user->internals_exists) && isset($fl_until)) {
             $torrent->fl_until = Carbon::now()->addDays($request->integer('fl_until'));
         }
-        $torrent->sticky = $user->group->is_modo || $user->group->is_internal ? ($request->input('sticky') ?? false) : false;
+        /** @phpstan-ignore property.notFound (Larastan doesn't yet support loadExists()) */
+        $torrent->sticky = $user->group->is_modo || $user->internals_exists ? ($request->input('sticky') ?? false) : false;
         $torrent->moderated_at = Carbon::now();
         $torrent->moderated_by = User::SYSTEM_USER_ID;
 

--- a/app/Http/Controllers/TorrentBuffController.php
+++ b/app/Http/Controllers/TorrentBuffController.php
@@ -45,7 +45,7 @@ class TorrentBuffController extends Controller
     {
         $user = $request->user();
 
-        abort_unless($user->group->is_modo || $user->group->is_internal, 403);
+        abort_unless($user->group->is_modo || $user->internals()->exists(), 403);
         $torrent = Torrent::withoutGlobalScope(ApprovedScope::class)->findOrFail($id);
         $torrent->bumped_at = Carbon::now();
         $torrent->save();
@@ -78,7 +78,7 @@ class TorrentBuffController extends Controller
     {
         $user = $request->user();
 
-        abort_unless($user->group->is_modo || $user->group->is_internal, 403);
+        abort_unless($user->group->is_modo || $user->internals()->exists(), 403);
         $torrent = Torrent::withoutGlobalScope(ApprovedScope::class)->findOrFail($id);
         $torrent->sticky = !$torrent->sticky;
         $torrent->save();
@@ -94,7 +94,7 @@ class TorrentBuffController extends Controller
     {
         $user = $request->user();
 
-        abort_unless($user->group->is_modo || $user->group->is_internal, 403);
+        abort_unless($user->group->is_modo || $user->internals()->exists(), 403);
         $torrent = Torrent::withoutGlobalScope(ApprovedScope::class)->findOrFail($id);
         $torrentUrl = href_torrent($torrent);
 
@@ -138,7 +138,7 @@ class TorrentBuffController extends Controller
     {
         $user = $request->user();
 
-        abort_unless($user->group->is_modo || $user->group->is_internal, 403);
+        abort_unless($user->group->is_modo || $user->internals()->exists(), 403);
         $torrent = Torrent::withoutGlobalScope(ApprovedScope::class)->findOrFail($id);
 
         if ($torrent->featured()->doesntExist()) {
@@ -201,7 +201,7 @@ class TorrentBuffController extends Controller
     {
         $user = $request->user();
 
-        abort_unless($user->group->is_modo || $user->group->is_internal, 403);
+        abort_unless($user->group->is_modo || $user->internals()->exists(), 403);
         $torrent = Torrent::withoutGlobalScope(ApprovedScope::class)->findOrFail($id);
         $torrentUrl = href_torrent($torrent);
 
@@ -275,7 +275,7 @@ class TorrentBuffController extends Controller
     public function setRefundable(Request $request, int $id): \Illuminate\Http\RedirectResponse
     {
         $user = $request->user();
-        abort_unless($user->group->is_modo || $user->group->is_internal, 403);
+        abort_unless($user->group->is_modo || $user->internals()->exists(), 403);
 
         $torrent = Torrent::withoutGlobalScope(ApprovedScope::class)->findOrFail($id);
         $torrent_url = href_torrent($torrent);

--- a/app/Http/Requests/StoreTorrentRequest.php
+++ b/app/Http/Requests/StoreTorrentRequest.php
@@ -44,6 +44,7 @@ class StoreTorrentRequest extends FormRequest
      */
     public function rules(Request $request): array
     {
+        $user = $request->user()->loadExists('internals');
         $category = Category::findOrFail($request->integer('category_id'));
 
         return [
@@ -223,19 +224,22 @@ class StoreTorrentRequest extends FormRequest
             'internal' => [
                 'sometimes',
                 'boolean',
-                Rule::when(!$request->user()->group->is_modo && !$request->user()->group->is_internal, 'prohibited'),
+                /** @phpstan-ignore property.notFound (Larastan doesn't yet support loadExists()) */
+                Rule::when(!$user->group->is_modo && !$user->internals_exists, 'prohibited'),
             ],
             'free' => [
                 'sometimes',
                 'integer',
                 'numeric',
                 'between:0,100',
-                Rule::when(!$request->user()->group->is_modo && !$request->user()->group->is_internal, 'prohibited'),
+                /** @phpstan-ignore property.notFound (Larastan doesn't yet support loadExists()) */
+                Rule::when(!$user->group->is_modo && !$user->internals_exists, 'prohibited'),
             ],
             'refundable' => [
                 'sometimes',
                 'boolean',
-                Rule::when(!$request->user()->group->is_modo && !$request->user()->group->is_internal, 'prohibited'),
+                /** @phpstan-ignore property.notFound (Larastan doesn't yet support loadExists()) */
+                Rule::when(!$user->group->is_modo && !$user->internals_exists, 'prohibited'),
             ],
         ];
     }

--- a/app/Http/Requests/UpdateTorrentRequest.php
+++ b/app/Http/Requests/UpdateTorrentRequest.php
@@ -143,17 +143,17 @@ class UpdateTorrentRequest extends FormRequest
             'internal' => [
                 'sometimes',
                 'boolean',
-                Rule::when(!$request->user()->group->is_modo && !$request->user()->group->is_internal, 'prohibited'),
+                Rule::when(!$request->user()->group->is_modo && !$request->user()->internals()->exists(), 'prohibited'),
             ],
             'free' => [
                 'sometimes',
                 'between:0,100',
-                Rule::when(!$request->user()->group->is_modo && !$request->user()->group->is_internal, 'prohibited'),
+                Rule::when(!$request->user()->group->is_modo && !$request->user()->internals()->exists(), 'prohibited'),
             ],
             'refundable' => [
                 'sometimes',
                 'boolean',
-                Rule::when(!$request->user()->group->is_modo && !$request->user()->group->is_internal, 'prohibited'),
+                Rule::when(!$request->user()->group->is_modo && !$request->user()->internals()->exists(), 'prohibited'),
             ],
         ];
     }

--- a/resources/views/torrent/create.blade.php
+++ b/resources/views/torrent/create.blade.php
@@ -460,7 +460,7 @@
                     />
                     <label class="form__label" for="sd">{{ __('torrent.sd-content') }}?</label>
                 </p>
-                @if (auth()->user()->group->is_modo || auth()->user()->group->is_internal)
+                @if (auth()->user()->group->is_modo ||auth()->user()->internals()->exists())
                     <p class="form__group">
                         <input type="hidden" name="internal" value="0" />
                         <input
@@ -506,7 +506,7 @@
                     </p>
                 @endif
 
-                @if (auth()->user()->group->is_modo || auth()->user()->group->is_internal)
+                @if (auth()->user()->group->is_modo ||auth()->user()->internals()->exists())
                     <p class="form__group">
                         <input type="hidden" name="refundable" value="0" />
                         <input
@@ -523,7 +523,7 @@
                     </p>
                 @endif
 
-                @if (auth()->user()->group->is_modo || auth()->user()->group->is_internal)
+                @if (auth()->user()->group->is_modo ||auth()->user()->internals()->exists())
                     <p class="form__group">
                         <select name="free" id="free" class="form__select">
                             <option

--- a/resources/views/torrent/edit.blade.php
+++ b/resources/views/torrent/edit.blade.php
@@ -451,7 +451,7 @@
                     />
                     <label class="form__label" for="sd">{{ __('torrent.sd-content') }}?</label>
                 </p>
-                @if (auth()->user()->group->is_modo || auth()->user()->group->is_internal)
+                @if (auth()->user()->group->is_modo ||auth()->user()->internals()->exists())
                     <p class="form__group">
                         <input type="hidden" name="internal" value="0" />
                         <input

--- a/resources/views/torrent/partials/tools.blade.php
+++ b/resources/views/torrent/partials/tools.blade.php
@@ -113,7 +113,7 @@
                 </li>
             @endif
 
-            @if (auth()->user()->group->is_modo || auth()->user()->group->is_internal)
+            @if (auth()->user()->group->is_modo ||auth()->user()->internals()->exists())
                 <menu
                     style="
                         display: flex;

--- a/resources/views/torrent/show.blade.php
+++ b/resources/views/torrent/show.blade.php
@@ -50,7 +50,7 @@
     @include('torrent.partials.buttons')
 
     {{-- Tools Block --}}
-    @if (auth()->user()->group->is_internal || auth()->user()->group->is_editor || auth()->user()->group->is_modo || (auth()->id() === $torrent->user_id && $canEdit))
+    @if (auth()->user()->internals()->exists() ||auth()->user()->group->is_editor ||auth()->user()->group->is_modo ||(auth()->id() === $torrent->user_id && $canEdit))
         @include('torrent.partials.tools')
     @endif
 


### PR DESCRIPTION
Internals that are not member of the internal group (e.g., Editor) and not Moderator+ should still be able to set the internal options on their uploads. They need to be in at least one Internal group, checked using count of `InternalUsers`.