### PR TITLE
(Update) Style tweaks and donation transaction wrapping

### DIFF
--- a/resources/sass/layout/_secondary-nav.scss
+++ b/resources/sass/layout/_secondary-nav.scss
@@ -3,7 +3,7 @@
 .secondary-nav {
     display: grid;
     grid-template-columns: 1fr auto 1fr;
-    box-shadow: 0 8px 10px 0 rgba(0, 0, 0, 0.2);
+    box-shadow: var(--secondary-nav-box-shadow);
     background-color: var(--secondary-nav-bg);
     margin: 0;
     padding: 0 18px;

--- a/resources/sass/layout/_secondary-nav.scss
+++ b/resources/sass/layout/_secondary-nav.scss
@@ -3,6 +3,7 @@
 .secondary-nav {
     display: grid;
     grid-template-columns: 1fr auto 1fr;
+    box-shadow: 0 8px 10px 0 rgba(0, 0, 0, 0.2);
     background-color: var(--secondary-nav-bg);
     margin: 0;
     padding: 0 18px;

--- a/resources/sass/themes/_cosmic-void.scss
+++ b/resources/sass/themes/_cosmic-void.scss
@@ -242,6 +242,7 @@
     --scrollbar-color: #ffffff13;
 
     --secondary-nav-bg: #292929;
+    --secondary-nav-box-shadow: none;
     --secondary-nav-tab-fg: #aaa;
     --secondary-nav-tab-bg: inherit;
     --secondary-nav-tab-active-text-decoration: underline #777 2px;

--- a/resources/sass/themes/_galactic.scss
+++ b/resources/sass/themes/_galactic.scss
@@ -281,6 +281,7 @@
     --scrollbar-color: #ffffff19;
 
     --secondary-nav-bg: #292929;
+    --secondary-nav-box-shadow: none;
     --secondary-nav-tab-fg: #aaa;
     --secondary-nav-tab-bg: inherit;
     --secondary-nav-tab-active-text-decoration: underline #777 2px;

--- a/resources/sass/themes/_light.scss
+++ b/resources/sass/themes/_light.scss
@@ -253,6 +253,7 @@
     --scrollbar-color: #0004;
 
     --secondary-nav-bg: #e2e2e2;
+    --secondary-nav-box-shadow: none;
     --secondary-nav-tab-fg: #222;
     --secondary-nav-tab-bg: inherit;
     --secondary-nav-tab-active-text-decoration: underline #222 2px;

--- a/resources/sass/themes/_material-design-v3-amoled.scss
+++ b/resources/sass/themes/_material-design-v3-amoled.scss
@@ -252,6 +252,7 @@
     --scrollbar-color: #0004;
 
     --secondary-nav-bg: #000;
+    --secondary-nav-box-shadow: none;
     --secondary-nav-tab-fg: #fff;
     --secondary-nav-tab-bg: inherit;
     --secondary-nav-tab-active-text-decoration: underline #ddd 2px;

--- a/resources/sass/themes/_material-design-v3-dark.scss
+++ b/resources/sass/themes/_material-design-v3-dark.scss
@@ -253,6 +253,7 @@
     --scrollbar-color: #0004;
 
     --secondary-nav-bg: #221e24;
+    --secondary-nav-box-shadow: none;
     --secondary-nav-tab-fg: #999;
     --secondary-nav-tab-bg: inherit;
     --secondary-nav-tab-active-text-decoration: underline #0099ff 2px;

--- a/resources/sass/themes/_material-design-v3-light.scss
+++ b/resources/sass/themes/_material-design-v3-light.scss
@@ -252,6 +252,7 @@
     --scrollbar-color: #0004;
 
     --secondary-nav-bg: #f4f4f4;
+    --secondary-nav-box-shadow: none;
     --secondary-nav-tab-fg: #050505;
     --secondary-nav-tab-bg: inherit;
     --secondary-nav-tab-active-text-decoration: underline #0099ff 2px;

--- a/resources/sass/themes/_material-design-v3-navy.scss
+++ b/resources/sass/themes/_material-design-v3-navy.scss
@@ -330,7 +330,7 @@
     --torrent-group-bg: #0f111a;
     --torrent-group-header-bg: #0f111a;
     --torrent-group-text: #fff;
-    --torrent-group-text-muted: #444;
+    --torrent-group-text-muted: #999999;
     --torrent-group-table-stripe-even: rgba(0, 0, 0, 0.18);
     --torrent-group-table-stripe-odd: rgba(0, 0, 0, 0.1);
     --torrent-group-hover-brightness-emphasis: 1.13;

--- a/resources/sass/themes/_material-design-v3-navy.scss
+++ b/resources/sass/themes/_material-design-v3-navy.scss
@@ -27,7 +27,7 @@
     --bbcode-input-bg: #0c0e15;
 
     --bbcode-rendered-fg-default: #c9d1d9;
-    --bbcode-rendered-fg-muted: #fff;
+    --bbcode-rendered-fg-muted: #808080;
     --bbcode-rendered-fg-subtle: #484f58;
     --bbcode-rendered-canvas-default: transparent;
     --bbcode-rendered-canvas-subtle: #313131;
@@ -330,7 +330,7 @@
     --torrent-group-bg: #0f111a;
     --torrent-group-header-bg: #0f111a;
     --torrent-group-text: #fff;
-    --torrent-group-text-muted: #fff;
+    --torrent-group-text-muted: #444;
     --torrent-group-table-stripe-even: rgba(0, 0, 0, 0.18);
     --torrent-group-table-stripe-odd: rgba(0, 0, 0, 0.1);
     --torrent-group-hover-brightness-emphasis: 1.13;
@@ -560,7 +560,7 @@ a {
 }
 
 .text-muted {
-    color: #0e111c;
+    color: #808080;
 }
 
 hr {

--- a/resources/sass/themes/_material-design-v3-navy.scss
+++ b/resources/sass/themes/_material-design-v3-navy.scss
@@ -254,6 +254,7 @@
     --scrollbar-color: #0004;
 
     --secondary-nav-bg: #08090f;
+    --secondary-nav-box-shadow: 0 8px 10px 0 rgba(0, 0, 0, 0.3);
     --secondary-nav-tab-fg: #fff;
     --secondary-nav-tab-bg: inherit;
     --secondary-nav-tab-active-text-decoration: underline #0099ff 2px;

--- a/resources/sass/themes/_material-design-v3-navy.scss
+++ b/resources/sass/themes/_material-design-v3-navy.scss
@@ -253,14 +253,14 @@
 
     --scrollbar-color: #0004;
 
-    --secondary-nav-bg: #0c0e15;
+    --secondary-nav-bg: #08090f;
     --secondary-nav-tab-fg: #fff;
     --secondary-nav-tab-bg: inherit;
     --secondary-nav-tab-active-text-decoration: underline #0099ff 2px;
     --secondary-nav-tab-hover-fg: #fff;
     --secondary-nav-tab-hover-bg: transparent;
     --secondary-nav-tab-hover-text-decoration: underline #0088ff 2px;
-    --secondary-nav-tab-menu-bg: #0c0e15;
+    --secondary-nav-tab-menu-bg: #08090f;
     --secondary-nav-tab-menu-fg: inherit;
     --secondary-nav-tab-menu-border: none;
     --secondary-nav-tab-menu-border-radius: 6px;

--- a/resources/sass/themes/_nord.scss
+++ b/resources/sass/themes/_nord.scss
@@ -268,6 +268,7 @@
     --scrollbar-color: #ffffff19;
 
     --secondary-nav-bg: #242933;
+    --secondary-nav-box-shadow: none;
     --secondary-nav-tab-fg: #d8dee9;
     --secondary-nav-tab-bg: inherit;
     --secondary-nav-tab-active-text-decoration: transparent #81a1c1 2px;

--- a/resources/sass/themes/_revel.scss
+++ b/resources/sass/themes/_revel.scss
@@ -272,6 +272,7 @@
     --scrollbar-color: #ffffff19;
 
     --secondary-nav-bg: #292929;
+    --secondary-nav-box-shadow: none;
     --secondary-nav-tab-fg: #aaa;
     --secondary-nav-tab-bg: inherit;
     --secondary-nav-tab-active-text-decoration: none;

--- a/resources/views/Staff/donation/index.blade.php
+++ b/resources/views/Staff/donation/index.blade.php
@@ -39,7 +39,7 @@
                         <th>Upload #</th>
                         <th>Invite #</th>
                         <th>Bonus #</th>
-                        <th>Lenght</th>
+                        <th>Length</th>
                         <th>Status</th>
                         <th>{{ __('common.actions') }}</th>
                     </tr>
@@ -51,7 +51,9 @@
                             <td>
                                 <x-user_tag :user="$donation->user" :anon="false" />
                             </td>
-                            <td>{{ $donation->transaction }}</td>
+                            <td style="max-width: 80ch; word-wrap: break-word; white-space: normal">
+                                {{ $donation->transaction }}
+                            </td>
                             <td
                                 class="{{ $donation->package->trashed() ? 'text-danger' : '' }}"
                                 title="{{ $donation->package->trashed() ? 'Package has been deleted' : '' }}"


### PR DESCRIPTION
This fixes muted-text colors on the material navy theme, adds a drop shadow to the secondary navigation bar on all themes, and wraps extremely long transactions inputs on the staffs donation index. Users sometimes paste really long strings making it annoying to see all the elements without scrolling horizontally.