### PR TITLE
(Update) Helpdesk category sort/icons & transaction text wrapping

### DIFF
--- a/resources/sass/layout/_secondary-nav.scss
+++ b/resources/sass/layout/_secondary-nav.scss
@@ -3,6 +3,7 @@
 .secondary-nav {
     display: grid;
     grid-template-columns: 1fr auto 1fr;
+    box-shadow: 0 8px 10px 0 rgba(0, 0, 0, 0.2);
     background-color: var(--secondary-nav-bg);
     margin: 0;
     padding: 0 18px;

--- a/resources/sass/themes/_material-design-v3-navy.scss
+++ b/resources/sass/themes/_material-design-v3-navy.scss
@@ -560,7 +560,7 @@ a {
 }
 
 .text-muted {
-    color: #0e111c;
+    color: #fff;
 }
 
 hr {

--- a/resources/sass/themes/_material-design-v3-navy.scss
+++ b/resources/sass/themes/_material-design-v3-navy.scss
@@ -27,7 +27,7 @@
     --bbcode-input-bg: #0c0e15;
 
     --bbcode-rendered-fg-default: #c9d1d9;
-    --bbcode-rendered-fg-muted: #fff;
+    --bbcode-rendered-fg-muted: #444;
     --bbcode-rendered-fg-subtle: #484f58;
     --bbcode-rendered-canvas-default: transparent;
     --bbcode-rendered-canvas-subtle: #313131;
@@ -330,7 +330,7 @@
     --torrent-group-bg: #0f111a;
     --torrent-group-header-bg: #0f111a;
     --torrent-group-text: #fff;
-    --torrent-group-text-muted: #fff;
+    --torrent-group-text-muted: #444;
     --torrent-group-table-stripe-even: rgba(0, 0, 0, 0.18);
     --torrent-group-table-stripe-odd: rgba(0, 0, 0, 0.1);
     --torrent-group-hover-brightness-emphasis: 1.13;
@@ -560,7 +560,7 @@ a {
 }
 
 .text-muted {
-    color: #fff;
+    color: #444;
 }
 
 hr {

--- a/resources/sass/themes/_material-design-v3-navy.scss
+++ b/resources/sass/themes/_material-design-v3-navy.scss
@@ -27,7 +27,7 @@
     --bbcode-input-bg: #0c0e15;
 
     --bbcode-rendered-fg-default: #c9d1d9;
-    --bbcode-rendered-fg-muted: #444;
+    --bbcode-rendered-fg-muted: #808080;
     --bbcode-rendered-fg-subtle: #484f58;
     --bbcode-rendered-canvas-default: transparent;
     --bbcode-rendered-canvas-subtle: #313131;
@@ -560,7 +560,7 @@ a {
 }
 
 .text-muted {
-    color: #444;
+    color: #808080;
 }
 
 hr {

--- a/resources/views/Staff/donation/index.blade.php
+++ b/resources/views/Staff/donation/index.blade.php
@@ -39,7 +39,7 @@
                         <th>Upload #</th>
                         <th>Invite #</th>
                         <th>Bonus #</th>
-                        <th>Lenght</th>
+                        <th>Length</th>
                         <th>Status</th>
                         <th>{{ __('common.actions') }}</th>
                     </tr>
@@ -51,7 +51,7 @@
                             <td>
                                 <x-user_tag :user="$donation->user" :anon="false" />
                             </td>
-                            <td>{{ $donation->transaction }}</td>
+                            <td style="max-width: 80ch; word-wrap: break-word; white-space: normal;">{{ $donation->transaction }}</td>
                             <td
                                 class="{{ $donation->package->trashed() ? 'text-danger' : '' }}"
                                 title="{{ $donation->package->trashed() ? 'Package has been deleted' : '' }}"

--- a/resources/views/Staff/donation/index.blade.php
+++ b/resources/views/Staff/donation/index.blade.php
@@ -51,7 +51,9 @@
                             <td>
                                 <x-user_tag :user="$donation->user" :anon="false" />
                             </td>
-                            <td style="max-width: 80ch; word-wrap: break-word; white-space: normal;">{{ $donation->transaction }}</td>
+                            <td style="max-width: 80ch; word-wrap: break-word; white-space: normal">
+                                {{ $donation->transaction }}
+                            </td>
                             <td
                                 class="{{ $donation->package->trashed() ? 'text-danger' : '' }}"
                                 title="{{ $donation->package->trashed() ? 'Package has been deleted' : '' }}"

--- a/resources/views/livewire/comment.blade.php
+++ b/resources/views/livewire/comment.blade.php
@@ -28,11 +28,8 @@
                             input = document.getElementById(
                                 '{{ $comment->isParent() ? 'new-comment__textarea' : 'reply-comment' }}'
                             );
-                            input.value +=
-                                '[quote={{ $comment->anon ? 'Anonymous' : '@' . $comment->user->username }}]';
-                            input.value += decodeURIComponent(
-                                escape(atob('{{ base64_encode($comment->content) }}'))
-                            );
+                            input.value += '[quote={{ $comment->anon ? 'Anonymous' : '@' . $comment->user->username }}]';
+                            input.value += decodeURIComponent(escape(atob('{{ base64_encode($comment->content) }}')));
                             input.value += '[/quote]';
                             input.dispatchEvent(new Event('input'));
                             input.focus();

--- a/resources/views/livewire/comment.blade.php
+++ b/resources/views/livewire/comment.blade.php
@@ -29,9 +29,9 @@
                                 '{{ $comment->isParent() ? 'new-comment__textarea' : 'reply-comment' }}'
                             );
                             input.value +=
-                                '[quote={{ \htmlspecialchars($comment->anon ? 'Anonymous' : '@' . $comment->user->username) }}]';
+                                '[quote={{ $comment->anon ? 'Anonymous' : '@' . $comment->user->username }}]';
                             input.value += decodeURIComponent(
-                                escape(atob('{{ base64_encode(\htmlspecialchars($comment->content)) }}'))
+                                escape(atob('{{ base64_encode($comment->content) }}'))
                             );
                             input.value += '[/quote]';
                             input.dispatchEvent(new Event('input'));

--- a/resources/views/livewire/ticket-search.blade.php
+++ b/resources/views/livewire/ticket-search.blade.php
@@ -84,6 +84,10 @@
                         {{ __('ticket.priority') }}
                         @include('livewire.includes._sort-icon', ['field' => 'priority_id'])
                     </th>
+                    <th wire:click="sortBy('category_id')" role="columnheader button">
+                        {{ __('ticket.category') }}
+                        @include('livewire.includes._sort-icon', ['field' => 'category_id'])
+                    </th>
                     <th wire:click="sortBy('user_id')" role="columnheader button">
                         {{ __('common.username') }}
                         @include('livewire.includes._sort-icon', ['field' => 'user_id'])
@@ -128,19 +132,67 @@
                         <td>
                             @switch($ticket->priority->name)
                                 @case('Low')
-                                    <i class="fas fa-circle text-yellow"></i>
+                                    <i class="{{ config('other.font-awesome') }} fa-circle text-yellow"></i>
 
                                     @break
                                 @case('Medium')
-                                    <i class="fas fa-circle text-orange"></i>
+                                    <i class="{{ config('other.font-awesome') }} fa-circle text-orange"></i>
 
                                     @break
                                 @case('High')
-                                    <i class="fas fa-circle text-red"></i>
+                                    <i class="{{ config('other.font-awesome') }} fa-circle text-red"></i>
 
                                     @break
                             @endswitch
                             {{ $ticket->priority->name }}
+                        </td>
+                        <td>
+                            @switch($ticket->category->name)
+                                @case('Accounts')
+                                    <i class="{{ config('other.font-awesome') }} fa-user-circle"></i>
+                                    @break
+
+                                @case('Appeals')
+                                    <i class="{{ config('other.font-awesome') }} fa-gavel"></i>
+                                    @break
+
+                                @case('Forums')
+                                    <i class="{{ config('other.font-awesome') }} fa-comments"></i>
+                                    @break
+
+                                @case('Requests')
+                                    <i class="{{ config('other.font-awesome') }} fa-hands-helping"></i>
+                                    @break
+
+                                @case('Subtitles')
+                                    <i class="{{ config('other.font-awesome') }} fa-closed-captioning"></i>
+                                    @break
+
+                                @case('Torrents')
+                                    <i class="{{ config('other.font-awesome') }} fa-download"></i>
+                                    @break
+
+                                @case('MediaHub')
+                                    <i class="{{ config('other.font-awesome') }} fa-database"></i>
+                                    @break
+
+                                @case('Technical')
+                                    <i class="{{ config('other.font-awesome') }} fa-tools"></i>
+                                    @break
+
+                                @case('Playlists')
+                                    <i class="{{ config('other.font-awesome') }} fa-list-ol"></i>
+                                    @break
+
+                                @case('Bugs')
+                                    <i class="{{ config('other.font-awesome') }} fa-bug"></i>
+                                    @break
+
+                                @case('Other')
+                                    <i class="{{ config('other.font-awesome') }} fa-ellipsis-h"></i>
+                                    @break
+                            @endswitch
+                            {{ $ticket->category->name }}
                         </td>
                         <td>
                             <x-user_tag :user="$ticket->user" :anon="false" />

--- a/resources/views/livewire/ticket-search.blade.php
+++ b/resources/views/livewire/ticket-search.blade.php
@@ -132,15 +132,21 @@
                         <td>
                             @switch($ticket->priority->name)
                                 @case('Low')
-                                    <i class="{{ config('other.font-awesome') }} fa-circle text-yellow"></i>
+                                    <i
+                                        class="{{ config('other.font-awesome') }} fa-circle text-yellow"
+                                    ></i>
 
                                     @break
                                 @case('Medium')
-                                    <i class="{{ config('other.font-awesome') }} fa-circle text-orange"></i>
+                                    <i
+                                        class="{{ config('other.font-awesome') }} fa-circle text-orange"
+                                    ></i>
 
                                     @break
                                 @case('High')
-                                    <i class="{{ config('other.font-awesome') }} fa-circle text-red"></i>
+                                    <i
+                                        class="{{ config('other.font-awesome') }} fa-circle text-red"
+                                    ></i>
 
                                     @break
                             @endswitch
@@ -149,47 +155,56 @@
                         <td>
                             @switch($ticket->category->name)
                                 @case('Accounts')
-                                    <i class="{{ config('other.font-awesome') }} fa-user-circle"></i>
-                                    @break
+                                    <i
+                                        class="{{ config('other.font-awesome') }} fa-user-circle"
+                                    ></i>
 
+                                    @break
                                 @case('Appeals')
                                     <i class="{{ config('other.font-awesome') }} fa-gavel"></i>
-                                    @break
 
+                                    @break
                                 @case('Forums')
                                     <i class="{{ config('other.font-awesome') }} fa-comments"></i>
-                                    @break
 
+                                    @break
                                 @case('Requests')
-                                    <i class="{{ config('other.font-awesome') }} fa-hands-helping"></i>
-                                    @break
+                                    <i
+                                        class="{{ config('other.font-awesome') }} fa-hands-helping"
+                                    ></i>
 
+                                    @break
                                 @case('Subtitles')
-                                    <i class="{{ config('other.font-awesome') }} fa-closed-captioning"></i>
-                                    @break
+                                    <i
+                                        class="{{ config('other.font-awesome') }} fa-closed-captioning"
+                                    ></i>
 
+                                    @break
                                 @case('Torrents')
                                     <i class="{{ config('other.font-awesome') }} fa-download"></i>
-                                    @break
 
+                                    @break
                                 @case('MediaHub')
                                     <i class="{{ config('other.font-awesome') }} fa-database"></i>
-                                    @break
 
+                                    @break
                                 @case('Technical')
                                     <i class="{{ config('other.font-awesome') }} fa-tools"></i>
-                                    @break
 
+                                    @break
                                 @case('Playlists')
                                     <i class="{{ config('other.font-awesome') }} fa-list-ol"></i>
-                                    @break
 
+                                    @break
                                 @case('Bugs')
                                     <i class="{{ config('other.font-awesome') }} fa-bug"></i>
-                                    @break
 
+                                    @break
                                 @case('Other')
-                                    <i class="{{ config('other.font-awesome') }} fa-ellipsis-h"></i>
+                                    <i
+                                        class="{{ config('other.font-awesome') }} fa-ellipsis-h"
+                                    ></i>
+
                                     @break
                             @endswitch
                             {{ $ticket->category->name }}


### PR DESCRIPTION
There's a few changes in here, first I added the categories in the help desk index and added matching icons to the default categories and made the existing icons match the icon format in the config, I changed muted-text on the navy theme to make muted text more visible, I removed the htmlspecialchars from the comments quote button so that ampersands and quotations show up properly instead of HTML encoded text, and finally I added text wrapping to transactions on the staff's donation page since users were able to paste huge texts/tokens which would add a pesky horizontal scrollbar so you can view the donation cost and action buttons.