### PR TITLE
(Update) Fix column spans on user page

### DIFF
--- a/resources/views/livewire/user-notes.blade.php
+++ b/resources/views/livewire/user-notes.blade.php
@@ -145,7 +145,7 @@
                     </tr>
                 @empty
                     <tr>
-                        <td colspan="4">No notes</td>
+                        <td colspan="5">No notes</td>
                     </tr>
                 @endforelse
             </tbody>

--- a/resources/views/stats/themes/index.blade.php
+++ b/resources/views/stats/themes/index.blade.php
@@ -85,6 +85,10 @@
                                     Material Design 3 Amoled Theme
 
                                     @break
+                                @case('15')
+                                    Material Design 3 Navy Theme
+
+                                    @break
                             @endswitch
                         </td>
                         <td>Used By {{ $siteTheme->value }} Users</td>

--- a/resources/views/user/profile/show.blade.php
+++ b/resources/views/user/profile/show.blade.php
@@ -328,8 +328,6 @@
                                     </td>
                                 </tr>
                             @endforelse
-                        </tbody>
-                        <tfoot>
                             <tr>
                                 <td
                                     colspan="{{ 7 + (int) auth()->user()->group->is_modo + (int) config('announce.connectable_check') }}"
@@ -341,7 +339,7 @@
                                     </a>
                                 </td>
                             </tr>
-                        </tfoot>
+                        </tbody>
                     </table>
                 </div>
             </section>

--- a/resources/views/user/profile/show.blade.php
+++ b/resources/views/user/profile/show.blade.php
@@ -330,7 +330,7 @@
                             @endforelse
                             <tr>
                                 <td
-                                    colspan="{{ 7 + (int) auth()->user()->group->is_modo + (int) config('announce.connectable_check') }}"
+                                    colspan="{{ 7 + (int) config('announce.connectable_check') }}"
                                 >
                                     If you don't recognize a torrent client or IP address in the
                                     list, please

--- a/resources/views/user/profile/show.blade.php
+++ b/resources/views/user/profile/show.blade.php
@@ -328,6 +328,8 @@
                                     </td>
                                 </tr>
                             @endforelse
+                        </tbody>
+                        <tfoot>
                             <tr>
                                 <td
                                     colspan="{{ 7 + (int) config('announce.connectable_check') }}"
@@ -339,7 +341,7 @@
                                     </a>
                                 </td>
                             </tr>
-                        </tbody>
+                        </tfoot>
                     </table>
                 </div>
             </section>

--- a/resources/views/user/profile/show.blade.php
+++ b/resources/views/user/profile/show.blade.php
@@ -331,9 +331,7 @@
                         </tbody>
                         <tfoot>
                             <tr>
-                                <td
-                                    colspan="{{ 7 + (int) config('announce.connectable_check') }}"
-                                >
+                                <td colspan="{{ 7 + (int) config('announce.connectable_check') }}">
                                     If you don't recognize a torrent client or IP address in the
                                     list, please
                                     <a href="{{ route('tickets.index') }}">

--- a/resources/views/user/profile/show.blade.php
+++ b/resources/views/user/profile/show.blade.php
@@ -322,7 +322,7 @@
                             @empty
                                 <tr>
                                     <td
-                                        colspan="{{ \config('announce.connectable_check') === true ? 7 : 6 }}"
+                                        colspan="{{ \config('announce.connectable_check') === true ? 8 : 7 }}"
                                     >
                                         No Clients
                                     </td>
@@ -332,7 +332,7 @@
                         <tfoot>
                             <tr>
                                 <td
-                                    colspan="{{ 5 + (int) auth()->user()->group->is_modo + (int) config('announce.connectable_check') }}"
+                                    colspan="{{ 7 + (int) auth()->user()->group->is_modo + (int) config('announce.connectable_check') }}"
                                 >
                                     If you don't recognize a torrent client or IP address in the
                                     list, please


### PR DESCRIPTION
This fixes the row column span for each table and moves the tickets message in the clients footer into the table and removes the table footer to match the rest of the tables on the user page.