### PR TITLE
(Fix) Conversation delete button

### DIFF
--- a/resources/views/user/conversations/show.blade.php
+++ b/resources/views/user/conversations/show.blade.php
@@ -70,9 +70,9 @@
         <h2 class="panel__heading">{{ __('common.users') }}</h2>
         <div class="panel__body">
             <ul>
-                @foreach ($conversation->users as $user)
+                @foreach ($conversation->users as $conversationUser)
                     <li>
-                        <x-user_tag :user="$user" :anon="false" />
+                        <x-user_tag :user="$conversationUser" :anon="false" />
                     </li>
                 @endforeach
             </ul>


### PR DESCRIPTION
The `$user` variable in the for loop here is overwriting the existing `$user` variable used for the delete conversation form. We need to choose a different variable name.