### PR TITLE
(Update) Override freeleech & doubleup tags when featured

### DIFF
--- a/app/DTO/TorrentSearchFiltersDTO.php
+++ b/app/DTO/TorrentSearchFiltersDTO.php
@@ -556,7 +556,7 @@ readonly class TorrentSearchFiltersDTO
 
         if ($this->free !== []) {
             if (!config('other.freeleech')) {
-                if (in_array("100", $this->free, true)) {
+                if (in_array(100, $this->free, false)) {
                     $filters[] = [
                         'free IN '.json_encode(array_map('intval', $this->free)),
                         'featured = true',

--- a/app/DTO/TorrentSearchFiltersDTO.php
+++ b/app/DTO/TorrentSearchFiltersDTO.php
@@ -542,12 +542,12 @@ readonly class TorrentSearchFiltersDTO
 
         if ($this->free !== []) {
             if (!config('other.freeleech')) {
-                $filters[] = 'free IN '.json_encode(array_map('intval', $this->free));
+                $filters[] = '(free IN ' . json_encode(array_map('intval', $this->free)) . ' OR featured = true)';
             }
         }
 
         if ($this->doubleup) {
-            $filters[] = 'doubleup = true';
+            $filters[] = '(doubleup = true OR featured = true)';
         }
 
         if ($this->featured) {

--- a/app/DTO/TorrentSearchFiltersDTO.php
+++ b/app/DTO/TorrentSearchFiltersDTO.php
@@ -312,7 +312,7 @@ readonly class TorrentSearchFiltersDTO
                             $query
                                 ->whereIntegerInRaw('free', (array) $this->free)
                                 ->when(
-                                    in_array(100, $this->free, true),
+                                    in_array(100, $this->free, false),
                                     fn ($query) => $query->orWhere('featured', '=', true)
                                 )
                         )

--- a/app/DTO/TorrentSearchFiltersDTO.php
+++ b/app/DTO/TorrentSearchFiltersDTO.php
@@ -550,7 +550,10 @@ readonly class TorrentSearchFiltersDTO
         }
 
         if ($this->doubleup) {
-            $filters[] = '(doubleup = true OR featured = true)';
+            $filters[] = [
+                'doubleup = true',
+                'featured = true',
+            ];
         }
 
         if ($this->featured) {

--- a/app/DTO/TorrentSearchFiltersDTO.php
+++ b/app/DTO/TorrentSearchFiltersDTO.php
@@ -313,7 +313,7 @@ readonly class TorrentSearchFiltersDTO
                                 ->whereIntegerInRaw('free', (array) $this->free)
                                 ->when(
                                     in_array(100, $this->free, true),
-                                    fn ($query) => $query->orWhere('featured', '=', 1)
+                                    fn ($query) => $query->orWhere('featured', '=', true)
                                 )
                         )
                     )

--- a/app/DTO/TorrentSearchFiltersDTO.php
+++ b/app/DTO/TorrentSearchFiltersDTO.php
@@ -308,11 +308,11 @@ readonly class TorrentSearchFiltersDTO
                     ->when(
                         config('other.freeleech'),
                         fn ($query) => $query->whereBetween('free', [0, 100]),
-                        fn ($query) => $query->where(fn ($query) =>
-                            $query
+                        fn ($query) => $query->where(
+                            fn ($query) => $query
                                 ->whereIntegerInRaw('free', (array) $this->free)
                                 ->when(
-                                    in_array(100, $this->free, false),
+                                    \in_array(100, $this->free, false),
                                     fn ($query) => $query->orWhere('featured', '=', true)
                                 )
                         )
@@ -344,8 +344,8 @@ readonly class TorrentSearchFiltersDTO
             )
             ->when(
                 $this->doubleup,
-                fn ($query) => $query->where(fn ($query) =>
-                    $query
+                fn ($query) => $query->where(
+                    fn ($query) => $query
                         ->where('doubleup', '=', 1)
                         ->orWhere('featured', '=', 1)
                 )
@@ -556,7 +556,7 @@ readonly class TorrentSearchFiltersDTO
 
         if ($this->free !== []) {
             if (!config('other.freeleech')) {
-                if (in_array(100, $this->free, false)) {
+                if (\in_array(100, $this->free, false)) {
                     $filters[] = [
                         'free IN '.json_encode(array_map('intval', $this->free)),
                         'featured = true',

--- a/app/DTO/TorrentSearchFiltersDTO.php
+++ b/app/DTO/TorrentSearchFiltersDTO.php
@@ -542,7 +542,10 @@ readonly class TorrentSearchFiltersDTO
 
         if ($this->free !== []) {
             if (!config('other.freeleech')) {
-                $filters[] = '(free IN ' . json_encode(array_map('intval', $this->free)) . ' OR featured = true)';
+                $filters[] = [
+                    'free IN '.json_encode(array_map('intval', $this->free)),
+                    'featured = true',
+                ];
             }
         }
 


### PR DESCRIPTION
When featuring torrents the freeleech tag remains unchanged so when filtering through 100% freeleech torrents if that featured torrent didn't have 100% freeleech it will not appear even though it gets freeleech from the feature, same with doubleup. This change commands Meilisearch to include featured torrents in doubleup/freeleech filters.