### PR TITLE
(Add) Allow Modo users to 'Revive' Deleted Invites & Expired Invites.

### DIFF
--- a/app/Http/Controllers/User/InviteController.php
+++ b/app/Http/Controllers/User/InviteController.php
@@ -160,16 +160,50 @@ class InviteController extends Controller
      */
     public function send(Request $request, User $user, Invite $sentInvite): \Illuminate\Http\RedirectResponse
     {
-        abort_unless($request->user()->group->is_modo || ($request->user()->is($user) && ($user->can_invite ?? $user->group->can_invite)), 403);
+        $isModo = $request->user()->group->is_modo;
+
+        abort_unless($isModo || ($request->user()->is($user) && ($user->can_invite ?? $user->group->can_invite)), 403);
 
         if ($sentInvite->accepted_by !== null) {
+
             return to_route('users.invites.index', ['user' => $user])
                 ->withErrors(trans('user.invite-already-used'));
+
+        }
+
+        if ($sentInvite->deleted_at !== null) {
+
+            if ($isModo && config('other.modo_revive_deleted_invites')) {
+
+                $sentInvite->expires_on = now()->addDays(config('other.invite_expire'));
+                $sentInvite->deleted_at = null;
+                $sentInvite->internal_note .= (!empty($sentInvite->internal_note)? PHP_EOL : '').
+                    "Invite Revived by Modo ".$request->user()->username." @ ". now()->toDateString() . PHP_EOL  ;
+                $sentInvite->save();
+
+            } else {
+
+                return to_route('users.invites.index', ['user' => $user])
+                    ->withErrors(trans('user.invite-deleted'));
+
+            }
+
         }
 
         if ($sentInvite->expires_on < now()) {
-            return to_route('users.invites.index', ['user' => $user])
-                ->withErrors(trans('user.invite-expired'));
+
+            if($isModo && config('other.modo_revive_expired_invites')) {
+
+                $sentInvite->expires_on = now()->addDays(config('other.invite_expire'));
+                $sentInvite->save();
+
+            } else {
+
+                return to_route('users.invites.index', ['user' => $user])
+                    ->withErrors(trans('user.invite-expired'));
+
+            }
+
         }
 
         Mail::to($sentInvite->email)->send(new InviteUser($sentInvite));

--- a/config/other.php
+++ b/config/other.php
@@ -125,9 +125,9 @@ return [
     'invite-only'   => true,
     'invite_expire' => 14,
 
-    /* Allow Modo Staff to Revive (Restore, Renew & Resend) Deleted Invites */
+    /* Allow Modo Staff to Revive (Restore & Renew) Deleted Invites */
     'modo_revive_deleted_invites' => true,
-    /* Allow Modo Staff to Revive (Restore, Renew & Resend) Expired Invites */
+    /* Allow Modo Staff to Revive (Restore & Renew) Expired Invites */
     'modo_revive_expired_invites' => true,
 
     'invites_restriced' => false,

--- a/config/other.php
+++ b/config/other.php
@@ -125,6 +125,11 @@ return [
     'invite-only'   => true,
     'invite_expire' => 14,
 
+    /* Allow Modo Staff to Revive (Restore, Renew & Resend) Deleted Invites */
+    'modo_revive_deleted_invites' => true,
+    /* Allow Modo Staff to Revive (Restore, Renew & Resend) Expired Invites */
+    'modo_revive_expired_invites' => true,
+
     'invites_restriced' => false,
     'invite_groups'     => [
         'Administrator',

--- a/lang/en/common.php
+++ b/lang/en/common.php
@@ -172,6 +172,7 @@ return [
     'remove'               => 'Remove',
     'report'               => 'Report',
     'resend'               => 'Resend',
+    'revive'               => 'Revive',
     'resolution'           => 'Resolution',
     'resolutions'          => 'Resolutions',
     'reporter'             => 'Reporter',

--- a/lang/en/user.php
+++ b/lang/en/user.php
@@ -152,6 +152,7 @@ return [
     'invited-by'                           => 'Invited By',
     'invite-already-sent'                  => 'The email address your trying to send a invite to has already been sent one.',
     'invite-already-used'                  => 'The invite you are trying to resend has already been used.',
+    'invite-deleted'                       => 'The invite you are trying to resend has been deleted.',
     'invite-expired'                       => 'The invite you are trying to resend has expired.',
     'invite-friend'                        => 'Invite your friend (Email + Message Required)',
     'invite-resent-success'                => 'Invite was resent successfully!',

--- a/lang/en/user.php
+++ b/lang/en/user.php
@@ -156,6 +156,8 @@ return [
     'invite-expired'                       => 'The invite you are trying to resend has expired.',
     'invite-friend'                        => 'Invite your friend (Email + Message Required)',
     'invite-resent-success'                => 'Invite was resent successfully!',
+    'invite-revive-success'                => 'Invite was revived successfully!',
+    'invite-revive-failed'                 => 'Invite was not able to be revived.',
     'invite-sent-success'                  => 'Invite was sent successfully!',
     'invite-tree'                          => 'Invite Tree',
     'invites'                              => 'Invites',

--- a/resources/views/user/invite/index.blade.php
+++ b/resources/views/user/invite/index.blade.php
@@ -107,39 +107,41 @@
                             <td>
                                 <menu class="data-table__actions">
                                     <li class="data-table__action">
-                                        @php
-                                            $revive =
-                                                $invite->accepted_at === null &&
-                                                (($invite->deleted_at !== null && config('other.modo_revive_deleted_invites')) ||
-                                                    ($invite->expires_on < now() && config('other.modo_revive_expired_invites'))) &&
-                                                auth()->user()->group->is_modo;
-                                        @endphp
-
-                                        <form
-                                            action="{{ route('users.invites.send', ['user' => $user, 'sentInvite' => $invite]) }}"
-                                            method="POST"
-                                            x-data="confirmation"
-                                        >
-                                            @csrf
-                                            @if ($revive)
+                                        @if ($invite->accepted_at === null &&
+                                            (($invite->deleted_at !== null && config('other.modo_revive_deleted_invites')) ||
+                                                ($invite->expires_on < now() && config('other.modo_revive_expired_invites'))) &&
+                                            auth()->user()->group->is_modo)
+                                            <form
+                                                action="{{ route('users.invites.revive', ['user' => $user, 'sentInvite' => $invite]) }}"
+                                                method="POST"
+                                                x-data="confirmation"
+                                            >
+                                                @csrf
                                                 <button
                                                     x-on:click.prevent="confirmAction"
-                                                    data-b64-deletion-message="{{ base64_encode('Are you sure you want to revive the invite for ' . $invite->email . ' and resend it?') }}"
+                                                    data-b64-deletion-message="{{ base64_encode('Are you sure you want to revive the invite for ' . $invite->email .'?') }}"
                                                     class="form__button form__button--text"
                                                 >
                                                     {{ __('common.revive') }}
                                                 </button>
-                                            @else
+                                            </form>
+                                        @else
+                                            <form
+                                                action="{{ route('users.invites.send', ['user' => $user, 'sentInvite' => $invite]) }}"
+                                                method="POST"
+                                                x-data="confirmation"
+                                            >
+                                                @csrf
                                                 <button
                                                     x-on:click.prevent="confirmAction"
-                                                    data-b64-deletion-message="{{ base64_encode('Are you sure you want to resend the email to: ' . $invite->email . '?') }}"
+                                                    data-b64-deletion-message="{{ base64_encode('Are you sure you want to resend the invite email to ' . $invite->email . '?') }}"
                                                     class="form__button form__button--text"
                                                     @disabled($invite->accepted_at !== null || $invite->expires_on < now() || $invite->deleted_at !== null)
                                                 >
                                                     {{ __('common.resend') }}
                                                 </button>
-                                            @endif
-                                        </form>
+                                            </form>
+                                        @endif
                                     </li>
                                     <li class="data-table__action">
                                         <form

--- a/resources/views/user/invite/index.blade.php
+++ b/resources/views/user/invite/index.blade.php
@@ -119,7 +119,7 @@
                                                 @csrf
                                                 <button
                                                     x-on:click.prevent="confirmAction"
-                                                    data-b64-deletion-message="{{ base64_encode('Are you sure you want to revive the invite for ' . $invite->email .'?') }}"
+                                                    data-b64-deletion-message="{{ base64_encode('Are you sure you want to revive the invite for ' . $invite->email . '?') }}"
                                                     class="form__button form__button--text"
                                                 >
                                                     {{ __('common.revive') }}

--- a/resources/views/user/invite/index.blade.php
+++ b/resources/views/user/invite/index.blade.php
@@ -107,20 +107,45 @@
                             <td>
                                 <menu class="data-table__actions">
                                     <li class="data-table__action">
+                                        @php
+                                            $revive =
+                                                    (
+                                                        $invite->accepted_at === null &&
+                                                        (
+                                                            ( $invite->deleted_at !== null && config('other.modo_revive_deleted_invites') ) ||
+                                                            ( $invite->expires_on < now() && config('other.modo_revive_expired_invites') )
+                                                        ) && auth()->user()->group->is_modo
+                                                    );
+                                        @endphp
                                         <form
                                             action="{{ route('users.invites.send', ['user' => $user, 'sentInvite' => $invite]) }}"
                                             method="POST"
                                             x-data="confirmation"
                                         >
                                             @csrf
-                                            <button
-                                                x-on:click.prevent="confirmAction"
-                                                data-b64-deletion-message="{{ base64_encode('Are you sure you want to resend the email to: ' . $invite->email . '?') }}"
-                                                class="form__button form__button--text"
-                                                @disabled($invite->accepted_at !== null || $invite->expires_on < now())
-                                            >
-                                                {{ __('common.resend') }}
-                                            </button>
+                                            @if($revive)
+
+                                                <button
+                                                    x-on:click.prevent="confirmAction"
+                                                    data-b64-deletion-message="{{ base64_encode('Are you sure you want to revive the invite for ' . $invite->email . ' and resend it?') }}"
+                                                    class="form__button form__button--text"
+                                                >
+                                                    {{ __('common.revive') }}
+                                                </button>
+
+                                            @else
+
+                                                <button
+                                                    x-on:click.prevent="confirmAction"
+                                                    data-b64-deletion-message="{{ base64_encode('Are you sure you want to resend the email to: ' . $invite->email . '?') }}"
+                                                    class="form__button form__button--text"
+                                                    @disabled($invite->accepted_at !== null || $invite->expires_on < now() || $invite->deleted_at !== null)
+                                                >
+                                                    {{ __('common.resend') }}
+                                                </button>
+
+                                            @endif
+
                                         </form>
                                     </li>
                                     <li class="data-table__action">

--- a/resources/views/user/invite/index.blade.php
+++ b/resources/views/user/invite/index.blade.php
@@ -109,22 +109,19 @@
                                     <li class="data-table__action">
                                         @php
                                             $revive =
-                                                    (
-                                                        $invite->accepted_at === null &&
-                                                        (
-                                                            ( $invite->deleted_at !== null && config('other.modo_revive_deleted_invites') ) ||
-                                                            ( $invite->expires_on < now() && config('other.modo_revive_expired_invites') )
-                                                        ) && auth()->user()->group->is_modo
-                                                    );
+                                                $invite->accepted_at === null &&
+                                                (($invite->deleted_at !== null && config('other.modo_revive_deleted_invites')) ||
+                                                    ($invite->expires_on < now() && config('other.modo_revive_expired_invites'))) &&
+                                                auth()->user()->group->is_modo;
                                         @endphp
+
                                         <form
                                             action="{{ route('users.invites.send', ['user' => $user, 'sentInvite' => $invite]) }}"
                                             method="POST"
                                             x-data="confirmation"
                                         >
                                             @csrf
-                                            @if($revive)
-
+                                            @if ($revive)
                                                 <button
                                                     x-on:click.prevent="confirmAction"
                                                     data-b64-deletion-message="{{ base64_encode('Are you sure you want to revive the invite for ' . $invite->email . ' and resend it?') }}"
@@ -132,9 +129,7 @@
                                                 >
                                                     {{ __('common.revive') }}
                                                 </button>
-
                                             @else
-
                                                 <button
                                                     x-on:click.prevent="confirmAction"
                                                     data-b64-deletion-message="{{ base64_encode('Are you sure you want to resend the email to: ' . $invite->email . '?') }}"
@@ -143,9 +138,7 @@
                                                 >
                                                     {{ __('common.resend') }}
                                                 </button>
-
                                             @endif
-
                                         </form>
                                     </li>
                                     <li class="data-table__action">

--- a/routes/web.php
+++ b/routes/web.php
@@ -511,7 +511,7 @@ Route::middleware('language')->group(function (): void {
         Route::prefix('invites')->name('invites.')->group(function (): void {
             Route::get('/create', [App\Http\Controllers\User\InviteController::class, 'create'])->name('create');
             Route::post('/store', [App\Http\Controllers\User\InviteController::class, 'store'])->name('store');
-            Route::post('/{sentInvite}/send', [App\Http\Controllers\User\InviteController::class, 'send'])->name('send');
+            Route::post('/{sentInvite}/send', [App\Http\Controllers\User\InviteController::class, 'send'])->name('send')->withTrashed();
             Route::delete('/{sentInvite}', [App\Http\Controllers\User\InviteController::class, 'destroy'])->name('destroy')->withTrashed();
             Route::get('/', [App\Http\Controllers\User\InviteController::class, 'index'])->name('index')->withTrashed();
         });

--- a/routes/web.php
+++ b/routes/web.php
@@ -511,7 +511,8 @@ Route::middleware('language')->group(function (): void {
         Route::prefix('invites')->name('invites.')->group(function (): void {
             Route::get('/create', [App\Http\Controllers\User\InviteController::class, 'create'])->name('create');
             Route::post('/store', [App\Http\Controllers\User\InviteController::class, 'store'])->name('store');
-            Route::post('/{sentInvite}/send', [App\Http\Controllers\User\InviteController::class, 'send'])->name('send')->withTrashed();
+            Route::post('/{sentInvite}/send', [App\Http\Controllers\User\InviteController::class, 'send'])->name('send');
+            Route::post('/{sentInvite}/revive', [App\Http\Controllers\User\InviteController::class, 'revive'])->name('revive')->withTrashed();
             Route::delete('/{sentInvite}', [App\Http\Controllers\User\InviteController::class, 'destroy'])->name('destroy')->withTrashed();
             Route::get('/', [App\Http\Controllers\User\InviteController::class, 'index'])->name('index')->withTrashed();
         });


### PR DESCRIPTION
  - Configuration to Enable/Disable in 'config/other.php'
  - Enabled by Default
  - Expiration Date is extended by the existing 'invite_expire' config.