### PR TITLE
(Fix) Receiving chat pms from other users while in chat pm

### DIFF
--- a/resources/js/components/chat/Chatbox.vue
+++ b/resources/js/components/chat/Chatbox.vue
@@ -961,7 +961,7 @@ export default {
           if (this.activeTab.substring(0, 3) != 'bot' && this.activeTab.substring(0, 6) != 'target')
             return false;
           if (e.message.bot && e.message.bot.id != this.bot) return false;
-          if (e.message.target && e.message.target.id != this.target) return false;
+          if (e.message.user && e.message.user.id != this.target) return false;
           this.messages.push(e.message);
           if (this.bot && this.bot > 0) {
             this.handleMessage('bot', this.bot, e.message);


### PR DESCRIPTION
When conversing in a chat pm and you receive a chat pm from another user, their message will appear inside of the current chat pm you have open.

This is because of incorrect logic inside Chatbox.vue. When user A sends a message to user B via the Chatter event, the message will have a subproperty `user` with user A's id. But user A is user B's target. So, these two properties need to be compared to determine if the message should be saved or not.