### PR TITLE
(Update) Reorder composite primary indexes on history/peers table

### DIFF
--- a/database/migrations/2025_03_02_101912_reorder_peer_and_history_primary_composite_index.php
+++ b/database/migrations/2025_03_02_101912_reorder_peer_and_history_primary_composite_index.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * NOTICE OF LICENSE.
+ *
+ * UNIT3D Community Edition is open-sourced software licensed under the GNU Affero General Public License v3.0
+ * The details is bundled with this project in the file LICENSE.txt.
+ *
+ * @project    UNIT3D Community Edition
+ *
+ * @author     Roardom <roardom@protonmail.com>
+ * @license    https://www.gnu.org/licenses/agpl-3.0.en.html/ GNU Affero General Public License v3.0
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('history', function (Blueprint $table): void {
+            $table->dropPrimary(['user_id', 'torrent_id']);
+            $table->primary(['torrent_id', 'user_id'])->change();
+        });
+
+        Schema::table('peers', function (Blueprint $table): void {
+            $table->dropPrimary(['user_id', 'torrent_id', 'peer_id']);
+            $table->primary(['torrent_id', 'user_id', 'peer_id'])->change();
+        });
+    }
+};


### PR DESCRIPTION
Most sites have significantly more torrents than users, so it's more efficient to narrow down by torrent before narrowing down by user when finding a specific record.