### PR TITLE
update: remove phpstan nullsafe.neverNull rule

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -517,12 +517,6 @@ parameters:
 			path: app/Http/Controllers/User/ResurrectionController.php
 
 		-
-			message: '#^Using nullsafe property access "\?\-\>seedtime" on left side of \?\? is unnecessary\. Use \-\> instead\.$#'
-			identifier: nullsafe.neverNull
-			count: 1
-			path: app/Http/Controllers/User/ResurrectionController.php
-
-		-
 			message: '#^Binary operation "/" between string\|null and 1000000 results in an error\.$#'
 			identifier: binaryOp.invalid
 			count: 2
@@ -841,18 +835,6 @@ parameters:
 			path: app/Http/Resources/UserResource.php
 
 		-
-			message: '#^Using nullsafe property access "\?\-\>downloaded" on left side of \?\? is unnecessary\. Use \-\> instead\.$#'
-			identifier: nullsafe.neverNull
-			count: 1
-			path: app/Jobs/ProcessAnnounce.php
-
-		-
-			message: '#^Using nullsafe property access "\?\-\>uploaded" on left side of \?\? is unnecessary\. Use \-\> instead\.$#'
-			identifier: nullsafe.neverNull
-			count: 1
-			path: app/Jobs/ProcessAnnounce.php
-
-		-
 			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$name\.$#'
 			identifier: property.notFound
 			count: 2
@@ -869,12 +851,6 @@ parameters:
 			identifier: missingType.iterableValue
 			count: 1
 			path: app/Models/Rss.php
-
-		-
-			message: '#^Using nullsafe property access "\?\-\>read_topic" on left side of \?\? is unnecessary\. Use \-\> instead\.$#'
-			identifier: nullsafe.neverNull
-			count: 1
-			path: app/Models/Topic.php
 
 		-
 			message: '#^Instanceof between App\\Models\\Comment and App\\Models\\Comment will always evaluate to true\.$#'
@@ -935,12 +911,6 @@ parameters:
 			identifier: identical.alwaysTrue
 			count: 1
 			path: app/Providers/FortifyServiceProvider.php
-
-		-
-			message: '#^Using nullsafe property access "\?\-\>id" on left side of \?\? is unnecessary\. Use \-\> instead\.$#'
-			identifier: nullsafe.neverNull
-			count: 1
-			path: app/Providers/RouteServiceProvider.php
 
 		-
 			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Collection\<int, App\\Models\\Chatroom\>\:\:\$id\.$#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -32,3 +32,5 @@ parameters:
         -
             message: '#^Call to an undefined method Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\Torrent, [a-zA-Z0-9\\_]+\>\:\:searchable\(\)\.$#'
             identifier: method.notFound
+        -
+            identifier: nullsafe.neverNull


### PR DESCRIPTION
Imo, this is a bad rule. Although it is correct in that ?? will shortcircuit any null checks, I strongly prefer it being explicit as to which properties in the chain are nullable and which aren't. In fact, I wish we could enforce explit ?-> over -> when the property is nullable so that it's obvious which properties are null or not.