### PR TITLE
Adds cover_url and banner_url to API , fixes blades

### DIFF
--- a/app/Helpers/UrlHelper.php
+++ b/app/Helpers/UrlHelper.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\Helpers;
+
+class UrlHelper
+{
+    /**
+     * Array of trusted URLs or domains.
+     *
+     * @var array
+     */
+    private static $trustedUrls = [
+        'imdb.com', 'imdb.org', 'imdb.co', 'imdb.idv', 'imdbshow.com', 'media-imdb.com',
+        'archive.org',
+        'coverartarchive.org',
+        'dvdempire.com', 'adultdvdempire.com', 'adultempire.com',
+        'cduniverse.com',
+
+    ];
+
+    /**
+     * Array of trusted IP ranges.
+     *
+     * @var array
+     */
+    private static $trustedIpRanges = [
+        '192.168.1.0/24',
+        '10.0.0.0/8',
+        '52.94.224.0/20', // imdb (AWS host most of the public web, not adding all possible ranges)
+        '207.241.224.0/20','207.241.224.0/24','207.241.237.0/24','208.70.24.0/21', // archive.org
+        '142.132.128.0/17', // coverartarchive
+        '199.182.184.0/22', '204.14.177.0/24', // dvdempire
+    ];
+
+    /**
+     * Check if a URL is trusted for external host
+     *
+     * @param string $url The URL to check
+     * @return bool
+     */
+    public static function isTrustedExternalHost($url)
+    {
+        $host = parse_url($url, PHP_URL_HOST);
+
+        // Check if the host matches any safe URL or domain
+        if (in_array($host, self::$trustedUrls)) {
+            return true;
+        }
+
+        // Convert the host to IP if possible, then check IP ranges
+        if (filter_var($host, FILTER_VALIDATE_IP)) {
+            $ip = $host;
+        } else {
+            $ip = gethostbyname($host);
+        }
+
+        if ($ip !== $host) { // if DNS lookup was successful
+            foreach (self::$trustedIpRanges as $range) {
+                if (self::ipInRange($ip, $range)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Check if an IP is within a given range.
+     *
+     * @param string $ip IP address to check
+     * @param string $range IP range in CIDR format
+     * @return bool
+     */
+    private static function ipInRange($ip, $range)
+    {
+        [$subnet, $bits] = explode('/', $range);
+        $ip = ip2long($ip);
+        $subnet = ip2long($subnet);
+        $mask = -1 << (32 - $bits);
+        $subnet &= $mask; # nb: in case the supplied subnet wasn't correctly aligned
+        return ($ip & $mask) == $subnet;
+    }
+}

--- a/app/Models/Torrent.php
+++ b/app/Models/Torrent.php
@@ -36,6 +36,8 @@ use voku\helper\AntiXSS;
  *
  * @property string                          $info_hash
  * @property int                             $id
+ * @property string|null                     $cover_url
+ * @property string|null                     $banner_url
  * @property string                          $name
  * @property string                          $description
  * @property string|null                     $mediainfo
@@ -140,6 +142,8 @@ class Torrent extends Model
     public const string SEARCHABLE = <<<'SQL'
             torrents.id,
             torrents.name,
+            torrents.cover_url,
+            torrents.banner_url,
             torrents.description,
             torrents.mediainfo,
             torrents.bdinfo,
@@ -832,6 +836,8 @@ class Torrent extends Model
         $missingRequiredAttributes = array_diff([
             'id',
             'name',
+            'cover_url',
+            'banner_url',
             'description',
             'mediainfo',
             'bdinfo',
@@ -904,6 +910,8 @@ class Torrent extends Model
         return [
             'id'                 => $torrent->id,
             'name'               => $torrent->name,
+            'cover_url'          => $torrent->cover_url,
+            'banner_url'         => $torrent->banner_url,
             'description'        => $torrent->description,
             'mediainfo'          => $torrent->mediainfo,
             'bdinfo'             => $torrent->bdinfo,

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,8 @@
         "symfony/dom-crawler": "^6.4.12",
         "theodorejb/polycast": "dev-master",
         "voku/anti-xss": "^4.1.42",
-        "vstelmakh/url-highlight": "^3.1.1"
+        "vstelmakh/url-highlight": "^3.1.1",
+        "ext-imagick": "*"
     },
     "require-dev": {
         "barryvdh/laravel-debugbar": "^3.14.6",

--- a/database/migrations/2024_12_16_183945_add_cover_and_banner_url_to_torrents_table.php
+++ b/database/migrations/2024_12_16_183945_add_cover_and_banner_url_to_torrents_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddCoverAndBannerUrlToTorrentsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('torrents', function (Blueprint $table) {
+            $table->string('cover_url', 255)->nullable()->after('folder');
+            $table->string('banner_url', 255)->nullable()->after('cover_url');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('torrents', function (Blueprint $table) {
+            $table->dropColumn(['cover_url', 'banner_url']);
+        });
+    }
+}

--- a/database/schema/mysql-schema.sql
+++ b/database/schema/mysql-schema.sql
@@ -2835,3 +2835,4 @@ INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (324,'2024_10_29_18
 INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (325,'2024_11_01_013426_add_soft_deletes_to_donation_packages_table',1);
 INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (326,'2024_11_13_044550_create_unregistered_info_hashes_table',1);
 INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (327,'2024_11_26_170256_add_is_torrent_modo_to_groups_table',1);
+INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (328, '2024_12_16_183945_add_cover_and_banner_url_to_torrents_table.php', 1);

--- a/resources/views/components/torrent/card.blade.php
+++ b/resources/views/components/torrent/card.blade.php
@@ -44,23 +44,40 @@
             <figure class="torrent-card__figure">
                 <img
                     class="torrent-card__image"
-                                @switch(true)
+                    @switch(true)
                         @case($torrent->category->movie_meta || $torrent->category->tv_meta)
                             src="{{ isset($meta->poster) ? tmdb_image('poster_mid', $meta->poster) : 'https://via.placeholder.com/160x240' }}"
-                    
-                            @break
-                        @case($torrent->category->game_meta && isset($torrent->meta) && $meta->cover->image_id && $meta->name)
-                            src="https://images.igdb.com/igdb/image/upload/t_cover_big/{{ $torrent->meta->cover->image_id }}.jpg"
-                    
-                            @break
-                        @case($torrent->category->music_meta)
-                            src="https://via.placeholder.com/160x240"
-                    
-                            @break
-                        @case($torrent->category->no_meta && file_exists(public_path() . '/files/img/torrent-cover_' . $torrent->id . '.jpg'))
-                            src="{{ url('files/img/torrent-cover_' . $torrent->id . '.jpg') }}"
-                    
-                            @break
+
+                    @break
+                    @case($torrent->category->game_meta && isset($torrent->meta) && $meta->cover->image_id && $meta->name)
+                        src="https://images.igdb.com/igdb/image/upload/t_cover_big/{{ $torrent->meta->cover->image_id }}.jpg"
+
+                    @break
+                    @case($torrent->category->music_meta) {{--Could combine music_meta||no_meta , left seperate to ease special handling if needed--}}
+                    @php
+                        $coverPath = 'files/img/torrent-cover_' . $torrent->id;
+                        $coverFile = collect(glob(public_path($coverPath . '.*')))->first();
+                        $imageSrc = $coverFile !== null
+                            ? asset(str_replace(public_path(), '', $coverFile))
+                            : ($torrent->cover_url && filter_var($torrent->cover_url, FILTER_VALIDATE_URL)
+                                ? $torrent->cover_url
+                                : 'https://via.placeholder.com/160x240');
+                    @endphp
+                    src="{{ $imageSrc }}"
+
+                    @break
+                    @case($torrent->category->no_meta)
+                        @php
+                            $coverPath = 'files/img/torrent-cover_' . $torrent->id;
+                            $coverFile = collect(glob(public_path($coverPath . '.*')))->first();
+                            $imageSrc = $coverFile !== null
+                                ? asset(str_replace(public_path(), '', $coverFile))
+                                : ($torrent->cover_url && filter_var($torrent->cover_url, FILTER_VALIDATE_URL)
+                                    ? $torrent->cover_url
+                                    : 'https://via.placeholder.com/160x240');
+                        @endphp
+                        src="{{ $imageSrc }}"
+                    @break
                     @endswitch
 
                     alt="{{ __('torrent.similar') }}"

--- a/resources/views/components/torrent/row.blade.php
+++ b/resources/views/components/torrent/row.blade.php
@@ -46,8 +46,17 @@
                 @endif
 
                 @if ($torrent->category->music_meta)
+                    @php
+                        $coverPath = 'files/img/torrent-cover_' . $torrent->id;
+                        $coverFile = collect(glob(public_path($coverPath . '.*')))->first();
+                        $imageSrc = $coverFile !== null
+                            ? asset(str_replace(public_path(), '', $coverFile))
+                            : ($torrent->cover_url && filter_var($torrent->cover_url, FILTER_VALIDATE_URL)
+                                ? $torrent->cover_url
+                                : 'https://via.placeholder.com/90x135');
+                    @endphp
                     <img
-                        src="https://via.placeholder.com/90x135"
+                        src="{{ $imageSrc }}"
                         class="torrent-search--list__poster-img"
                         loading="lazy"
                         alt="{{ __('torrent.similar') }}"
@@ -55,21 +64,21 @@
                 @endif
 
                 @if ($torrent->category->no_meta)
-                    @if (file_exists(public_path() . '/files/img/torrent-cover_' . $torrent->id . '.jpg'))
-                        <img
-                            src="{{ url('files/img/torrent-cover_' . $torrent->id . '.jpg') }}"
-                            class="torrent-search--list__poster-img"
-                            loading="lazy"
-                            alt="{{ __('torrent.similar') }}"
-                        />
-                    @else
-                        <img
-                            src="https://via.placeholder.com/400x600"
-                            class="torrent-search--list__poster-img"
-                            loading="lazy"
-                            alt="{{ __('torrent.similar') }}"
-                        />
-                    @endif
+                    @php
+                        $coverPath = 'files/img/torrent-cover_' . $torrent->id;
+                        $coverFile = collect(glob(public_path($coverPath . '.*')))->first();
+                        $imageSrc = $coverFile !== null
+                            ? asset(str_replace(public_path(), '', $coverFile))
+                            : ($torrent->cover_url && filter_var($torrent->cover_url, FILTER_VALIDATE_URL)
+                                ? $torrent->cover_url
+                                : 'https://via.placeholder.com/400x600');
+                    @endphp
+                    <img
+                        src="{{ $imageSrc }}"
+                        class="torrent-search--list__poster-img"
+                        loading="lazy"
+                        alt="{{ __('torrent.similar') }}"
+                    />
                 @endif
             </a>
         </td>

--- a/resources/views/torrent/download_check.blade.php
+++ b/resources/views/torrent/download_check.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.default')
+Ï@extends('layout.default')
 
 @section('title')
     <title>{{ __('torrent.download-check') }} - {{ config('other.title') }}</title>

--- a/resources/views/torrent/partials/no_meta.blade.php
+++ b/resources/views/torrent/partials/no_meta.blade.php
@@ -1,17 +1,24 @@
+
 <section class="meta">
-    @if (file_exists(public_path() . '/files/img/torrent-banner_' . $torrent->id . '.jpg'))
-        <img
-            class="meta__backdrop"
-            src="{{ url('/files/img/torrent-banner_' . $torrent->id . '.jpg') }}"
-            alt=""
-        />
-    @endif
+    @php
+        $bannerPath = 'files/img/torrent-banner_' . $torrent->id;
+        $coverPath = 'files/img/torrent-cover_' . $torrent->id;
+
+        function setImageSrc($path, $urlField, $placeholder) {
+            $file = collect(glob(public_path($path . '.*')))->first();
+            return $file
+                ? asset(str_replace(public_path(), '', $file))
+                : ($urlField && filter_var($urlField, FILTER_VALIDATE_URL) ? $urlField : $placeholder);
+        }
+
+        $bannerSrc = setImageSrc($bannerPath, $torrent->banner_url, 'https://via.placeholder.com/1280x720');
+        $coverSrc = setImageSrc($coverPath, $torrent->cover_url, 'https://via.placeholder.com/400x600');
+    @endphp
+
+    <img class="meta__backdrop" src="{{ $bannerSrc }}" alt="Banner Image" />
 
     <span class="meta__poster-link">
-        <img
-            src="{{ file_exists(public_path() . '/files/img/torrent-cover_' . $torrent->id . '.jpg') ? url('/files/img/torrent-cover_' . $torrent->id . '.jpg') : 'https://via.placeholder.com/400x600' }}"
-            class="meta__poster"
-        />
+        <img src="{{ $coverSrc }}" class="meta__poster" alt="Cover Image" />
     </span>
     <div class="meta__actions">
         <a class="meta__dropdown-button" href="#">


### PR DESCRIPTION
Expects url hence `cover_url` and `banner_url`, no change has been made to `http/TorrentController.php` which could probably benefit from this change as well (though you may want to add it as additional option rather than replacement) 

Considerations: Imagick needed for compression (if enabled) , better support for varying filetypes while preserving alpha channels if applicable. 

Conversion to .webp its old news but lets optimize storage, load times and leverage capabilities to  include transparency for applicable no_meta categories. (yes, I've made sure it can grab .jpg for backward compatibility) 

____

Whats with this UrlHelper?? 

I'm a php baby, so might be a better way to implement this. The idea is to try to keep things read-only so externally hosted is great. However not so reliable. DMCA's anyone? So while whitelists is great for hosting screenshots and whatnot, having nuked covers and banners might not be ideal. Thus this would be a helper where you can configure trusted external hosts (that wont be here today, gone tomorrow) and just display 'em if trusted. Else, we can just download the image, compress and serve it. Obviously safeguards need to be in place so this feature should be able to be turned off. Also could skip download if content-header not known to prevent abuse.


Hope this helps.