### PR TITLE
(Add) Quoting in Livewire Comments

### DIFF
--- a/resources/views/livewire/comment.blade.php
+++ b/resources/views/livewire/comment.blade.php
@@ -29,7 +29,7 @@
                                 '{{ $comment->isParent() ? 'new-comment__textarea' : 'reply-comment' }}'
                             );
                             input.value +=
-                                '[quote={{ \htmlspecialchars('@' . ($comment->anon ? 'Anonymous' : $comment->user->username)) }}]';
+                                '[quote={{ \htmlspecialchars($comment->anon ? 'Anonymous' : '@' . $comment->user->username) }}]';
                             input.value += decodeURIComponent(
                                 escape(atob('{{ base64_encode(\htmlspecialchars($comment->content)) }}'))
                             );

--- a/resources/views/livewire/comment.blade.php
+++ b/resources/views/livewire/comment.blade.php
@@ -19,12 +19,15 @@
                         </button>
                     </li>
                 @endif
-                    <li class="comment__toolbar-item">
-                        <button
-                            class="post__quote"
-                            title="{{ __('forum.quote') }}"
-                            x-on:click="
-                            input = document.getElementById('{{ $comment->isParent() ? "new-comment__textarea" : "reply-comment" }}');
+
+                <li class="comment__toolbar-item">
+                    <button
+                        class="post__quote"
+                        title="{{ __('forum.quote') }}"
+                        x-on:click="
+                            input = document.getElementById(
+                                '{{ $comment->isParent() ? 'new-comment__textarea' : 'reply-comment' }}'
+                            );
                             input.value += '[quote={{ \htmlspecialchars('@' . $comment->user->username) }}]';
                             input.value += (() => {
                                 var text = document.createElement('textarea');
@@ -40,10 +43,10 @@
                             input.dispatchEvent(new Event('input'));
                             input.focus();
                         "
-                        >
-                            <i class="{{ \config('other.font-awesome') }} fa-quote-left"></i>
-                        </button>
-                    </li>
+                    >
+                        <i class="{{ \config('other.font-awesome') }} fa-quote-left"></i>
+                    </button>
+                </li>
                 @if ($comment->user_id === auth()->id() || auth()->user()->group->is_modo)
                     <li class="comment__toolbar-item">
                         <button wire:click="$toggle('isEditing')" class="comment__edit">

--- a/resources/views/livewire/comment.blade.php
+++ b/resources/views/livewire/comment.blade.php
@@ -30,16 +30,7 @@
                             );
                             input.value +=
                                 '[quote={{ \htmlspecialchars('@' . ($comment->anon ? 'Anonymous' : $comment->user->username)) }}]';
-                            input.value += (() => {
-                                var text = document.createElement('textarea');
-                                text.innerHTML = decodeURIComponent(
-                                    atob('{{ base64_encode($comment->content) }}')
-                                        .split('')
-                                        .map((c) => '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2))
-                                        .join('')
-                                );
-                                return text.value;
-                            })();
+                            input.value += atob('{{ base64_encode($comment->content) }}');
                             input.value += '[/quote]';
                             input.dispatchEvent(new Event('input'));
                             input.focus();

--- a/resources/views/livewire/comment.blade.php
+++ b/resources/views/livewire/comment.blade.php
@@ -30,7 +30,9 @@
                             );
                             input.value +=
                                 '[quote={{ \htmlspecialchars('@' . ($comment->anon ? 'Anonymous' : $comment->user->username)) }}]';
-                            input.value += decodeURIComponent(escape(atob('{{ base64_encode(\htmlspecialchars($comment->content)) }}')));
+                            input.value += decodeURIComponent(
+                                escape(atob('{{ base64_encode(\htmlspecialchars($comment->content)) }}'))
+                            );
                             input.value += '[/quote]';
                             input.dispatchEvent(new Event('input'));
                             input.focus();

--- a/resources/views/livewire/comment.blade.php
+++ b/resources/views/livewire/comment.blade.php
@@ -19,7 +19,31 @@
                         </button>
                     </li>
                 @endif
-
+                    <li class="comment__toolbar-item">
+                        <button
+                            class="post__quote"
+                            title="{{ __('forum.quote') }}"
+                            x-on:click="
+                            input = document.getElementById('{{ $comment->isParent() ? "new-comment__textarea" : "reply-comment" }}');
+                            input.value += '[quote={{ \htmlspecialchars('@' . $comment->user->username) }}]';
+                            input.value += (() => {
+                                var text = document.createElement('textarea');
+                                text.innerHTML = decodeURIComponent(
+                                    atob('{{ base64_encode($comment->content) }}')
+                                        .split('')
+                                        .map((c) => '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2))
+                                        .join('')
+                                );
+                                return text.value;
+                            })();
+                            input.value += '[/quote]';
+                            input.dispatchEvent(new Event('input'));
+                            input.focus();
+                        "
+                        >
+                            <i class="{{ \config('other.font-awesome') }} fa-quote-left"></i>
+                        </button>
+                    </li>
                 @if ($comment->user_id === auth()->id() || auth()->user()->group->is_modo)
                     <li class="comment__toolbar-item">
                         <button wire:click="$toggle('isEditing')" class="comment__edit">

--- a/resources/views/livewire/comment.blade.php
+++ b/resources/views/livewire/comment.blade.php
@@ -28,7 +28,8 @@
                             input = document.getElementById(
                                 '{{ $comment->isParent() ? 'new-comment__textarea' : 'reply-comment' }}'
                             );
-                            input.value += '[quote={{ \htmlspecialchars('@' . $comment->user->username) }}]';
+                            input.value +=
+                                '[quote={{ \htmlspecialchars('@' . ($comment->anon ? 'Anonymous' : $comment->user->username)) }}]';
                             input.value += (() => {
                                 var text = document.createElement('textarea');
                                 text.innerHTML = decodeURIComponent(

--- a/resources/views/livewire/comment.blade.php
+++ b/resources/views/livewire/comment.blade.php
@@ -30,7 +30,7 @@
                             );
                             input.value +=
                                 '[quote={{ \htmlspecialchars('@' . ($comment->anon ? 'Anonymous' : $comment->user->username)) }}]';
-                            input.value += atob('{{ base64_encode($comment->content) }}');
+                            input.value += decodeURIComponent(escape(atob('{{ base64_encode(\htmlspecialchars($comment->content)) }}')));
                             input.value += '[/quote]';
                             input.dispatchEvent(new Event('input'));
                             input.focus();


### PR DESCRIPTION
Ported the Quoting Implementation from the Forums to Livewire Comments so Torrent Comments and any other comments using Livewire Comments can be quoted. Functionally identical to Forums.

This should close this issue: https://github.com/HDInnovations/UNIT3D-Community-Edition/issues/4385