### PR TITLE
(Fix) Notification setting logic when notification doesn't exist

### DIFF
--- a/app/Notifications/NewBon.php
+++ b/app/Notifications/NewBon.php
@@ -53,17 +53,17 @@ class NewBon extends Notification implements ShouldQueue
             return true;
         }
 
-        if ($notifiable->notification?->block_notifications == 1) {
+        if ($notifiable->notification?->block_notifications === 1) {
             return false;
         }
 
-        if (!$notifiable->notification?->show_bon_gift) {
+        if ($notifiable->notification?->show_bon_gift === 0) {
             return false;
         }
 
         // If the sender's group ID is found in the "Block all notifications from the selected groups" array,
         // the expression will return false.
-        return ! \in_array($this->gift->sender->group_id, $notifiable->notification->json_bon_groups, true);
+        return ! \in_array($this->gift->sender->group_id, $notifiable->notification?->json_bon_groups ?? [], true);
     }
 
     /**

--- a/app/Notifications/NewComment.php
+++ b/app/Notifications/NewComment.php
@@ -64,28 +64,28 @@ class NewComment extends Notification
         }
 
         // Evaluate general settings
-        if ($notifiable->notification?->block_notifications == 1) {
+        if ($notifiable->notification?->block_notifications === 1) {
             return false;
         }
 
         // Evaluate model based settings
         switch (true) {
             case $this->model instanceof Torrent:
-                if (!$notifiable->notification?->show_torrent_comment) {
+                if ($notifiable->notification?->show_torrent_comment === 0) {
                     return false;
                 }
 
                 // If the sender's group ID is found in the "Block all notifications from the selected groups" array,
                 // the expression will return false.
-                return ! \in_array($this->comment->user->group_id, $notifiable->notification->json_torrent_groups, true);
+                return ! \in_array($this->comment->user->group_id, $notifiable->notification?->json_torrent_groups ?? [], true);
             case $this->model instanceof TorrentRequest:
-                if (!$notifiable->notification?->show_request_comment) {
+                if ($notifiable->notification?->show_request_comment === 0) {
                     return false;
                 }
 
                 // If the sender's group ID is found in the "Block all notifications from the selected groups" array,
                 // the expression will return false.
-                return ! \in_array($this->comment->user->group_id, $notifiable->notification->json_request_groups, true);
+                return ! \in_array($this->comment->user->group_id, $notifiable->notification?->json_request_groups ?? [], true);
             case $this->model instanceof Ticket:
                 return ! ($this->model->staff_id === $this->comment->id && $this->model->staff_id !== null)
                 ;

--- a/app/Notifications/NewCommentTag.php
+++ b/app/Notifications/NewCommentTag.php
@@ -66,39 +66,39 @@ class NewCommentTag extends Notification implements ShouldQueue
         }
 
         // Evaluate general settings
-        if ($notifiable->notification?->block_notifications == 1) {
+        if ($notifiable->notification?->block_notifications === 1) {
             return false;
         }
 
         // Evaluate model based settings
         switch (true) {
             case $this->model instanceof Torrent:
-                if (!$notifiable->notification?->show_mention_torrent_comment) {
+                if ($notifiable->notification?->show_mention_torrent_comment === 0) {
                     return false;
                 }
 
                 // If the sender's group ID is found in the "Block all notifications from the selected groups" array,
                 // the expression will return false.
-                return ! \in_array($this->comment->user->group_id, $notifiable->notification->json_mention_groups, true);
+                return ! \in_array($this->comment->user->group_id, $notifiable->notification?->json_mention_groups ?? [], true);
             case $this->model instanceof TorrentRequest:
-                if (!$notifiable->notification?->show_mention_request_comment) {
+                if ($notifiable->notification?->show_mention_request_comment === 0) {
                     return false;
                 }
 
                 // If the sender's group ID is found in the "Block all notifications from the selected groups" array,
                 // the expression will return false.
-                return ! \in_array($this->comment->user->group_id, $notifiable->notification->json_mention_groups, true);
+                return ! \in_array($this->comment->user->group_id, $notifiable->notification?->json_mention_groups ?? [], true);
             case $this->model instanceof Ticket:
                 return ! ($this->model->staff_id === $this->comment->id);
             case $this->model instanceof Playlist:
             case $this->model instanceof Article:
-                if (!$notifiable->notification?->show_mention_article_comment) {
+                if ($notifiable->notification?->show_mention_article_comment === 0) {
                     return false;
                 }
 
                 // If the sender's group ID is found in the "Block all notifications from the selected groups" array,
                 // the expression will return false.
-                return ! \in_array($this->comment->user->group_id, $notifiable->notification->json_mention_groups, true);
+                return ! \in_array($this->comment->user->group_id, $notifiable->notification?->json_mention_groups ?? [], true);
             case $this->model instanceof Collection:
                 break;
         }

--- a/app/Notifications/NewFollow.php
+++ b/app/Notifications/NewFollow.php
@@ -47,17 +47,17 @@ class NewFollow extends Notification implements ShouldQueue
      */
     public function shouldSend(User $notifiable): bool
     {
-        if ($notifiable->notification?->block_notifications == 1) {
+        if ($notifiable->notification?->block_notifications === 1) {
             return false;
         }
 
-        if (!$notifiable->notification?->show_account_follow) {
+        if ($notifiable->notification?->show_account_follow === 0) {
             return false;
         }
 
         // If the sender's group ID is found in the "Block all notifications from the selected groups" array,
         // the expression will return false.
-        return ! \in_array($this->follower->group_id, $notifiable->notification->json_following_groups, true);
+        return ! \in_array($this->follower->group_id, $notifiable->notification?->json_following_groups ?? [], true);
     }
 
     /**

--- a/app/Notifications/NewPost.php
+++ b/app/Notifications/NewPost.php
@@ -64,7 +64,7 @@ class NewPost extends Notification implements ShouldQueue
             default        => 'show_forum_topic',
         };
 
-        if (!$notifiable->notification?->$targetNotification) {
+        if ($notifiable->notification?->$targetNotification === 0) {
             return false;
         }
 
@@ -80,7 +80,7 @@ class NewPost extends Notification implements ShouldQueue
             return true;
         }
 
-        return ! \in_array($this->post->user->group_id, $notifiable->notification->$targetGroup, true);
+        return ! \in_array($this->post->user->group_id, $notifiable->notification?->$targetGroup ?? [], true);
     }
 
     /**

--- a/app/Notifications/NewPostTag.php
+++ b/app/Notifications/NewPostTag.php
@@ -58,17 +58,17 @@ class NewPostTag extends Notification implements ShouldQueue
             return true;
         }
 
-        if ($notifiable->notification?->block_notifications == 1) {
+        if ($notifiable->notification?->block_notifications === 1) {
             return false;
         }
 
-        if (!$notifiable->notification?->show_mention_forum_post) {
+        if ($notifiable->notification?->show_mention_forum_post === 0) {
             return false;
         }
 
         // If the sender's group ID is found in the "Block all notifications from the selected groups" array,
         // the expression will return false.
-        return ! \in_array($this->post->user->group_id, $notifiable->notification->json_mention_groups, true);
+        return ! \in_array($this->post->user->group_id, $notifiable->notification?->json_mention_groups ?? [], true);
     }
 
     /**

--- a/app/Notifications/NewRequestBounty.php
+++ b/app/Notifications/NewRequestBounty.php
@@ -53,17 +53,17 @@ class NewRequestBounty extends Notification implements ShouldQueue
             return false;
         }
 
-        if ($notifiable->notification?->block_notifications == 1) {
+        if ($notifiable->notification?->block_notifications === 1) {
             return false;
         }
 
-        if (!$notifiable->notification?->show_request_bounty) {
+        if ($notifiable->notification?->show_request_bounty === 0) {
             return false;
         }
 
         // If the sender's group ID is found in the "Block all notifications from the selected groups" array,
         // the expression will return false.
-        return ! \in_array($this->bounty->user->group_id, $notifiable->notification->json_request_groups, true);
+        return ! \in_array($this->bounty->user->group_id, $notifiable->notification?->json_request_groups ?? [], true);
     }
 
     /**

--- a/app/Notifications/NewRequestClaim.php
+++ b/app/Notifications/NewRequestClaim.php
@@ -53,17 +53,17 @@ class NewRequestClaim extends Notification implements ShouldQueue
             return false;
         }
 
-        if ($notifiable->notification?->block_notifications == 1) {
+        if ($notifiable->notification?->block_notifications === 1) {
             return false;
         }
 
-        if (!$notifiable->notification?->show_request_claim) {
+        if ($notifiable->notification?->show_request_claim === 0) {
             return false;
         }
 
         // If the sender's group ID is found in the "Block all notifications from the selected groups" array,
         // the expression will return false.
-        return ! \in_array($this->claim->user->group_id, $notifiable->notification->json_request_groups, true);
+        return ! \in_array($this->claim->user->group_id, $notifiable->notification?->json_request_groups ?? [], true);
     }
 
     /**

--- a/app/Notifications/NewRequestFill.php
+++ b/app/Notifications/NewRequestFill.php
@@ -53,17 +53,17 @@ class NewRequestFill extends Notification implements ShouldQueue
             return false;
         }
 
-        if ($notifiable->notification?->block_notifications == 1) {
+        if ($notifiable->notification?->block_notifications === 1) {
             return false;
         }
 
-        if (!$notifiable->notification?->show_request_fill) {
+        if ($notifiable->notification?->show_request_fill === 0) {
             return false;
         }
 
         // If the sender's group ID is found in the "Block all notifications from the selected groups" array,
         // the expression will return false.
-        return ! \in_array($this->torrentRequest->filler->group_id, $notifiable->notification->json_request_groups, true);
+        return ! \in_array($this->torrentRequest->filler->group_id, $notifiable->notification?->json_request_groups ?? [], true);
     }
 
     /**

--- a/app/Notifications/NewRequestFillApprove.php
+++ b/app/Notifications/NewRequestFillApprove.php
@@ -53,17 +53,17 @@ class NewRequestFillApprove extends Notification implements ShouldQueue
             return false;
         }
 
-        if ($notifiable->notification?->block_notifications == 1) {
+        if ($notifiable->notification?->block_notifications === 1) {
             return false;
         }
 
-        if (!$notifiable->notification?->show_request_fill_approve) {
+        if ($notifiable->notification?->show_request_fill_approve === 0) {
             return false;
         }
 
         // If the sender's group ID is found in the "Block all notifications from the selected groups" array,
         // the expression will return false.
-        return ! \in_array($this->torrentRequest->approver->group_id, $notifiable->notification->json_request_groups, true);
+        return ! \in_array($this->torrentRequest->approver->group_id, $notifiable->notification?->json_request_groups ?? [], true);
     }
 
     /**

--- a/app/Notifications/NewRequestFillReject.php
+++ b/app/Notifications/NewRequestFillReject.php
@@ -53,17 +53,17 @@ class NewRequestFillReject extends Notification implements ShouldQueue
             return false;
         }
 
-        if ($notifiable->notification?->block_notifications == 1) {
+        if ($notifiable->notification?->block_notifications === 1) {
             return false;
         }
 
-        if (!$notifiable->notification?->show_request_fill_reject) {
+        if ($notifiable->notification?->show_request_fill_reject === 0) {
             return false;
         }
 
         // If the sender's group ID is found in the "Block all notifications from the selected groups" array,
         // the expression will return false.
-        return ! \in_array($this->torrentRequest->user->group_id, $notifiable->notification->json_request_groups, true);
+        return ! \in_array($this->torrentRequest->user->group_id, $notifiable->notification?->json_request_groups ?? [], true);
     }
 
     /**

--- a/app/Notifications/NewRequestUnclaim.php
+++ b/app/Notifications/NewRequestUnclaim.php
@@ -53,17 +53,17 @@ class NewRequestUnclaim extends Notification implements ShouldQueue
             return false;
         }
 
-        if ($notifiable->notification?->block_notifications == 1) {
+        if ($notifiable->notification?->block_notifications === 1) {
             return false;
         }
 
-        if (!$notifiable->notification?->show_request_unclaim) {
+        if ($notifiable->notification?->show_request_unclaim === 0) {
             return false;
         }
 
         // If the sender's group ID is found in the "Block all notifications from the selected groups" array,
         // the expression will return false.
-        return ! \in_array($this->torrentRequestClaim->user->group_id, $notifiable->notification->json_request_groups, true);
+        return ! \in_array($this->torrentRequestClaim->user->group_id, $notifiable->notification?->json_request_groups ?? [], true);
     }
 
     /**

--- a/app/Notifications/NewTopic.php
+++ b/app/Notifications/NewTopic.php
@@ -48,17 +48,17 @@ class NewTopic extends Notification implements ShouldQueue
      */
     public function shouldSend(User $notifiable): bool
     {
-        if ($notifiable->notification?->block_notifications == 1) {
+        if ($notifiable->notification?->block_notifications === 1) {
             return false;
         }
 
-        if (!$notifiable->notification?->show_subscription_forum) {
+        if ($notifiable->notification?->show_subscription_forum === 0) {
             return false;
         }
 
         // If the sender's group ID is found in the "Block all notifications from the selected groups" array,
         // the expression will return false.
-        return ! \in_array($this->user->group_id, $notifiable->notification->json_subscription_groups, true);
+        return ! \in_array($this->user->group_id, $notifiable->notification?->json_subscription_groups ?? [], true);
     }
 
     /**

--- a/app/Notifications/NewUnfollow.php
+++ b/app/Notifications/NewUnfollow.php
@@ -47,17 +47,17 @@ class NewUnfollow extends Notification implements ShouldQueue
      */
     public function shouldSend(User $notifiable): bool
     {
-        if ($notifiable->notification?->block_notifications == 1) {
+        if ($notifiable->notification?->block_notifications === 1) {
             return false;
         }
 
-        if (!$notifiable->notification?->show_account_unfollow) {
+        if ($notifiable->notification?->show_account_unfollow === 0) {
             return false;
         }
 
         // If the sender's group ID is found in the "Block all notifications from the selected groups" array,
         // the expression will return false.
-        return ! \in_array($this->unfollower->group_id, $notifiable->notification->json_account_groups, true);
+        return ! \in_array($this->unfollower->group_id, $notifiable->notification?->json_account_groups ?? [], true);
     }
 
     /**

--- a/app/Notifications/NewUpload.php
+++ b/app/Notifications/NewUpload.php
@@ -52,17 +52,17 @@ class NewUpload extends Notification implements ShouldQueue
             return false;
         }
 
-        if ($notifiable->notification?->block_notifications == 1) {
+        if ($notifiable->notification?->block_notifications === 1) {
             return false;
         }
 
-        if (!$notifiable->notification?->show_following_upload) {
+        if ($notifiable->notification?->show_following_upload === 0) {
             return false;
         }
 
         // If the sender's group ID is found in the "Block all notifications from the selected groups" array,
         // the expression will return false.
-        return ! \in_array($this->torrent->user->group_id, $notifiable->notification->json_following_groups, true);
+        return ! \in_array($this->torrent->user->group_id, $notifiable->notification?->json_following_groups ?? [], true);
     }
 
     /**

--- a/tests/Feature/Notifications/NewCommentTorrentRequestTagNotificationTest.php
+++ b/tests/Feature/Notifications/NewCommentTorrentRequestTagNotificationTest.php
@@ -75,10 +75,10 @@ test('user tags user on request creates a notification for tagged user', functio
     $this->assertEquals(1, Comment::count());
 
     Notification::assertSentTo(
-        [$user],
-        NewCommentTag::class
+        $user,
+        NewCommentTag::class,
+        1,
     );
-    Notification::assertCount(1);
 });
 
 test('user tags user on request creates a notification for tagged user when mentions are disabled for other specific group', function (): void {
@@ -128,11 +128,11 @@ test('user tags user on request creates a notification for tagged user when ment
 
     $this->assertEquals(1, Comment::count());
 
-    Notification::assertSentTo(
-        [$user],
-        NewCommentTag::class
+    Notification::assertSentToTimes(
+        $user,
+        NewCommentTag::class,
+        1,
     );
-    Notification::assertCount(1);
 });
 
 test('user tags user on request does not create a notification for tagged user when all notifications disabled', function (): void {

--- a/tests/Feature/Notifications/NewCommentTorrentTagNotificationTest.php
+++ b/tests/Feature/Notifications/NewCommentTorrentTagNotificationTest.php
@@ -74,11 +74,11 @@ test('user tags user on torrent creates a notification for tagged user', functio
 
     $this->assertEquals(1, Comment::count());
 
-    Notification::assertSentTo(
-        [$user],
-        NewCommentTag::class
+    Notification::assertSentToTimes(
+        $user,
+        NewCommentTag::class,
+        1,
     );
-    Notification::assertCount(1);
 });
 
 test('user tags user on torrent creates a notification for tagged user when mentions are disabled for other specific group', function (): void {
@@ -128,11 +128,11 @@ test('user tags user on torrent creates a notification for tagged user when ment
 
     $this->assertEquals(1, Comment::count());
 
-    Notification::assertSentTo(
-        [$user],
-        NewCommentTag::class
+    Notification::assertSentToTimes(
+        $user,
+        NewCommentTag::class,
+        1,
     );
-    Notification::assertCount(1);
 });
 
 test('user tags user on torrent does not create a notification for tagged user when all notifications disabled', function (): void {

--- a/tests/Feature/Notifications/NewPostTagNotificationTest.php
+++ b/tests/Feature/Notifications/NewPostTagNotificationTest.php
@@ -93,11 +93,11 @@ test('user tags user in forum topic creates a notification for tagged user', fun
         'user_id'  => $poster->id,
     ]);
 
-    Notification::assertSentTo(
-        [$user],
-        NewPostTag::class
+    Notification::assertSentToTimes(
+        $user,
+        NewPostTag::class,
+        1,
     );
-    Notification::assertCount(1);
 });
 
 test('user tags user in forum topic creates a notification for tagged user when post mention notifications are not disabled for specific group', function (): void {
@@ -166,11 +166,11 @@ test('user tags user in forum topic creates a notification for tagged user when 
         'user_id'  => $poster->id,
     ]);
 
-    Notification::assertSentTo(
-        [$user],
-        NewPostTag::class
+    Notification::assertSentToTimes(
+        $user,
+        NewPostTag::class,
+        1,
     );
-    Notification::assertCount(1);
 });
 
 test('user tags user in forum topic does not create a notification for tagged user when all notifications disabled', function (): void {
@@ -241,7 +241,6 @@ test('user tags user in forum topic does not create a notification for tagged us
         [$user],
         NewPostTag::class
     );
-    Notification::assertCount(0);
 });
 
 test('staff tags user in forum topic creates a notification for tagged user even when post mention notifications are disabled', function (): void {
@@ -309,11 +308,11 @@ test('staff tags user in forum topic creates a notification for tagged user even
         'user_id'  => $poster->id,
     ]);
 
-    Notification::assertSentTo(
-        [$user],
-        NewPostTag::class
+    Notification::assertSentToTimes(
+        $user,
+        NewPostTag::class,
+        1,
     );
-    Notification::assertCount(1);
 });
 
 test('user tags user in forum topic does not create a notification for tagged user when post mention notifications are disabled', function (): void {
@@ -384,7 +383,6 @@ test('user tags user in forum topic does not create a notification for tagged us
         [$user],
         NewPostTag::class
     );
-    Notification::assertCount(0);
 });
 
 test('user tags user in forum topic does not create a notification for tagged user when post mention notifications are not disabled for specific group', function (): void {
@@ -456,5 +454,4 @@ test('user tags user in forum topic does not create a notification for tagged us
         [$user],
         NewPostTag::class
     );
-    Notification::assertCount(0);
 });


### PR DESCRIPTION
The previous logic was evaluating the null non-existent notification setting as false.