### PR TITLE
(Fix) Only show title when the user is not set to anonymous

### DIFF
--- a/resources/views/components/torrent/comment-listing.blade.php
+++ b/resources/views/components/torrent/comment-listing.blade.php
@@ -58,7 +58,7 @@
                 </a>
             </x-slot>
         </x-user_tag>
-        @if (! empty($comment->user->title))
+        @if (! empty($comment->user->title) && ! $comment->anon)
             <p class="comment__author-title">
                 {{ $comment->user->title }}
             </p>


### PR DESCRIPTION
Only show title when the user is not set to anonymous.